### PR TITLE
Refactor RecordCollectionHostView to avoid Swift type-check timeout

### DIFF
--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -54,27 +54,9 @@ public struct RecordCollectionHostView: View {
     }
 
     public var body: some View {
-        Group {
-            switch selectedViewMode {
-            case .list:
-                listPane
-            case .browse:
-                browsePane
-            case .detail:
-                detailPane
-            }
-        }
+        contentPane
         .navigationTitle(workspaceTitle)
-        .toolbar {
-            RecordWorkspaceToolbarContent(
-                statusText: workspaceStatusText ?? "\(documents.count) records",
-                selectedViewMode: $selectedViewMode,
-                supportedViewModes: configuration.supportedViewModes,
-                primaryActionTitle: primaryCreateActionTitle,
-                onPrimaryAction: onCreateDocument == nil ? nil : handleCreateDocument,
-                overflowMenuContent: workspaceOverflowMenu
-            )
-        }
+        .toolbar(content: workspaceToolbar)
         .onAppear {
             restorePersistedViewMode()
             syncSelection(from: initialSelectedDocumentID)
@@ -88,6 +70,30 @@ public struct RecordCollectionHostView: View {
         .onChange(of: initialSelectedDocumentID) { _, selectedId in
             syncSelection(from: selectedId)
         }
+    }
+
+    @ViewBuilder
+    private var contentPane: some View {
+        switch selectedViewMode {
+        case .list:
+            listPane
+        case .browse:
+            browsePane
+        case .detail:
+            detailPane
+        }
+    }
+
+    @ToolbarContentBuilder
+    private func workspaceToolbar() -> some ToolbarContent {
+        RecordWorkspaceToolbarContent(
+            statusText: workspaceStatusText ?? "\(documents.count) records",
+            selectedViewMode: $selectedViewMode,
+            supportedViewModes: configuration.supportedViewModes,
+            primaryActionTitle: primaryCreateActionTitle,
+            onPrimaryAction: onCreateDocument == nil ? nil : handleCreateDocument,
+            overflowMenuContent: workspaceOverflowMenu
+        )
     }
 
     private var listPane: some View {


### PR DESCRIPTION
### Motivation
- The Swift compiler produced "The compiler is unable to type-check this expression in reasonable time" for `RecordCollectionHostView`, indicating a very large/complex SwiftUI expression that needed to be simplified.
- The change aims to reduce expression complexity so the type checker can complete without timeouts while preserving existing behavior.

### Description
- Replaced the large inline `Group`/`switch` in `body` with a dedicated `@ViewBuilder` computed view `contentPane` that returns `listPane`, `browsePane`, or `detailPane` based on `selectedViewMode`.
- Extracted the toolbar construction into a `workspaceToolbar()` function annotated with `@ToolbarContentBuilder` and wired it into the view with `.toolbar(content: workspaceToolbar)`.
- No functional changes to view-mode switching, selection logic, or toolbar inputs; this is strictly a structural refactor to improve compiler type-checking.

### Testing
- Ran `swift build`, which failed in this environment due to SwiftPM being unable to fetch `swift-argument-parser` because of network/proxy restrictions (`CONNECT tunnel failed, response 403`).
- No other automated tests were run in this environment due to the dependency fetch failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fd296a3083259d0cf2a77a404f5b)