### PR TITLE
Fix Swift compiler diagnostic failure in RecordCollectionHostView toolbar

### DIFF
--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -86,12 +86,15 @@ public struct RecordCollectionHostView: View {
 
     @ToolbarContentBuilder
     private func workspaceToolbar() -> some ToolbarContent {
+        let statusText = workspaceStatusText ?? "\(documents.count) records"
+        let primaryAction: (() -> Void)? = onCreateDocument == nil ? nil : handleCreateDocument
+
         RecordWorkspaceToolbarContent(
-            statusText: workspaceStatusText ?? "\(documents.count) records",
+            statusText: statusText,
             selectedViewMode: $selectedViewMode,
             supportedViewModes: configuration.supportedViewModes,
             primaryActionTitle: primaryCreateActionTitle,
-            onPrimaryAction: onCreateDocument == nil ? nil : handleCreateDocument,
+            onPrimaryAction: primaryAction,
             overflowMenuContent: workspaceOverflowMenu
         )
     }


### PR DESCRIPTION
### Motivation
- The Swift compiler emitted a "Failed to produce diagnostic for expression" error around the inline toolbar construction in `RecordCollectionHostView`, so the change reduces type-inference complexity to avoid the compiler failure.

### Description
- In `mercantis core/UIShell/RecordCollectionHostView.swift` the `workspaceToolbar()` builder was simplified by extracting `statusText` and an explicitly typed `primaryAction: (() -> Void)?` local, and passing those into `RecordWorkspaceToolbarContent` with no change in runtime behavior.

### Testing
- Attempted `swift build` in the environment, but the build was blocked by a network error fetching `https://github.com/apple/swift-argument-parser/` (CONNECT tunnel failed, response 403), so no successful automated build completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e607d232908325a06358a9641d91cf)