### PR TITLE
Seed XCTest suite for core subsystems (P0.1)

### DIFF
--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -16,18 +16,21 @@ Principles guiding the ranking:
 
 These are either doc-vs-code drift or latent correctness issues. None add features.
 
-### P0.1 — Add an XCTest target [M, low risk] — infra
+### P0.1 — Add an XCTest target [M, low risk] — infra *(tests landed; target wire-up pending)*
 
-No test target exists. At minimum, add one and cover:
+Test source is now in `mercantis coreTests/`:
 
-- `ExpressionEvaluator` round-trips (boolean, formula, edge cases: empty input, unary minus, division by zero, unknown field).
-- `ValidationPipeline` stage sequencing and short-circuiting.
-- `MetaComposer` merge order and cache invalidation across custom fields / property setters / generation bumps.
-- `ConflictResolver` LWW / VCM / AO branches.
-- `DocumentEngine.save` → `sync_queue` atomic append; concurrency conflict on stale `updatedAt`; submit immutability for non-`allowOnSubmit` fields.
-- `MigrationRunner` applies v1→v2→v3 in order, idempotent on re-run.
+- `ExpressionEvaluatorTests.swift` — boolean, formula, comparisons, unary minus (P0.9 regression), division by zero, undefined field, empty input.
+- `ValidationPipelineTests.swift` — each stage in isolation plus short-circuit ordering.
+- `MetaComposerTests.swift` — custom-field insertion, property setters, cache invalidation.
+- `ConflictResolverTests.swift` — LWW / VCM / AO across equal / newer / stale versions.
+- `DocumentEngineTests.swift` — save/fetch round-trip, sync-queue atomicity, `DocumentVersion` recording, optimistic concurrency, submit immutability, cancel link integrity, amend.
+- `MigrationRunnerTests.swift` — v1/v2/v3 applied in order, expected tables/columns, idempotency, custom-version registration.
+- `Support/TestSupport.swift` — shared fixtures (tempdir DB, DocType / Document builders, `DocumentEngine` harness).
 
-Why first: every enhancement below lands more safely on top of a test target. The validation pipeline in particular was built for independent stage testing (ADR-022) — shipping it without tests defeats the design.
+**Remaining work:** wire the files into an Xcode Unit Testing Bundle target. Steps are in `mercantis coreTests/README.md`. Once added, the suite runs via `⌘U` or `xcodebuild test`.
+
+Why this was first: every enhancement below lands more safely on top of a test target. The validation pipeline in particular was built for independent stage testing (ADR-022) — shipping it without tests defeats the design.
 
 ### P0.2 — Run sync-received writes through `DocumentEngine` [M, medium risk] — ADR-005/022/024
 

--- a/Docs/IMPLEMENTATION-STATUS.md
+++ b/Docs/IMPLEMENTATION-STATUS.md
@@ -169,10 +169,9 @@ The `ValidationPipeline`'s `PermissionStage` calls into `PermissionEngine.canPer
 
 ## 3. Test coverage
 
-- **No test target.** `project.pbxproj` has exactly two native targets: the app (`mercantis core`, iOS/macOS app) and the CLI (`MercantisCLI`, tool). No `XCTest` target, no `*Tests` folder anywhere.
-- Every ADR that introduces a new subsystem claims "independently testable" (ADR-011, ADR-022 in particular). None of it is tested.
-
-This is by far the biggest risk compounder: the ValidationPipeline and ConflictResolver have exactly the shape that rewards unit testing, and get none.
+- **XCTest tests written in `mercantis coreTests/`.** Covers `ExpressionEvaluator`, `MetaComposer`, `ConflictResolver`, `ValidationPipeline`, `DocumentEngine` (save/fetch/concurrency/submit/cancel/amend), and `MigrationRunner` (v1/v2/v3 + idempotency).
+- **Wire-up pending.** The test target does not yet exist in `project.pbxproj`. `mercantis coreTests/README.md` lists the one-time Xcode setup. After that, `⌘U` or `xcodebuild test` runs the suite.
+- Other subsystems remain intentionally uncovered until their implementation settles (see P0.2/P0.5 in `Docs/ENHANCEMENT-PROPOSAL.md`).
 
 ---
 

--- a/mercantis coreTests/ConflictResolverTests.swift
+++ b/mercantis coreTests/ConflictResolverTests.swift
@@ -1,0 +1,77 @@
+//
+//  ConflictResolverTests.swift
+//  mercantis coreTests
+//
+//  Covers ADR-006: Last-Write-Wins, Version-Checked, and Append-Only policies.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class ConflictResolverTests: XCTestCase {
+
+    private let resolver = ConflictResolver()
+
+    // MARK: - Helpers
+
+    private func mutation(at version: Int64) -> MutationRecord {
+        MutationRecord(
+            id: UUID(),
+            type: .upsertDocument,
+            payload: Data(),
+            deviceId: "remote",
+            userId: "remote-user",
+            localTimestamp: Date(),
+            syncVersion: version,
+            status: .applied
+        )
+    }
+
+    // MARK: - Last-Write-Wins
+
+    func testLWWAcceptsRemoteWhenVersionIsNewer() {
+        let policy = SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false)
+        let result = resolver.resolve(remoteMutation: mutation(at: 5), localSyncVersion: 3, syncPolicy: policy)
+        guard case .accepted = result else { return XCTFail("expected .accepted, got \(result)") }
+    }
+
+    func testLWWAcceptsRemoteAtEqualVersion() {
+        let policy = SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false)
+        let result = resolver.resolve(remoteMutation: mutation(at: 3), localSyncVersion: 3, syncPolicy: policy)
+        guard case .accepted = result else { return XCTFail("expected .accepted, got \(result)") }
+    }
+
+    func testLWWConflictsWhenRemoteIsStale() {
+        let policy = SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false)
+        let result = resolver.resolve(remoteMutation: mutation(at: 1), localSyncVersion: 3, syncPolicy: policy)
+        guard case .conflicted(let local, let remote) = result else {
+            return XCTFail("expected .conflicted, got \(result)")
+        }
+        XCTAssertEqual(local, 3)
+        XCTAssertEqual(remote, 1)
+    }
+
+    // MARK: - Version-Checked Merge
+
+    func testVCMAcceptsOnlyWhenVersionsMatch() {
+        let policy = SyncPolicy(conflictResolution: .versionChecked, immutableAfterSubmit: true)
+        let result = resolver.resolve(remoteMutation: mutation(at: 7), localSyncVersion: 7, syncPolicy: policy)
+        guard case .accepted = result else { return XCTFail("expected .accepted, got \(result)") }
+    }
+
+    func testVCMConflictsWhenVersionsDisagree() {
+        let policy = SyncPolicy(conflictResolution: .versionChecked, immutableAfterSubmit: true)
+        let result = resolver.resolve(remoteMutation: mutation(at: 8), localSyncVersion: 7, syncPolicy: policy)
+        guard case .conflicted = result else { return XCTFail("expected .conflicted, got \(result)") }
+    }
+
+    // MARK: - Append-Only
+
+    func testAppendOnlyAlwaysAccepts() {
+        let policy = SyncPolicy(conflictResolution: .appendOnly, immutableAfterSubmit: false)
+        let result = resolver.resolve(remoteMutation: mutation(at: 0), localSyncVersion: 99, syncPolicy: policy)
+        guard case .appendedAsNew = result else {
+            return XCTFail("expected .appendedAsNew, got \(result)")
+        }
+    }
+}

--- a/mercantis coreTests/DocumentEngineTests.swift
+++ b/mercantis coreTests/DocumentEngineTests.swift
@@ -1,0 +1,320 @@
+//
+//  DocumentEngineTests.swift
+//  mercantis coreTests
+//
+//  Covers the core CRUD path (ADR-005, ADR-009), optimistic concurrency
+//  (ADR-023), and the submit/cancel/amend lifecycle (ADR-013).
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class DocumentEngineTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness()
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        harness = nil
+    }
+
+    // MARK: - Helpers
+
+    private func syncQueueCount() throws -> Int {
+        try harness.database.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM sync_queue") ?? 0
+        }
+    }
+
+    private func documentVersionCount(for documentId: String) throws -> Int {
+        try harness.database.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM document_versions WHERE documentId = ?",
+                arguments: [documentId]
+            ) ?? 0
+        }
+    }
+
+    // MARK: - Save / fetch round-trip
+
+    func testSaveThenFetchReturnsTheSameDocument() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        let doc = TestSupport.makeDocument(id: "note-1",
+                                           fields: ["title": .string("Hello")])
+        try harness.engine.save(doc)
+
+        let fetched = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "note-1"))
+        XCTAssertEqual(fetched.id, "note-1")
+        XCTAssertEqual(fetched.fields["title"], .string("Hello"))
+    }
+
+    func testSaveAppendsExactlyOneMutationRecord() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        XCTAssertEqual(try syncQueueCount(), 0)
+
+        try harness.engine.save(TestSupport.makeDocument(fields: ["title": .string("x")]))
+
+        XCTAssertEqual(try syncQueueCount(), 1, "save() must append exactly one mutation row")
+    }
+
+    func testSaveBumpsUpdatedAtOnRefetch() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        let original = TestSupport.makeDocument(
+            id: "note-ts",
+            fields: ["title": .string("x")],
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+        try harness.engine.save(original)
+
+        let fetched = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "note-ts"))
+        XCTAssertGreaterThan(fetched.updatedAt.timeIntervalSince1970, 0,
+                             "updatedAt must be refreshed by save()")
+    }
+
+    // MARK: - Optimistic concurrency (ADR-023)
+
+    func testSecondSaveWithStaleTimestampThrowsConcurrencyConflict() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        let doc = TestSupport.makeDocument(id: "note-c",
+                                           fields: ["title": .string("v1")])
+        try harness.engine.save(doc)
+
+        // The caller's in-memory copy still carries the original updatedAt,
+        // but the stored row has been rewritten with a fresh timestamp.
+        XCTAssertThrowsError(try harness.engine.save(doc)) { error in
+            guard case DocumentEngine.DocumentEngineError.concurrencyConflict = error else {
+                return XCTFail("expected concurrencyConflict, got \(error)")
+            }
+        }
+    }
+
+    func testSaveSucceedsAfterRefetch() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        try harness.engine.save(TestSupport.makeDocument(id: "note-r",
+                                                         fields: ["title": .string("v1")]))
+
+        var refetched = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "note-r"))
+        refetched.fields["title"] = .string("v2")
+
+        XCTAssertNoThrow(try harness.engine.save(refetched))
+
+        let final = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "note-r"))
+        XCTAssertEqual(final.fields["title"], .string("v2"))
+    }
+
+    // MARK: - Document versioning (ADR-024)
+
+    func testSaveRecordsADocumentVersionWhenFieldsChange() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        try harness.engine.save(TestSupport.makeDocument(id: "note-v",
+                                                         fields: ["title": .string("v1")]))
+        var refetched = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "note-v"))
+        refetched.fields["title"] = .string("v2")
+        try harness.engine.save(refetched)
+
+        XCTAssertGreaterThanOrEqual(try documentVersionCount(for: "note-v"), 1)
+    }
+
+    // MARK: - Delete
+
+    func testDeleteRemovesRowAndAppendsMutation() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        try harness.engine.save(TestSupport.makeDocument(id: "note-d",
+                                                         fields: ["title": .string("x")]))
+        XCTAssertNotNil(try harness.engine.fetch(docType: "Note", id: "note-d"))
+
+        try harness.engine.delete(docType: "Note", id: "note-d")
+
+        XCTAssertNil(try harness.engine.fetch(docType: "Note", id: "note-d"))
+        XCTAssertEqual(try syncQueueCount(), 2, "one save + one delete mutation")
+    }
+
+    // MARK: - Submit (ADR-013)
+
+    func testSubmitTransitionsDocStatusToOne() throws {
+        let docType = TestSupport.makeDocType(isSubmittable: true)
+        try harness.registry.register(docType)
+
+        var doc = TestSupport.makeDocument(id: "inv-1",
+                                           docType: "Note",
+                                           fields: ["title": .string("Invoice 1")])
+        try harness.engine.save(doc)
+
+        // Refetch so we have the up-to-date timestamp before submitting.
+        doc = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "inv-1"))
+        try harness.engine.submit(&doc)
+
+        let fetched = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "inv-1"))
+        XCTAssertEqual(fetched.docStatus, 1)
+    }
+
+    func testSubmitRejectsNonSubmittableDocType() throws {
+        let docType = TestSupport.makeDocType(isSubmittable: false)
+        try harness.registry.register(docType)
+
+        var doc = TestSupport.makeDocument(id: "note-ns",
+                                           docType: "Note",
+                                           fields: ["title": .string("x")])
+        try harness.engine.save(doc)
+        doc = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "note-ns"))
+
+        XCTAssertThrowsError(try harness.engine.submit(&doc)) { error in
+            guard case DocumentEngine.DocumentEngineError.notSubmittable = error else {
+                return XCTFail("expected notSubmittable, got \(error)")
+            }
+        }
+    }
+
+    func testEditingNonAllowOnSubmitFieldAfterSubmitIsRejected() throws {
+        let docType = TestSupport.makeDocType(
+            isSubmittable: true,
+            fields: [
+                TestSupport.textField("title", required: true, allowOnSubmit: false),
+                TestSupport.textField("memo", allowOnSubmit: true)
+            ]
+        )
+        try harness.registry.register(docType)
+
+        var doc = TestSupport.makeDocument(
+            id: "inv-imm",
+            fields: ["title": .string("Final"), "memo": .string("")]
+        )
+        try harness.engine.save(doc)
+        doc = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "inv-imm"))
+        try harness.engine.submit(&doc)
+
+        var afterSubmit = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "inv-imm"))
+        afterSubmit.fields["title"] = .string("Tampered") // non-allowOnSubmit
+
+        XCTAssertThrowsError(try harness.engine.save(afterSubmit)) { error in
+            guard case DocumentEngine.DocumentEngineError.fieldImmutableAfterSubmit(let key, _) = error else {
+                return XCTFail("expected fieldImmutableAfterSubmit, got \(error)")
+            }
+            XCTAssertEqual(key, "title")
+        }
+    }
+
+    func testEditingAllowOnSubmitFieldAfterSubmitSucceeds() throws {
+        let docType = TestSupport.makeDocType(
+            isSubmittable: true,
+            fields: [
+                TestSupport.textField("title", required: true, allowOnSubmit: false),
+                TestSupport.textField("memo", allowOnSubmit: true)
+            ]
+        )
+        try harness.registry.register(docType)
+
+        var doc = TestSupport.makeDocument(
+            id: "inv-memo",
+            fields: ["title": .string("Final"), "memo": .string("")]
+        )
+        try harness.engine.save(doc)
+        doc = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "inv-memo"))
+        try harness.engine.submit(&doc)
+
+        var afterSubmit = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "inv-memo"))
+        afterSubmit.fields["memo"] = .string("post-submit note")
+
+        XCTAssertNoThrow(try harness.engine.save(afterSubmit))
+
+        let final = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "inv-memo"))
+        XCTAssertEqual(final.fields["memo"], .string("post-submit note"))
+    }
+
+    // MARK: - Cancel (ADR-013)
+
+    func testCancelBlockedByLinkedSubmittedDocument() throws {
+        // Parent DocType and Child DocType (child has a link to parent).
+        let parent = TestSupport.makeDocType(
+            id: "Parent",
+            isSubmittable: true,
+            fields: [TestSupport.textField("title", required: true)]
+        )
+        let child = TestSupport.makeDocType(
+            id: "Child",
+            isSubmittable: true,
+            fields: [
+                TestSupport.textField("title", required: true),
+                TestSupport.linkField("parent", targeting: "Parent")
+            ]
+        )
+        try harness.registry.register(parent)
+        try harness.registry.register(child)
+
+        // Save and submit the parent.
+        var parentDoc = TestSupport.makeDocument(
+            id: "P-1", docType: "Parent",
+            fields: ["title": .string("Parent 1")]
+        )
+        try harness.engine.save(parentDoc)
+        parentDoc = try XCTUnwrap(harness.engine.fetch(docType: "Parent", id: "P-1"))
+        try harness.engine.submit(&parentDoc)
+
+        // Save and submit a child that links to parent.
+        var childDoc = TestSupport.makeDocument(
+            id: "C-1", docType: "Child",
+            fields: ["title": .string("Child 1"), "parent": .string("P-1")]
+        )
+        try harness.engine.save(childDoc)
+        childDoc = try XCTUnwrap(harness.engine.fetch(docType: "Child", id: "C-1"))
+        try harness.engine.submit(&childDoc)
+
+        // Attempting to cancel the parent must be blocked.
+        var submittedParent = try XCTUnwrap(harness.engine.fetch(docType: "Parent", id: "P-1"))
+        XCTAssertThrowsError(try harness.engine.cancel(&submittedParent)) { error in
+            guard case DocumentEngine.DocumentEngineError.cancelBlockedByLinks(_, let ids) = error else {
+                return XCTFail("expected cancelBlockedByLinks, got \(error)")
+            }
+            XCTAssertTrue(ids.contains("C-1"))
+        }
+    }
+
+    // MARK: - Amend (ADR-013)
+
+    func testAmendCreatesDraftWithAmendedFromReference() throws {
+        let docType = TestSupport.makeDocType(
+            isSubmittable: true,
+            fields: [TestSupport.textField("title", required: true)]
+        )
+        try harness.registry.register(docType)
+
+        var doc = TestSupport.makeDocument(
+            id: "orig", fields: ["title": .string("Original")]
+        )
+        try harness.engine.save(doc)
+        doc = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "orig"))
+        try harness.engine.submit(&doc)
+
+        var submitted = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "orig"))
+        try harness.engine.cancel(&submitted)
+
+        let cancelled = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "orig"))
+        XCTAssertEqual(cancelled.docStatus, 2)
+
+        let amended = try harness.engine.amend(cancelled)
+        XCTAssertEqual(amended.docStatus, 0)
+        XCTAssertEqual(amended.amendedFrom, "orig")
+        XCTAssertNotEqual(amended.id, "orig")
+        XCTAssertEqual(amended.fields["title"], .string("Original"))
+    }
+}

--- a/mercantis coreTests/ExpressionEvaluatorTests.swift
+++ b/mercantis coreTests/ExpressionEvaluatorTests.swift
@@ -1,0 +1,146 @@
+//
+//  ExpressionEvaluatorTests.swift
+//  mercantis coreTests
+//
+//  Covers the sandboxed expression evaluator described in ADR-017.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class ExpressionEvaluatorTests: XCTestCase {
+
+    private let evaluator = ExpressionEvaluator()
+
+    // MARK: - Boolean literals & identifiers
+
+    func testBooleanLiterals() throws {
+        XCTAssertTrue(try evaluator.evaluateBool(expression: "true", context: [:]))
+        XCTAssertFalse(try evaluator.evaluateBool(expression: "false", context: [:]))
+    }
+
+    func testIdentifierTruthiness() throws {
+        XCTAssertTrue(try evaluator.evaluateBool(expression: "flag", context: ["flag": .bool(true)]))
+        XCTAssertFalse(try evaluator.evaluateBool(expression: "flag", context: ["flag": .bool(false)]))
+        XCTAssertTrue(try evaluator.evaluateBool(expression: "name", context: ["name": .string("x")]))
+        XCTAssertFalse(try evaluator.evaluateBool(expression: "name", context: ["name": .string("")]))
+        XCTAssertFalse(try evaluator.evaluateBool(expression: "missing", context: [:]))
+    }
+
+    // MARK: - Comparisons
+
+    func testStringEquality() throws {
+        let ctx: [String: FieldValue] = ["status": .string("Submitted")]
+        XCTAssertTrue(try evaluator.evaluateBool(expression: "status == \"Submitted\"", context: ctx))
+        XCTAssertFalse(try evaluator.evaluateBool(expression: "status != \"Submitted\"", context: ctx))
+    }
+
+    func testNumericComparisons() throws {
+        let ctx: [String: FieldValue] = ["total": .double(250.0)]
+        XCTAssertTrue(try evaluator.evaluateBool(expression: "total > 100", context: ctx))
+        XCTAssertTrue(try evaluator.evaluateBool(expression: "total >= 250", context: ctx))
+        XCTAssertFalse(try evaluator.evaluateBool(expression: "total < 100", context: ctx))
+        XCTAssertTrue(try evaluator.evaluateBool(expression: "total <= 250", context: ctx))
+    }
+
+    // MARK: - Boolean operators
+
+    func testBooleanOperators() throws {
+        let ctx: [String: FieldValue] = [
+            "status": .string("Submitted"),
+            "total":  .double(15_000)
+        ]
+        XCTAssertTrue(try evaluator.evaluateBool(
+            expression: "status == \"Submitted\" && total > 10000",
+            context: ctx))
+        XCTAssertTrue(try evaluator.evaluateBool(
+            expression: "status == \"Draft\" || total > 10000",
+            context: ctx))
+        XCTAssertFalse(try evaluator.evaluateBool(
+            expression: "!(total > 10000)",
+            context: ctx))
+    }
+
+    func testParenthesesChangePrecedence() throws {
+        let ctx: [String: FieldValue] = ["a": .bool(true), "b": .bool(false), "c": .bool(true)]
+        XCTAssertTrue(try evaluator.evaluateBool(expression: "a && (b || c)", context: ctx))
+        XCTAssertFalse(try evaluator.evaluateBool(expression: "(a && b) || (!c)", context: ctx))
+    }
+
+    // MARK: - Arithmetic formulas
+
+    func testArithmeticBasics() throws {
+        XCTAssertEqual(try evaluator.evaluateFormula(expression: "2 + 3", context: [:]), .double(5))
+        XCTAssertEqual(try evaluator.evaluateFormula(expression: "10 - 4", context: [:]), .double(6))
+        XCTAssertEqual(try evaluator.evaluateFormula(expression: "6 * 7", context: [:]), .double(42))
+        XCTAssertEqual(try evaluator.evaluateFormula(expression: "20 / 4", context: [:]), .double(5))
+    }
+
+    func testArithmeticPrecedence() throws {
+        XCTAssertEqual(
+            try evaluator.evaluateFormula(expression: "2 + 3 * 4", context: [:]),
+            .double(14))
+        XCTAssertEqual(
+            try evaluator.evaluateFormula(expression: "(2 + 3) * 4", context: [:]),
+            .double(20))
+    }
+
+    func testArithmeticReferencesNumericField() throws {
+        let ctx: [String: FieldValue] = ["qty": .int(4), "rate": .double(12.5)]
+        XCTAssertEqual(
+            try evaluator.evaluateFormula(expression: "qty * rate", context: ctx),
+            .double(50))
+    }
+
+    // MARK: - Unary minus (regression for P0.9)
+
+    func testUnaryMinusOnLiteralInArithmetic() throws {
+        XCTAssertEqual(try evaluator.evaluateFormula(expression: "-5", context: [:]), .double(-5))
+        XCTAssertEqual(try evaluator.evaluateFormula(expression: "1 + -2", context: [:]), .double(-1))
+        XCTAssertEqual(try evaluator.evaluateFormula(expression: "3 * -2", context: [:]), .double(-6))
+    }
+
+    func testDoubleUnaryMinus() throws {
+        XCTAssertEqual(try evaluator.evaluateFormula(expression: "--5", context: [:]), .double(5))
+    }
+
+    func testUnaryMinusOnParenthesisedExpression() throws {
+        XCTAssertEqual(try evaluator.evaluateFormula(expression: "-(2 + 3)", context: [:]), .double(-5))
+    }
+
+    func testUnaryMinusOnFieldRef() throws {
+        let ctx: [String: FieldValue] = ["price": .double(5)]
+        XCTAssertEqual(try evaluator.evaluateFormula(expression: "-price", context: ctx), .double(-5))
+    }
+
+    func testUnaryMinusInBooleanComparison() throws {
+        let ctx: [String: FieldValue] = ["price": .double(-5)]
+        XCTAssertTrue(try evaluator.evaluateBool(expression: "-5 == price", context: ctx))
+        XCTAssertFalse(try evaluator.evaluateBool(expression: "-5 != price", context: ctx))
+    }
+
+    // MARK: - Error cases
+
+    func testDivisionByZeroThrows() {
+        XCTAssertThrowsError(try evaluator.evaluateFormula(expression: "10 / 0", context: [:])) { error in
+            guard case ExpressionEvaluator.EvaluatorError.divisionByZero = error else {
+                return XCTFail("expected divisionByZero, got \(error)")
+            }
+        }
+    }
+
+    func testUndefinedFieldInFormulaThrows() {
+        XCTAssertThrowsError(try evaluator.evaluateFormula(expression: "qty * 2", context: [:])) { error in
+            guard case ExpressionEvaluator.EvaluatorError.undefinedField(let name) = error else {
+                return XCTFail("expected undefinedField, got \(error)")
+            }
+            XCTAssertEqual(name, "qty")
+        }
+    }
+
+    func testEmptyExpressionEvaluatesToFalse() throws {
+        // An empty expression has no tokens; `parseValue` returns .null and
+        // a truthiness fallback gives false.
+        XCTAssertFalse(try evaluator.evaluateBool(expression: "", context: [:]))
+    }
+}

--- a/mercantis coreTests/MetaComposerTests.swift
+++ b/mercantis coreTests/MetaComposerTests.swift
@@ -1,0 +1,201 @@
+//
+//  MetaComposerTests.swift
+//  mercantis coreTests
+//
+//  Covers ADR-021: ResolvedMeta composition from base DocType + custom fields
+//  + property setters, and cache invalidation via the generation counter.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class MetaComposerTests: XCTestCase {
+
+    private var url: URL!
+    private var database: MercantisDatabase!
+    private var registry: MetadataRegistry!
+    private var composer: MetaComposer!
+
+    override func setUpWithError() throws {
+        url = TestSupport.tempDatabaseURL()
+        database = try TestSupport.makeDatabase(at: url)
+        registry = MetadataRegistry(database: database)
+        composer = MetaComposer(registry: registry)
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: url)
+    }
+
+    // MARK: - Base composition
+
+    func testResolveUnknownDocTypeReturnsNil() {
+        XCTAssertNil(composer.resolve(docType: "DoesNotExist"))
+    }
+
+    func testResolvePreservesBaseFieldOrder() throws {
+        let docType = TestSupport.makeDocType(fields: [
+            TestSupport.textField("a"),
+            TestSupport.textField("b"),
+            TestSupport.textField("c")
+        ])
+        try registry.register(docType)
+
+        let resolved = try XCTUnwrap(composer.resolve(docType: "Note"))
+        XCTAssertEqual(resolved.fields.map(\.key), ["a", "b", "c"])
+        XCTAssertTrue(resolved.fields.allSatisfy { !$0.isCustom })
+    }
+
+    // MARK: - Custom fields
+
+    func testCustomFieldAppendedWhenInsertAfterIsNil() throws {
+        let docType = TestSupport.makeDocType(fields: [
+            TestSupport.textField("a"),
+            TestSupport.textField("b")
+        ])
+        try registry.register(docType)
+
+        let custom = CustomField(
+            docType: "Note",
+            fieldDefinition: TestSupport.textField("extra"),
+            insertAfter: nil
+        )
+        composer.setCustomFields([custom], for: "Note")
+
+        let resolved = try XCTUnwrap(composer.resolve(docType: "Note"))
+        XCTAssertEqual(resolved.fields.map(\.key), ["a", "b", "extra"])
+        XCTAssertTrue(resolved.fields.last!.isCustom)
+    }
+
+    func testCustomFieldInsertedAfterNamedField() throws {
+        let docType = TestSupport.makeDocType(fields: [
+            TestSupport.textField("a"),
+            TestSupport.textField("b"),
+            TestSupport.textField("c")
+        ])
+        try registry.register(docType)
+
+        let custom = CustomField(
+            docType: "Note",
+            fieldDefinition: TestSupport.textField("after_a"),
+            insertAfter: "a"
+        )
+        composer.setCustomFields([custom], for: "Note")
+
+        let resolved = try XCTUnwrap(composer.resolve(docType: "Note"))
+        XCTAssertEqual(resolved.fields.map(\.key), ["a", "after_a", "b", "c"])
+    }
+
+    func testCustomFieldWithUnknownInsertAfterFallsBackToAppend() throws {
+        let docType = TestSupport.makeDocType(fields: [
+            TestSupport.textField("a"),
+            TestSupport.textField("b")
+        ])
+        try registry.register(docType)
+
+        let custom = CustomField(
+            docType: "Note",
+            fieldDefinition: TestSupport.textField("extra"),
+            insertAfter: "does-not-exist"
+        )
+        composer.setCustomFields([custom], for: "Note")
+
+        let resolved = try XCTUnwrap(composer.resolve(docType: "Note"))
+        XCTAssertEqual(resolved.fields.map(\.key), ["a", "b", "extra"])
+    }
+
+    // MARK: - Property setters
+
+    func testPropertySetterOverridesLabel() throws {
+        let docType = TestSupport.makeDocType(fields: [
+            TestSupport.textField("title", label: "Title"),
+        ])
+        try registry.register(docType)
+
+        composer.setPropertySetters(
+            [PropertySetter(docType: "Note", fieldKey: "title", property: "label", value: "Subject")],
+            for: "Note")
+
+        let resolved = try XCTUnwrap(composer.resolve(docType: "Note"))
+        XCTAssertEqual(resolved.fields.first?.label, "Subject")
+    }
+
+    func testPropertySetterHiddenTrueSetsVisibilityFalse() throws {
+        let docType = TestSupport.makeDocType(fields: [TestSupport.textField("title")])
+        try registry.register(docType)
+
+        composer.setPropertySetters(
+            [PropertySetter(docType: "Note", fieldKey: "title", property: "hidden", value: "true")],
+            for: "Note")
+
+        let resolved = try XCTUnwrap(composer.resolve(docType: "Note"))
+        XCTAssertEqual(resolved.fields.first?.visibilityExpression, "false")
+    }
+
+    func testPropertySetterReadOnlyTrueSetsReadOnlyExpression() throws {
+        let docType = TestSupport.makeDocType(fields: [TestSupport.textField("title")])
+        try registry.register(docType)
+
+        composer.setPropertySetters(
+            [PropertySetter(docType: "Note", fieldKey: "title", property: "read_only", value: "true")],
+            for: "Note")
+
+        let resolved = try XCTUnwrap(composer.resolve(docType: "Note"))
+        XCTAssertEqual(resolved.fields.first?.readOnlyExpression, "true")
+    }
+
+    // MARK: - Cache
+
+    func testResolveReturnsSameInstanceUntilInvalidation() throws {
+        let docType = TestSupport.makeDocType(fields: [TestSupport.textField("title")])
+        try registry.register(docType)
+
+        let firstFields = try XCTUnwrap(composer.resolve(docType: "Note")).fields.map(\.key)
+        XCTAssertEqual(firstFields, ["title"])
+
+        composer.setCustomFields(
+            [CustomField(docType: "Note", fieldDefinition: TestSupport.textField("extra"), insertAfter: nil)],
+            for: "Note")
+
+        // setCustomFields invalidates the per-docType cache entry, so resolve
+        // now returns a recomposed ResolvedMeta.
+        let secondFields = try XCTUnwrap(composer.resolve(docType: "Note")).fields.map(\.key)
+        XCTAssertEqual(secondFields, ["title", "extra"])
+    }
+
+    func testInvalidateAllBumpsGeneration() throws {
+        let docType = TestSupport.makeDocType(fields: [TestSupport.textField("title")])
+        try registry.register(docType)
+
+        _ = composer.resolve(docType: "Note") // prime cache
+
+        // Invalidate globally.
+        composer.invalidateAll()
+
+        // Mutate the base registry entry by re-registering with a new field.
+        let updated = TestSupport.makeDocType(fields: [
+            TestSupport.textField("title"),
+            TestSupport.textField("body")
+        ])
+        try registry.register(updated)
+
+        let resolved = try XCTUnwrap(composer.resolve(docType: "Note"))
+        XCTAssertEqual(resolved.fields.map(\.key), ["title", "body"])
+    }
+
+    // MARK: - Inline draft resolution
+
+    func testResolveDraftDocTypeWithoutRegistryPersistence() {
+        let draft = TestSupport.makeDocType(
+            id: "DraftType",
+            fields: [TestSupport.textField("x")]
+        )
+        let custom = CustomField(
+            docType: "DraftType",
+            fieldDefinition: TestSupport.textField("y"),
+            insertAfter: "x"
+        )
+        let resolved = composer.resolve(docTypeDefinition: draft, customFields: [custom])
+        XCTAssertEqual(resolved.fields.map(\.key), ["x", "y"])
+    }
+}

--- a/mercantis coreTests/MigrationRunnerTests.swift
+++ b/mercantis coreTests/MigrationRunnerTests.swift
@@ -1,0 +1,120 @@
+//
+//  MigrationRunnerTests.swift
+//  mercantis coreTests
+//
+//  Covers ADR-002: forward-only, versioned schema migrations.
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class MigrationRunnerTests: XCTestCase {
+
+    private var url: URL!
+    private var pool: DatabasePool!
+
+    override func setUpWithError() throws {
+        url = TestSupport.tempDatabaseURL("migrations")
+        pool = try DatabasePool(path: url.path)
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: url)
+        pool = nil
+    }
+
+    // MARK: - Helpers
+
+    private func highestAppliedVersion() throws -> Int {
+        try pool.read { db in
+            try Int.fetchOne(db, sql: "SELECT MAX(version) FROM schema_version") ?? 0
+        }
+    }
+
+    private func tableExists(_ name: String) throws -> Bool {
+        try pool.read { db in
+            try Row.fetchOne(
+                db,
+                sql: "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+                arguments: [name]
+            ) != nil
+        }
+    }
+
+    private func columnExists(_ column: String, in table: String) throws -> Bool {
+        try pool.read { db in
+            let rows = try Row.fetchAll(db, sql: "PRAGMA table_info(\(table))")
+            return rows.contains { ($0["name"] as String?) == column }
+        }
+    }
+
+    // MARK: - Tests
+
+    func testBuiltInMigrationsApplyInOrder() throws {
+        var runner = MigrationRunner()
+        MigrationRunner.registerAll(into: &runner, pool: pool)
+        try runner.migrate(pool: pool)
+
+        XCTAssertEqual(try highestAppliedVersion(), 3)
+    }
+
+    func testV1CreatesExpectedTables() throws {
+        var runner = MigrationRunner()
+        MigrationRunner.registerAll(into: &runner, pool: pool)
+        try runner.migrate(pool: pool)
+
+        for table in ["doctypes", "fields", "documents", "document_children",
+                      "sync_queue", "audit_log", "apps", "workflows"] {
+            XCTAssertTrue(try tableExists(table), "\(table) should exist after v1")
+        }
+    }
+
+    func testV2AddsDocStatusAndAmendedFromColumns() throws {
+        var runner = MigrationRunner()
+        MigrationRunner.registerAll(into: &runner, pool: pool)
+        try runner.migrate(pool: pool)
+
+        XCTAssertTrue(try columnExists("docStatus", in: "documents"))
+        XCTAssertTrue(try columnExists("amendedFrom", in: "documents"))
+    }
+
+    func testV3CreatesDocumentVersionsTable() throws {
+        var runner = MigrationRunner()
+        MigrationRunner.registerAll(into: &runner, pool: pool)
+        try runner.migrate(pool: pool)
+
+        XCTAssertTrue(try tableExists("document_versions"))
+    }
+
+    func testSecondMigrateIsIdempotent() throws {
+        var runner = MigrationRunner()
+        MigrationRunner.registerAll(into: &runner, pool: pool)
+        try runner.migrate(pool: pool)
+        let rowsAfterFirst = try pool.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM schema_version") ?? 0
+        }
+
+        // Running migrate() again must not re-apply or duplicate rows.
+        XCTAssertNoThrow(try runner.migrate(pool: pool))
+        let rowsAfterSecond = try pool.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM schema_version") ?? 0
+        }
+        XCTAssertEqual(rowsAfterFirst, rowsAfterSecond, "schema_version must not duplicate rows")
+    }
+
+    func testCustomMigrationRegisteredAtHigherVersionIsApplied() throws {
+        var runner = MigrationRunner()
+        MigrationRunner.registerAll(into: &runner, pool: pool)
+        runner.register(version: 99, name: "test_marker", sql: """
+            CREATE TABLE IF NOT EXISTS test_marker (
+                id TEXT PRIMARY KEY NOT NULL
+            );
+        """)
+
+        try runner.migrate(pool: pool)
+
+        XCTAssertTrue(try tableExists("test_marker"))
+        XCTAssertEqual(try highestAppliedVersion(), 99)
+    }
+}

--- a/mercantis coreTests/README.md
+++ b/mercantis coreTests/README.md
@@ -1,0 +1,76 @@
+# mercantis coreTests
+
+XCTest coverage for Mercantis Core. Implements the P0.1 test target from
+`Docs/ENHANCEMENT-PROPOSAL.md`.
+
+## One-time Xcode setup
+
+The `.swift` files in this directory are not yet registered with any target.
+Add them by creating a Unit Testing Bundle:
+
+1. Open `mercantis core.xcodeproj`.
+2. In the Project navigator, select the project root → **+ Target**.
+3. Choose **macOS** (or **iOS**, as you prefer) → **Unit Testing Bundle** →
+   **Next**.
+4. Name: `mercantis coreTests`. Bundle identifier: whatever matches the
+   project's `PRODUCT_BUNDLE_IDENTIFIER` convention + `.tests`. Host
+   application: `mercantis core`. Click **Finish**.
+5. Xcode creates a default folder with a placeholder test file. **Delete
+   that folder** (move to trash). You want the target to point at the
+   existing `mercantis coreTests/` directory on disk.
+6. Right-click the project root → **Add Files to "mercantis core"**.
+   Select `mercantis coreTests/` on disk, enable **Create groups** (or
+   **Add as filesystem synchronized group** in Xcode 16+), and tick only
+   the `mercantis coreTests` target under "Add to targets".
+7. In the test target's **Build Phases → Link Binary With Libraries**,
+   add `GRDB` (same framework the app target links). The tests use
+   `import GRDB` directly for a few migration and sync-queue assertions.
+
+The main app module is exposed via `@testable import mercantis_core`.
+
+Run the tests with `⌘U` or `xcodebuild test -scheme "mercantis core"` from
+the command line.
+
+## What's covered
+
+| File | Subsystem | Notes |
+|---|---|---|
+| `ExpressionEvaluatorTests.swift` | `ExpressionEngine/` | Boolean, formula, comparisons, unary minus (P0.9 regression), division by zero, undefined field. |
+| `MetaComposerTests.swift` | `Metadata/` | Custom field insertion order, property setters (`label`, `hidden`, `read_only`), cache invalidation. |
+| `ConflictResolverTests.swift` | `SyncEngine/` | LWW, VCM, AO across equal/newer/stale versions. |
+| `ValidationPipelineTests.swift` | `DocumentEngine/` | Each stage in isolation plus short-circuit ordering. |
+| `DocumentEngineTests.swift` | `DocumentEngine/` | Save/fetch round-trip, sync-queue atomicity, `DocumentVersion` recording, optimistic concurrency, submit immutability, cancel link integrity, amend. |
+| `MigrationRunnerTests.swift` | `Storage/` | v1/v2/v3 applied in order, expected tables/columns present, idempotent re-runs, custom migrations at higher versions. |
+
+Shared fixtures live in `Support/TestSupport.swift`.
+
+## What's deliberately not covered yet
+
+- `SyncEngine.applyRemote*` paths — P0.2 in the enhancement proposal will
+  re-route these through `DocumentEngine`; tests should land with that
+  change rather than lock in the current shape.
+- `PermissionEngine` — P0.5 reconciles the ADR-011 chain with the flat
+  implementation; testing both shapes first is wasted effort.
+- `WorkflowEngine` — no persistence today (`WorkflowTransitionHistory` is
+  returned but not stored). Covered once the caller contract settles.
+- UI code in `UIShell/` and `Views/DesignSystem/` — UI regression tests
+  are out of scope for P0.1.
+
+## Writing new tests
+
+Use `TestSupport` builders to stay concise:
+
+```swift
+let docType = TestSupport.makeDocType(fields: [
+    TestSupport.textField("title", required: true)
+])
+let harness = try TestSupport.makeHarness()
+defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+try harness.registry.register(docType)
+try harness.engine.save(TestSupport.makeDocument(fields: ["title": .string("hi")]))
+```
+
+Each DB-backed test uses its own tempdir and cleans up in `tearDown`. Do
+not share a database across tests — GRDB `DatabasePool` keeps a persistent
+WAL that can confuse parallel runs.

--- a/mercantis coreTests/Support/TestSupport.swift
+++ b/mercantis coreTests/Support/TestSupport.swift
@@ -1,0 +1,186 @@
+//
+//  TestSupport.swift
+//  mercantis coreTests
+//
+//  Shared fixtures and builders for Mercantis Core tests.
+//
+
+import Foundation
+import XCTest
+@testable import mercantis_core
+
+enum TestSupport {
+
+    // MARK: - Database
+
+    /// Return a fresh URL under the system temp directory for a one-off SQLite file.
+    /// Each test should use its own URL and call `cleanUp(databaseURL:)` in tearDown.
+    static func tempDatabaseURL(_ label: String = "mercantis-test") -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mercantis-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("\(label).sqlite")
+    }
+
+    /// Build a fully migrated `MercantisDatabase` at `url`.
+    static func makeDatabase(at url: URL) throws -> MercantisDatabase {
+        try MercantisDatabase(databaseURL: url)
+    }
+
+    /// Remove the temp directory that contains `url`. Safe to call in tearDown.
+    static func cleanUp(databaseURL url: URL) {
+        let dir = url.deletingLastPathComponent()
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    // MARK: - DocType builders
+
+    static func textField(
+        _ key: String,
+        label: String? = nil,
+        required: Bool = false,
+        allowOnSubmit: Bool = false
+    ) -> FieldDefinition {
+        FieldDefinition(
+            key: key,
+            label: label ?? key.capitalized,
+            type: .text,
+            required: required,
+            allowOnSubmit: allowOnSubmit
+        )
+    }
+
+    static func numberField(
+        _ key: String,
+        label: String? = nil,
+        required: Bool = false
+    ) -> FieldDefinition {
+        FieldDefinition(
+            key: key,
+            label: label ?? key.capitalized,
+            type: .number,
+            required: required
+        )
+    }
+
+    static func linkField(
+        _ key: String,
+        targeting docType: String
+    ) -> FieldDefinition {
+        FieldDefinition(
+            key: key,
+            label: key.capitalized,
+            type: .link,
+            required: false,
+            linkedDocType: docType
+        )
+    }
+
+    static func defaultSyncPolicy() -> SyncPolicy {
+        SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false)
+    }
+
+    static func submittableSyncPolicy() -> SyncPolicy {
+        SyncPolicy(conflictResolution: .versionChecked, immutableAfterSubmit: true)
+    }
+
+    static func permissionRule(role: String = "System Manager") -> PermissionRule {
+        PermissionRule(
+            role: role,
+            canRead: true,
+            canWrite: true,
+            canCreate: true,
+            canDelete: true,
+            canSubmit: true,
+            canAmend: true
+        )
+    }
+
+    /// Build a minimal DocType with the given id and fields.
+    static func makeDocType(
+        id: String = "Note",
+        module: String = "Core",
+        appId: String = "app.mercantis.test",
+        fields: [FieldDefinition] = [textField("title", required: true)],
+        permissions: [PermissionRule] = [permissionRule()],
+        isSubmittable: Bool = false,
+        syncPolicy: SyncPolicy? = nil,
+        indexes: [IndexDefinition] = [],
+        titleField: String = "title"
+    ) -> DocType {
+        DocType(
+            id: id,
+            name: id,
+            module: module,
+            appId: appId,
+            isChildTable: false,
+            isSubmittable: isSubmittable,
+            fields: fields,
+            permissions: permissions,
+            syncPolicy: syncPolicy ?? defaultSyncPolicy(),
+            indexes: indexes,
+            searchFields: [titleField],
+            titleField: titleField
+        )
+    }
+
+    // MARK: - Document builders
+
+    static func makeDocument(
+        id: String = UUID().uuidString,
+        docType: String = "Note",
+        fields: [String: FieldValue] = ["title": .string("Hello")],
+        children: [String: [ChildRow]] = [:],
+        docStatus: Int = 0,
+        amendedFrom: String? = nil,
+        syncVersion: Int64 = 0,
+        updatedAt: Date = Date()
+    ) -> Document {
+        Document(
+            id: id,
+            docType: docType,
+            company: "",
+            status: "",
+            createdAt: updatedAt,
+            updatedAt: updatedAt,
+            syncVersion: syncVersion,
+            syncState: .local,
+            docStatus: docStatus,
+            amendedFrom: amendedFrom,
+            fields: fields,
+            children: children
+        )
+    }
+
+    // MARK: - DocumentEngine assembly
+
+    struct Harness {
+        let database: MercantisDatabase
+        let registry: MetadataRegistry
+        let emitter: EventEmitter
+        let engine: DocumentEngine
+        let url: URL
+    }
+
+    /// Spin up a DocumentEngine against a fresh on-disk SQLite file. Caller
+    /// should clean up by calling `TestSupport.cleanUp(databaseURL: harness.url)`.
+    static func makeHarness(
+        deviceId: String = "test-device",
+        userId: String = "test-user",
+        pipeline: ValidationPipeline? = nil
+    ) throws -> Harness {
+        let url = tempDatabaseURL()
+        let database = try makeDatabase(at: url)
+        let registry = MetadataRegistry(database: database)
+        let emitter = EventEmitter()
+        let engine = DocumentEngine(
+            database: database,
+            registry: registry,
+            deviceId: deviceId,
+            userId: userId,
+            eventEmitter: emitter,
+            validationPipeline: pipeline ?? ValidationPipeline()
+        )
+        return Harness(database: database, registry: registry, emitter: emitter, engine: engine, url: url)
+    }
+}

--- a/mercantis coreTests/ValidationPipelineTests.swift
+++ b/mercantis coreTests/ValidationPipelineTests.swift
@@ -1,0 +1,230 @@
+//
+//  ValidationPipelineTests.swift
+//  mercantis coreTests
+//
+//  Covers ADR-022: structured, ordered validation stages.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class ValidationPipelineTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func context(
+        for docType: DocType,
+        userRoles: Set<String> = [],
+        documentExists: @escaping @Sendable (String, String) -> Bool = { _, _ in true },
+        uniqueConflict: @escaping @Sendable (String, String, FieldValue, String) -> Bool = { _, _, _, _ in false }
+    ) -> ValidationContext {
+        ValidationContext(
+            docType: docType,
+            userId: "tester",
+            userRoles: userRoles,
+            expressionEvaluator: ExpressionEvaluator(),
+            documentExists: documentExists,
+            uniqueConflictExists: uniqueConflict
+        )
+    }
+
+    // MARK: - Required
+
+    func testRequiredStageFailsOnMissingValue() {
+        let docType = TestSupport.makeDocType(fields: [
+            TestSupport.textField("title", required: true)
+        ])
+        let doc = TestSupport.makeDocument(fields: [:])
+        let pipeline = ValidationPipeline(stages: [RequiredFieldStage()])
+
+        let errors = pipeline.validate(document: doc, context: context(for: docType))
+        XCTAssertEqual(errors.count, 1)
+        XCTAssertEqual(errors.first?.stage, "RequiredField")
+        XCTAssertEqual(errors.first?.field, "title")
+    }
+
+    func testRequiredStageFailsOnWhitespaceOnlyString() {
+        let docType = TestSupport.makeDocType(fields: [
+            TestSupport.textField("title", required: true)
+        ])
+        let doc = TestSupport.makeDocument(fields: ["title": .string("   ")])
+        let pipeline = ValidationPipeline(stages: [RequiredFieldStage()])
+
+        let errors = pipeline.validate(document: doc, context: context(for: docType))
+        XCTAssertEqual(errors.count, 1)
+    }
+
+    func testRequiredStagePassesForPopulatedField() {
+        let docType = TestSupport.makeDocType(fields: [
+            TestSupport.textField("title", required: true)
+        ])
+        let doc = TestSupport.makeDocument(fields: ["title": .string("Hello")])
+        let pipeline = ValidationPipeline(stages: [RequiredFieldStage()])
+
+        XCTAssertTrue(pipeline.validate(document: doc, context: context(for: docType)).isEmpty)
+    }
+
+    // MARK: - Type coercion
+
+    func testTypeCoercionRejectsBoolInTextField() {
+        let docType = TestSupport.makeDocType(fields: [TestSupport.textField("title")])
+        let doc = TestSupport.makeDocument(fields: ["title": .bool(true)])
+        let pipeline = ValidationPipeline(stages: [TypeCoercionStage()])
+
+        let errors = pipeline.validate(document: doc, context: context(for: docType))
+        XCTAssertEqual(errors.first?.stage, "TypeCoercion")
+    }
+
+    func testTypeCoercionAcceptsNumericStringForNumberField() {
+        let docType = TestSupport.makeDocType(fields: [TestSupport.numberField("qty")])
+        let doc = TestSupport.makeDocument(fields: ["qty": .string("42")])
+        let pipeline = ValidationPipeline(stages: [TypeCoercionStage()])
+
+        XCTAssertTrue(pipeline.validate(document: doc, context: context(for: docType)).isEmpty)
+    }
+
+    // MARK: - Link validation
+
+    func testLinkValidationFailsWhenTargetDoesNotExist() {
+        let docType = TestSupport.makeDocType(fields: [TestSupport.linkField("customer", targeting: "Customer")])
+        let doc = TestSupport.makeDocument(fields: ["customer": .string("missing-id")])
+        let pipeline = ValidationPipeline(stages: [LinkValidationStage()])
+
+        let ctx = context(for: docType, documentExists: { _, _ in false })
+        let errors = pipeline.validate(document: doc, context: ctx)
+        XCTAssertEqual(errors.first?.stage, "LinkValidation")
+        XCTAssertEqual(errors.first?.field, "customer")
+    }
+
+    func testLinkValidationPassesWhenTargetExists() {
+        let docType = TestSupport.makeDocType(fields: [TestSupport.linkField("customer", targeting: "Customer")])
+        let doc = TestSupport.makeDocument(fields: ["customer": .string("CUST-1")])
+        let pipeline = ValidationPipeline(stages: [LinkValidationStage()])
+
+        let ctx = context(for: docType, documentExists: { _, _ in true })
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    // MARK: - Unique constraint
+
+    func testUniqueConstraintFailsOnDuplicateValue() {
+        let docType = TestSupport.makeDocType(
+            fields: [TestSupport.textField("slug")],
+            indexes: [IndexDefinition(fieldKey: "slug", unique: true)]
+        )
+        let doc = TestSupport.makeDocument(fields: ["slug": .string("hello")])
+        let pipeline = ValidationPipeline(stages: [UniqueConstraintStage()])
+
+        let ctx = context(for: docType, uniqueConflict: { _, _, _, _ in true })
+        let errors = pipeline.validate(document: doc, context: ctx)
+        XCTAssertEqual(errors.first?.stage, "UniqueConstraint")
+    }
+
+    func testUniqueConstraintPassesWhenNoConflict() {
+        let docType = TestSupport.makeDocType(
+            fields: [TestSupport.textField("slug")],
+            indexes: [IndexDefinition(fieldKey: "slug", unique: true)]
+        )
+        let doc = TestSupport.makeDocument(fields: ["slug": .string("hello")])
+        let pipeline = ValidationPipeline(stages: [UniqueConstraintStage()])
+
+        let ctx = context(for: docType, uniqueConflict: { _, _, _, _ in false })
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    // MARK: - Validation rule expressions
+
+    func testValidationRuleFailsOnFalseExpression() {
+        let field = FieldDefinition(
+            key: "total",
+            label: "Total",
+            type: .number,
+            required: false,
+            validationRules: [ValidationRule(ruleType: "range", expression: "total > 0", message: "Must be positive")]
+        )
+        let docType = TestSupport.makeDocType(fields: [field])
+        let doc = TestSupport.makeDocument(fields: ["total": .double(-5)])
+        let pipeline = ValidationPipeline(stages: [ValidationRuleStage()])
+
+        let errors = pipeline.validate(document: doc, context: context(for: docType))
+        XCTAssertEqual(errors.first?.stage, "ValidationRule")
+        XCTAssertEqual(errors.first?.message, "Must be positive")
+    }
+
+    func testValidationRulePassesOnTrueExpression() {
+        let field = FieldDefinition(
+            key: "total",
+            label: "Total",
+            type: .number,
+            required: false,
+            validationRules: [ValidationRule(ruleType: "range", expression: "total > 0", message: "Must be positive")]
+        )
+        let docType = TestSupport.makeDocType(fields: [field])
+        let doc = TestSupport.makeDocument(fields: ["total": .double(10)])
+        let pipeline = ValidationPipeline(stages: [ValidationRuleStage()])
+
+        XCTAssertTrue(pipeline.validate(document: doc, context: context(for: docType)).isEmpty)
+    }
+
+    // MARK: - Pipeline ordering / short-circuit
+
+    func testPipelineShortCircuitsAfterFirstFailingStage() {
+        // RequiredField must fail first and prevent ValidationRule from running;
+        // the rule references `total` which, if run, would throw `undefinedField`
+        // and add a second error.
+        let field = FieldDefinition(
+            key: "total",
+            label: "Total",
+            type: .number,
+            required: true,
+            validationRules: [ValidationRule(ruleType: "range", expression: "total > 0", message: "positive")]
+        )
+        let docType = TestSupport.makeDocType(fields: [field])
+        let doc = TestSupport.makeDocument(fields: [:])
+        let pipeline = ValidationPipeline(stages: [
+            RequiredFieldStage(),
+            ValidationRuleStage()
+        ])
+
+        let errors = pipeline.validate(document: doc, context: context(for: docType))
+        XCTAssertEqual(errors.count, 1, "pipeline must stop at the first failing stage")
+        XCTAssertEqual(errors.first?.stage, "RequiredField")
+    }
+
+    // MARK: - Permission stage
+
+    func testPermissionStagePassesWhenRoleHasWriteAccess() {
+        let rule = PermissionRule(
+            role: "Editor",
+            canRead: true, canWrite: true, canCreate: true,
+            canDelete: false, canSubmit: false, canAmend: false
+        )
+        let docType = TestSupport.makeDocType(
+            fields: [TestSupport.textField("title")],
+            permissions: [rule]
+        )
+        let doc = TestSupport.makeDocument()
+        let pipeline = ValidationPipeline(stages: [PermissionStage()])
+
+        let ctx = context(for: docType, userRoles: ["Editor"])
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    func testPermissionStageFailsWhenRoleLacksWriteAccess() {
+        let rule = PermissionRule(
+            role: "Reader",
+            canRead: true, canWrite: false, canCreate: false,
+            canDelete: false, canSubmit: false, canAmend: false
+        )
+        let docType = TestSupport.makeDocType(
+            fields: [TestSupport.textField("title")],
+            permissions: [rule]
+        )
+        let doc = TestSupport.makeDocument()
+        let pipeline = ValidationPipeline(stages: [PermissionStage()])
+
+        let ctx = context(for: docType, userRoles: ["Reader"])
+        let errors = pipeline.validate(document: doc, context: ctx)
+        XCTAssertEqual(errors.first?.stage, "Permission")
+    }
+}


### PR DESCRIPTION
Lays down XCTest files in `mercantis coreTests/` covering the subsystems that the enhancement proposal flagged as load-bearing before any sync/permissions refactors land.

- Support/TestSupport.swift — shared fixtures: tempdir-backed MercantisDatabase, DocType / FieldDefinition / Document builders, and a DocumentEngine harness that wires database + registry + emitter.
- ExpressionEvaluatorTests — boolean, formula, comparisons, unary minus regressions (P0.9), division by zero, undefined field, empty input.
- MetaComposerTests — base composition order, custom-field insertion at `insertAfter`, property setters (label / hidden / read_only), cache invalidation via setCustomFields, invalidateAll, and inline draft resolution.
- ConflictResolverTests — LWW / VCM / AO branches across newer / equal / stale versions.
- ValidationPipelineTests — each stage in isolation (Required, TypeCoercion, LinkValidation, UniqueConstraint, ValidationRule, Permission) plus pipeline short-circuit ordering.
- DocumentEngineTests — save/fetch round-trip, one-mutation-per-save invariant, DocumentVersion recording, stale-timestamp concurrency conflict, refetch-then-save recovery, submit transitions docStatus, immutability enforcement for non-allowOnSubmit fields, cancel blocked by linked submitted documents, and amend creates a Draft with `amendedFrom` pointing at the cancelled source.
- MigrationRunnerTests — v1/v2/v3 applied in order, expected tables and columns exist, re-running `migrate` is idempotent, custom migration at a higher version applies.
- README.md — one-time Xcode steps for adding the Unit Testing Bundle target (files are not yet wired into project.pbxproj; doing that in Xcode's UI avoids hand-editing the synchronized-groups pbxproj).

Also updates Docs/IMPLEMENTATION-STATUS.md §3 and
Docs/ENHANCEMENT-PROPOSAL.md P0.1 to reflect that test source has landed and only the target wire-up remains.