### PR TITLE
Route sync-received writes through DocumentEngine (P0.2)

### DIFF
--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -32,14 +32,15 @@ Test source is now in `mercantis coreTests/`:
 
 Why this was first: every enhancement below lands more safely on top of a test target. The validation pipeline in particular was built for independent stage testing (ADR-022) — shipping it without tests defeats the design.
 
-### P0.2 — Run sync-received writes through `DocumentEngine` [M, medium risk] — ADR-005/022/024
+### P0.2 — Run sync-received writes through `DocumentEngine` [M, medium risk] — ADR-005/022/024 *(done)*
 
-Today, `SyncEngine.applyRemoteUpsert` writes straight to the `documents` table, bypassing:
-- `ValidationPipeline` (ADR-022) — remote data enters without type coercion / link / unique checks.
-- `DocumentVersion` diff recording (ADR-024) — sync-received writes leave no version trail, so audit history is incomplete.
-- The submit-immutability guard — a misbehaving peer could mutate a submitted document without local refusal.
+`DocumentEngine.applyRemote(_:from:)` now owns the persistence of sync-received upserts. It runs the same `ValidationPipeline` (ADR-022), submit-immutability guard (ADR-013), and `DocumentVersion` diff recording (ADR-024) that `save(_:)` runs for local writes, while skipping the mutation-log append (the remote mutation is the record) and the optimistic-concurrency check (conflict detection is `ConflictResolver`'s job). `syncState` is forced to `.synced`.
 
-Fix: have `applyRemoteUpsert` construct a `Document` and call a new `DocumentEngine.applyRemote(_:source:)` that runs the pipeline with a "remote" flag (to skip the mutation-log append, since the record is already the mutation). This also lets `DocumentSavedEvent` fire for UI refresh without the ad-hoc `storeMutationAsApplied` shortcut.
+Also fixed an adjacent latent bug: `UpsertPayload` was a 4-field projection that dropped the document's fields on push. Both local saves and remote applies now encode/decode the full `Document` into the mutation payload.
+
+`SyncEngine.applyRemoteUpsert` is now a thin dispatcher: decode → `ConflictResolver` → `.accepted` / `.appendedAsNew` delegate to `applyRemote`; `.conflicted` marks the local row. Coverage landed in `DocumentEngineTests.swift` (`testApplyRemote*`, `testSavedMutationPayloadEncodesFullDocument`) and the new `SyncEngineTests.swift` (StubCloudAdapter, push-payload round-trip, rejected invalid remotes, conflicted-without-overwrite).
+
+**Known follow-up:** `LinkValidationStage` runs on remote writes too, which means out-of-order arrivals (child-before-parent) will be rejected rather than buffered. Assumes the CloudAdapter preserves commit order. When a real adapter lands, either require ordered delivery in the adapter contract or add a buffered-retry layer. Tracked as a candidate ADR.
 
 ### P0.3 — Persist `lastServerSequence` [S, low risk] — ADR-005
 

--- a/Docs/IMPLEMENTATION-STATUS.md
+++ b/Docs/IMPLEMENTATION-STATUS.md
@@ -94,9 +94,9 @@ The `ValidationPipeline`'s `PermissionStage` calls into `PermissionEngine.canPer
 
 - **Shipped** — Push of pending mutations, pull of remote mutations, per-DocType sync-policy lookup, `ConflictResolver` with LWW / VCM / AO.
 - **Shipped** — `CloudAdapter` protocol + `NoOpCloudAdapter`.
-- **Partial** — `lastServerSequence` is kept in-memory only. A code comment says "a production version would store this in SQLite". Every process restart will re-pull everything the adapter knows about.
-- **Partial** — Remote mutations are stored in `sync_queue` with status `applied`, never pruned. The queue grows without bound.
-- **Partial** — `applyRemoteUpsert` overwrites the local document row without running it through `DocumentEngine.save`, so the `ValidationPipeline`, `DocumentVersion` diff tracking, and submit-immutability guard do **not** fire on sync-received writes. This is a real divergence from ADR-024 ("on every save").
+- **Shipped (P0.2)** — Remote upserts are now routed through `DocumentEngine.applyRemote(_:from:)`, so `ValidationPipeline`, submit-immutability guard, and `DocumentVersion` diff recording all fire on sync-received writes. `UpsertPayload` has been replaced by encoding the full `Document` into the mutation, so push carries a round-trippable payload.
+- **Partial** — `lastServerSequence` is kept in-memory only. A code comment says "a production version would store this in SQLite". Every process restart will re-pull everything the adapter knows about. (P0.3)
+- **Partial** — Remote mutations are stored in `sync_queue` with status `applied`, never pruned. The queue grows without bound. (P0.4)
 - **Partial** — `resolveConflict(docType:documentId:chosenVersion:resolvedBy:)` appends a `resolveConflict` mutation but does not load the chosen version's payload — the document row is left as whatever the last write set it to.
 
 ### 2.7 Expression Engine — §4.7 / ADR-017

--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -46,31 +46,9 @@ public final class DocumentEngine {
     /// If the document belongs to a submittable DocType and has `docStatus == 1` (Submitted),
     /// only fields marked `allowOnSubmit: true` can be changed. (ADR-013)
     public func save(_ document: Document) throws {
-        // Validate the document's DocType if it is registered.
         if let docType = registry.get(document.docType) {
             try validator.validate(docType)
-
-            // ADR-022: Run the structured validation pipeline.
-            let validationContext = ValidationContext(
-                docType: docType,
-                userId: userId,
-                expressionEvaluator: ExpressionEvaluator(),
-                documentExists: { [weak self] linkedDocType, linkedId in
-                    guard let self else { return true }
-                    return (try? self.fetch(docType: linkedDocType, id: linkedId)) != nil
-                },
-                uniqueConflictExists: { [weak self] docTypeName, fieldKey, value, excludeId in
-                    guard let self else { return false }
-                    let docs = (try? self.list(docType: docTypeName)) ?? []
-                    return docs.contains { doc in
-                        doc.id != excludeId && doc.fields[fieldKey] == value
-                    }
-                }
-            )
-            let pipelineErrors = validationPipeline.validate(document: document, context: validationContext)
-            if !pipelineErrors.isEmpty {
-                throw DocumentEngineError.validationFailed(errors: pipelineErrors)
-            }
+            try runValidationPipeline(on: document, docType: docType)
 
             // ADR-013: Immutability enforcement for submitted documents.
             if document.docStatus == 1 && docType.isSubmittable {
@@ -81,189 +59,120 @@ public final class DocumentEngine {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
 
-        // Encode field values as the payload JSON.
         let payloadData = try encoder.encode(document.fields)
         let payloadString = String(data: payloadData, encoding: .utf8) ?? "{}"
 
-        // ADR-023: Optimistic concurrency check via modifiedAt (updatedAt) timestamp.
-        // ADR-024: Load the existing document for diff computation.
-        // If the document already exists, compare its stored updatedAt against the
-        // in-memory value. If they differ, another save occurred between load and save.
-        let existingRow = try database.read { db in
-            try Row.fetchOne(
-                db,
-                sql: "SELECT updatedAt, payload FROM documents WHERE id = ? AND doctype = ? LIMIT 1",
-                arguments: [document.id, document.docType]
-            )
-        }
-        if let row = existingRow {
-            let storedTimestamp: String? = row["updatedAt"]
+        // ADR-023: Optimistic concurrency check via updatedAt.
+        // ADR-024: Load existing fields for diff computation.
+        let existing = try loadExistingState(docType: document.docType, id: document.id)
+        if let stored = existing?.updatedAt {
             let inMemoryTimestamp = ISO8601DateFormatter().string(from: document.updatedAt)
-            if let storedTimestamp, storedTimestamp != inMemoryTimestamp {
+            if stored != inMemoryTimestamp {
                 throw DocumentEngineError.concurrencyConflict(documentId: document.id)
             }
         }
+        let oldFields = existing?.fields ?? [:]
 
-        // ADR-024: Compute field-level diff for version tracking.
-        var oldFields: [String: FieldValue] = [:]
-        if let row = existingRow {
-            let existingPayloadString: String = row["payload"] ?? "{}"
-            if let existingPayloadData = existingPayloadString.data(using: .utf8) {
-                let decoder = JSONDecoder()
-                decoder.dateDecodingStrategy = .iso8601
-                oldFields = (try? decoder.decode([String: FieldValue].self, from: existingPayloadData)) ?? [:]
-            }
-        }
-        let fieldDiffs = computeFieldDiffs(oldFields: oldFields, newFields: document.fields)
-
-        // Build the mutation record.
         let mutation = MutationRecord(
             id: UUID(),
             type: .upsertDocument,
-            payload: try encoder.encode(UpsertPayload(document: document)),
+            payload: try encoder.encode(document),
             deviceId: deviceId,
             userId: userId,
             localTimestamp: Date(),
             syncVersion: document.syncVersion,
             status: .pending
         )
-        let mutationPayloadString = String(data: mutation.payload, encoding: .utf8) ?? "{}"
-        let mutationTimestamp = ISO8601DateFormatter().string(from: mutation.localTimestamp)
         let createdAtString = ISO8601DateFormatter().string(from: document.createdAt)
-        // ADR-023: Set updatedAt to the current time on every successful save.
         let saveTimestamp = Date()
         let updatedAtString = ISO8601DateFormatter().string(from: saveTimestamp)
 
         try database.write { db in
-            // Upsert the document row.
-            try db.execute(
-                sql: """
-                    INSERT INTO documents
-                        (id, doctype, company, status, createdAt, updatedAt, syncVersion, syncState, docStatus, amendedFrom, payload)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(id) DO UPDATE SET
-                        company     = excluded.company,
-                        status      = excluded.status,
-                        updatedAt   = excluded.updatedAt,
-                        syncVersion = excluded.syncVersion,
-                        syncState   = excluded.syncState,
-                        docStatus   = excluded.docStatus,
-                        amendedFrom = excluded.amendedFrom,
-                        payload     = excluded.payload
-                    """,
-                arguments: [
-                    document.id,
-                    document.docType,
-                    document.company,
-                    document.status,
-                    createdAtString,
-                    updatedAtString,
-                    document.syncVersion,
-                    document.syncState.rawValue,
-                    document.docStatus,
-                    document.amendedFrom,
-                    payloadString
-                ]
+            try upsertDocumentRow(
+                db, document: document,
+                createdAt: createdAtString,
+                updatedAt: updatedAtString,
+                syncState: document.syncState,
+                payloadString: payloadString
             )
-
-            // Remove stale child rows that are no longer present.
-            let currentChildIds = document.children.values.flatMap { $0 }.map { $0.id }
-            if currentChildIds.isEmpty {
-                try db.execute(
-                    sql: "DELETE FROM document_children WHERE parentId = ?",
-                    arguments: [document.id]
-                )
-            } else {
-                let placeholders = currentChildIds.map { _ in "?" }.joined(separator: ",")
-                var args: [any DatabaseValueConvertible] = [document.id]
-                args.append(contentsOf: currentChildIds)
-                try db.execute(
-                    sql: "DELETE FROM document_children WHERE parentId = ? AND id NOT IN (\(placeholders))",
-                    arguments: StatementArguments(args)
-                )
-            }
-
-            // Upsert child rows.
-            for (tableName, rows) in document.children {
-                for row in rows {
-                    let rowPayload = (try? encoder.encode(row.fields))
-                        .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
-                    try db.execute(
-                        sql: """
-                            INSERT INTO document_children
-                                (id, parentId, parentDocType, tableName, rowIndex, payload)
-                            VALUES (?, ?, ?, ?, ?, ?)
-                            ON CONFLICT(id) DO UPDATE SET
-                                rowIndex = excluded.rowIndex,
-                                payload  = excluded.payload
-                            """,
-                        arguments: [
-                            row.id,
-                            document.id,
-                            document.docType,
-                            tableName,
-                            row.rowIndex,
-                            rowPayload
-                        ]
-                    )
-                }
-            }
-
-            // Atomically append the mutation record to the sync queue.
-            try db.execute(
-                sql: """
-                    INSERT INTO sync_queue
-                        (id, type, payload, deviceId, userId, localTimestamp, syncVersion, status)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                arguments: [
-                    mutation.id.uuidString,
-                    mutation.type.rawValue,
-                    mutationPayloadString,
-                    mutation.deviceId,
-                    mutation.userId,
-                    mutationTimestamp,
-                    mutation.syncVersion,
-                    mutation.status.rawValue
-                ]
+            try syncChildRows(db, document: document, encoder: encoder)
+            try appendMutation(db, mutation: mutation)
+            try recordDocumentVersion(
+                db, document: document,
+                savedAt: saveTimestamp,
+                savedBy: userId,
+                oldFields: oldFields
             )
-
-            // ADR-024: Store the document version (field-level diff) if any fields changed.
-            if !fieldDiffs.isEmpty {
-                let version = DocumentVersion(
-                    documentId: document.id,
-                    docType: document.docType,
-                    savedAt: saveTimestamp,
-                    savedBy: userId,
-                    fieldDiffs: fieldDiffs
-                )
-                let versionEncoder = JSONEncoder()
-                versionEncoder.dateEncodingStrategy = .iso8601
-                let diffsData = try versionEncoder.encode(version.fieldDiffs)
-                let diffsString = String(data: diffsData, encoding: .utf8) ?? "[]"
-                let versionSavedAt = ISO8601DateFormatter().string(from: version.savedAt)
-
-                try db.execute(
-                    sql: """
-                        INSERT INTO document_versions
-                            (id, documentId, docType, savedAt, savedBy, fieldDiffs)
-                        VALUES (?, ?, ?, ?, ?, ?)
-                        """,
-                    arguments: [
-                        version.id,
-                        version.documentId,
-                        version.docType,
-                        versionSavedAt,
-                        version.savedBy,
-                        diffsString
-                    ]
-                )
-            }
         }
 
         eventEmitter.publish(DocumentSavedEvent(
             document: document,
             docType: document.docType
+        ))
+    }
+
+    // MARK: - Apply Remote (ADR-005, P0.2)
+
+    /// Apply a remote upsert received via the sync engine. (ADR-005)
+    ///
+    /// Unlike `save(_:)`:
+    /// - **No new `MutationRecord` is appended** to `sync_queue` — the remote
+    ///   mutation is the record; the `SyncEngine` marks it applied separately.
+    /// - **No optimistic-concurrency check** — conflict detection is the
+    ///   `SyncEngine`'s responsibility via `ConflictResolver` (ADR-006).
+    /// - `syncState` is forced to `.synced` and `syncVersion` is taken from
+    ///   the remote mutation.
+    ///
+    /// The `ValidationPipeline` (ADR-022), submit-immutability guard (ADR-013),
+    /// and `DocumentVersion` diff recording (ADR-024) all fire as they do for
+    /// local saves. A `DocumentSavedEvent` is emitted on completion so UI
+    /// observers refresh.
+    public func applyRemote(_ document: Document, from mutation: MutationRecord) throws {
+        var doc = document
+        doc.syncVersion = mutation.syncVersion
+        doc.syncState = .synced
+
+        if let docType = registry.get(doc.docType) {
+            try validator.validate(docType)
+            try runValidationPipeline(on: doc, docType: docType)
+            if doc.docStatus == 1 && docType.isSubmittable {
+                try enforceSubmitImmutability(document: doc, docType: docType)
+            }
+        }
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let payloadData = try encoder.encode(doc.fields)
+        let payloadString = String(data: payloadData, encoding: .utf8) ?? "{}"
+
+        let existing = try loadExistingState(docType: doc.docType, id: doc.id)
+        let oldFields = existing?.fields ?? [:]
+
+        let createdAtString = ISO8601DateFormatter().string(from: doc.createdAt)
+        let updatedAtString = ISO8601DateFormatter().string(from: doc.updatedAt)
+        let savedAt = Date()
+        let savedBy = mutation.userId.isEmpty ? userId : mutation.userId
+
+        try database.write { db in
+            try upsertDocumentRow(
+                db, document: doc,
+                createdAt: createdAtString,
+                updatedAt: updatedAtString,
+                syncState: .synced,
+                payloadString: payloadString
+            )
+            try syncChildRows(db, document: doc, encoder: encoder)
+            try recordDocumentVersion(
+                db, document: doc,
+                savedAt: savedAt,
+                savedBy: savedBy,
+                oldFields: oldFields
+            )
+        }
+
+        eventEmitter.publish(DocumentSavedEvent(
+            document: doc,
+            docType: doc.docType
         ))
     }
 
@@ -513,6 +422,204 @@ public final class DocumentEngine {
 
     // MARK: - Private Helpers
 
+    /// Run the full ValidationPipeline for a document under its DocType. (ADR-022)
+    private func runValidationPipeline(on document: Document, docType: DocType) throws {
+        let ctx = ValidationContext(
+            docType: docType,
+            userId: userId,
+            expressionEvaluator: ExpressionEvaluator(),
+            documentExists: { [weak self] linkedDocType, linkedId in
+                guard let self else { return true }
+                return (try? self.fetch(docType: linkedDocType, id: linkedId)) != nil
+            },
+            uniqueConflictExists: { [weak self] docTypeName, fieldKey, value, excludeId in
+                guard let self else { return false }
+                let docs = (try? self.list(docType: docTypeName)) ?? []
+                return docs.contains { doc in
+                    doc.id != excludeId && doc.fields[fieldKey] == value
+                }
+            }
+        )
+        let errors = validationPipeline.validate(document: document, context: ctx)
+        if !errors.isEmpty {
+            throw DocumentEngineError.validationFailed(errors: errors)
+        }
+    }
+
+    /// Read the currently-stored `updatedAt` string and field payload for a document, if any.
+    /// Used by `save(_:)` for the optimistic-concurrency check and by both save paths for
+    /// computing `DocumentVersion` diffs.
+    private func loadExistingState(
+        docType: String,
+        id: String
+    ) throws -> (updatedAt: String?, fields: [String: FieldValue])? {
+        let row = try database.read { db in
+            try Row.fetchOne(
+                db,
+                sql: "SELECT updatedAt, payload FROM documents WHERE id = ? AND doctype = ? LIMIT 1",
+                arguments: [id, docType]
+            )
+        }
+        guard let row = row else { return nil }
+        let updatedAt: String? = row["updatedAt"]
+        var fields: [String: FieldValue] = [:]
+        let payloadString: String = row["payload"] ?? "{}"
+        if let data = payloadString.data(using: .utf8) {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            fields = (try? decoder.decode([String: FieldValue].self, from: data)) ?? [:]
+        }
+        return (updatedAt, fields)
+    }
+
+    private func upsertDocumentRow(
+        _ db: Database,
+        document: Document,
+        createdAt: String,
+        updatedAt: String,
+        syncState: SyncState,
+        payloadString: String
+    ) throws {
+        try db.execute(
+            sql: """
+                INSERT INTO documents
+                    (id, doctype, company, status, createdAt, updatedAt, syncVersion, syncState, docStatus, amendedFrom, payload)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    company     = excluded.company,
+                    status      = excluded.status,
+                    updatedAt   = excluded.updatedAt,
+                    syncVersion = excluded.syncVersion,
+                    syncState   = excluded.syncState,
+                    docStatus   = excluded.docStatus,
+                    amendedFrom = excluded.amendedFrom,
+                    payload     = excluded.payload
+                """,
+            arguments: [
+                document.id,
+                document.docType,
+                document.company,
+                document.status,
+                createdAt,
+                updatedAt,
+                document.syncVersion,
+                syncState.rawValue,
+                document.docStatus,
+                document.amendedFrom,
+                payloadString
+            ]
+        )
+    }
+
+    private func syncChildRows(
+        _ db: Database,
+        document: Document,
+        encoder: JSONEncoder
+    ) throws {
+        let currentChildIds = document.children.values.flatMap { $0 }.map { $0.id }
+        if currentChildIds.isEmpty {
+            try db.execute(
+                sql: "DELETE FROM document_children WHERE parentId = ?",
+                arguments: [document.id]
+            )
+        } else {
+            let placeholders = currentChildIds.map { _ in "?" }.joined(separator: ",")
+            var args: [any DatabaseValueConvertible] = [document.id]
+            args.append(contentsOf: currentChildIds)
+            try db.execute(
+                sql: "DELETE FROM document_children WHERE parentId = ? AND id NOT IN (\(placeholders))",
+                arguments: StatementArguments(args)
+            )
+        }
+        for (tableName, rows) in document.children {
+            for row in rows {
+                let rowPayload = (try? encoder.encode(row.fields))
+                    .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+                try db.execute(
+                    sql: """
+                        INSERT INTO document_children
+                            (id, parentId, parentDocType, tableName, rowIndex, payload)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        ON CONFLICT(id) DO UPDATE SET
+                            rowIndex = excluded.rowIndex,
+                            payload  = excluded.payload
+                        """,
+                    arguments: [
+                        row.id,
+                        document.id,
+                        document.docType,
+                        tableName,
+                        row.rowIndex,
+                        rowPayload
+                    ]
+                )
+            }
+        }
+    }
+
+    private func appendMutation(_ db: Database, mutation: MutationRecord) throws {
+        let payloadString = String(data: mutation.payload, encoding: .utf8) ?? "{}"
+        let ts = ISO8601DateFormatter().string(from: mutation.localTimestamp)
+        try db.execute(
+            sql: """
+                INSERT INTO sync_queue
+                    (id, type, payload, deviceId, userId, localTimestamp, syncVersion, status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+            arguments: [
+                mutation.id.uuidString,
+                mutation.type.rawValue,
+                payloadString,
+                mutation.deviceId,
+                mutation.userId,
+                ts,
+                mutation.syncVersion,
+                mutation.status.rawValue
+            ]
+        )
+    }
+
+    /// Compute field-level diffs and insert a `DocumentVersion` row when fields changed. (ADR-024)
+    private func recordDocumentVersion(
+        _ db: Database,
+        document: Document,
+        savedAt: Date,
+        savedBy: String,
+        oldFields: [String: FieldValue]
+    ) throws {
+        let diffs = computeFieldDiffs(oldFields: oldFields, newFields: document.fields)
+        guard !diffs.isEmpty else { return }
+
+        let version = DocumentVersion(
+            documentId: document.id,
+            docType: document.docType,
+            savedAt: savedAt,
+            savedBy: savedBy,
+            fieldDiffs: diffs
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let diffsData = try encoder.encode(version.fieldDiffs)
+        let diffsString = String(data: diffsData, encoding: .utf8) ?? "[]"
+        let savedAtStr = ISO8601DateFormatter().string(from: version.savedAt)
+
+        try db.execute(
+            sql: """
+                INSERT INTO document_versions
+                    (id, documentId, docType, savedAt, savedBy, fieldDiffs)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+            arguments: [
+                version.id,
+                version.documentId,
+                version.docType,
+                savedAtStr,
+                version.savedBy,
+                diffsString
+            ]
+        )
+    }
+
     /// ADR-013: Check that only `allowOnSubmit` fields have been modified on a submitted document.
     private func enforceSubmitImmutability(document: Document, docType: DocType) throws {
         guard let existing = try fetch(docType: document.docType, id: document.id) else {
@@ -673,19 +780,4 @@ public final class DocumentEngine {
         case concurrencyConflict(documentId: String)
     }
 
-    // MARK: - Private Types
-
-    private struct UpsertPayload: Encodable {
-        let id: String
-        let docType: String
-        let company: String
-        let status: String
-
-        init(document: Document) {
-            self.id = document.id
-            self.docType = document.docType
-            self.company = document.company
-            self.status = document.status
-        }
-    }
 }

--- a/mercantis core/SyncEngine/SyncEngine.swift
+++ b/mercantis core/SyncEngine/SyncEngine.swift
@@ -223,23 +223,23 @@ public final class SyncEngine {
     }
 
     private func applyRemoteUpsert(_ mutation: MutationRecord) throws {
-        // Decode the payload to determine the document's DocType and fields.
-        guard let payloadDict = try? JSONSerialization.jsonObject(with: mutation.payload) as? [String: Any],
-              let docTypeName = payloadDict["docType"] as? String,
-              let documentId = payloadDict["id"] as? String else {
+        // The mutation payload is a JSON-encoded Document.
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let remoteDoc = try? decoder.decode(Document.self, from: mutation.payload) else {
             try storeMutationAsApplied(mutation)
             return
         }
 
         // Look up the DocType's sync policy.
-        let syncPolicy = registry.get(docTypeName)?.syncPolicy ?? SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false)
+        let syncPolicy = registry.get(remoteDoc.docType)?.syncPolicy
+            ?? SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false)
 
         // Determine the local document's sync version (0 if not found = new document).
         let localSyncVersion: Int64 = (try? database.read { db in
-            try Row.fetchOne(db, sql: "SELECT syncVersion FROM documents WHERE id = ?", arguments: [documentId])
+            try Row.fetchOne(db, sql: "SELECT syncVersion FROM documents WHERE id = ?", arguments: [remoteDoc.id])
         })?["syncVersion"] ?? 0
 
-        // Apply conflict resolution.
         let resolution = conflictResolver.resolve(
             remoteMutation: mutation,
             localSyncVersion: localSyncVersion,
@@ -248,59 +248,17 @@ public final class SyncEngine {
 
         switch resolution {
         case .accepted:
-            // Apply the remote mutation: update all document columns and mark synced.
-            let company = payloadDict["company"] as? String ?? ""
-            let status = payloadDict["status"] as? String ?? ""
-            let createdAt = payloadDict["createdAt"] as? String ?? ISO8601DateFormatter().string(from: mutation.localTimestamp)
-            let updatedAt = payloadDict["updatedAt"] as? String ?? ISO8601DateFormatter().string(from: Date())
-            let docStatus = payloadDict["docStatus"] as? Int ?? 0
-            let amendedFrom = payloadDict["amendedFrom"] as? String
-            let payloadJSON: String
-            if let fieldsObj = payloadDict["fields"] {
-                payloadJSON = (try? String(data: JSONSerialization.data(withJSONObject: fieldsObj), encoding: .utf8)) ?? "{}"
-            } else {
-                payloadJSON = "{}"
-            }
-
-            try database.write { db in
-                try db.execute(
-                    sql: """
-                        INSERT INTO documents
-                            (id, doctype, company, status, createdAt, updatedAt, syncVersion, syncState, docStatus, amendedFrom, payload)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        ON CONFLICT(id) DO UPDATE SET
-                            company     = excluded.company,
-                            status      = excluded.status,
-                            updatedAt   = excluded.updatedAt,
-                            syncVersion = excluded.syncVersion,
-                            syncState   = excluded.syncState,
-                            docStatus   = excluded.docStatus,
-                            amendedFrom = excluded.amendedFrom,
-                            payload     = excluded.payload
-                        """,
-                    arguments: [
-                        documentId,
-                        docTypeName,
-                        company,
-                        status,
-                        createdAt,
-                        updatedAt,
-                        mutation.syncVersion,
-                        SyncState.synced.rawValue,
-                        docStatus,
-                        amendedFrom,
-                        payloadJSON
-                    ]
-                )
-            }
+            // Route through DocumentEngine so the ValidationPipeline (ADR-022),
+            // submit-immutability guard (ADR-013), and DocumentVersion diff
+            // recording (ADR-024) all fire for remote writes. (P0.2)
+            try documentEngine.applyRemote(remoteDoc, from: mutation)
             try storeMutationAsApplied(mutation)
 
-        case .conflicted(_, _):
-            // Mark the document as conflicted.
+        case .conflicted:
             try database.write { db in
                 try db.execute(
                     sql: "UPDATE documents SET syncState = ? WHERE id = ?",
-                    arguments: [SyncState.conflicted.rawValue, documentId]
+                    arguments: [SyncState.conflicted.rawValue, remoteDoc.id]
                 )
                 try db.execute(
                     sql: "UPDATE sync_queue SET status = ? WHERE id = ?",
@@ -310,6 +268,7 @@ public final class SyncEngine {
 
         case .appendedAsNew:
             // Append-Only: always insert as a new record.
+            try documentEngine.applyRemote(remoteDoc, from: mutation)
             try storeMutationAsApplied(mutation)
         }
     }

--- a/mercantis coreTests/DocumentEngineTests.swift
+++ b/mercantis coreTests/DocumentEngineTests.swift
@@ -291,6 +291,148 @@ final class DocumentEngineTests: XCTestCase {
 
     // MARK: - Amend (ADR-013)
 
+    // MARK: - Apply Remote (P0.2 — routes sync-received writes through DocumentEngine)
+
+    private func remoteMutation(for doc: Document, userId: String = "remote-user") throws -> MutationRecord {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return MutationRecord(
+            id: UUID(),
+            type: .upsertDocument,
+            payload: try encoder.encode(doc),
+            deviceId: "remote-device",
+            userId: userId,
+            localTimestamp: Date(),
+            syncVersion: doc.syncVersion,
+            status: .applied
+        )
+    }
+
+    func testApplyRemotePersistsDocumentAndForcesSyncedState() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        let doc = TestSupport.makeDocument(
+            id: "r-1",
+            fields: ["title": .string("From remote")],
+            syncVersion: 7
+        )
+        let mutation = try remoteMutation(for: doc)
+
+        try harness.engine.applyRemote(doc, from: mutation)
+
+        let fetched = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "r-1"))
+        XCTAssertEqual(fetched.fields["title"], .string("From remote"))
+        XCTAssertEqual(fetched.syncState, .synced)
+        XCTAssertEqual(fetched.syncVersion, 7)
+    }
+
+    func testApplyRemoteDoesNotAppendToSyncQueue() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        let doc = TestSupport.makeDocument(id: "r-2", fields: ["title": .string("x")])
+        let mutation = try remoteMutation(for: doc)
+
+        XCTAssertEqual(try syncQueueCount(), 0)
+        try harness.engine.applyRemote(doc, from: mutation)
+        XCTAssertEqual(try syncQueueCount(), 0,
+                       "applyRemote must not append a new mutation — the received mutation is the record")
+    }
+
+    func testApplyRemoteRecordsDocumentVersion() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        // Seed a local version so the remote apply produces a diff.
+        try harness.engine.save(TestSupport.makeDocument(id: "r-3",
+                                                         fields: ["title": .string("v1")]))
+
+        let remote = TestSupport.makeDocument(id: "r-3",
+                                              fields: ["title": .string("v2")],
+                                              syncVersion: 5)
+        let mutation = try remoteMutation(for: remote)
+        try harness.engine.applyRemote(remote, from: mutation)
+
+        XCTAssertGreaterThanOrEqual(try documentVersionCount(for: "r-3"), 2,
+                                    "one version from save, one from applyRemote")
+    }
+
+    func testApplyRemoteRunsValidationPipelineAndRejectsInvalidRemoteDocuments() throws {
+        let docType = TestSupport.makeDocType(fields: [
+            TestSupport.textField("title", required: true)
+        ])
+        try harness.registry.register(docType)
+
+        // Remote document missing the required `title`.
+        let doc = TestSupport.makeDocument(id: "r-bad", fields: [:])
+        let mutation = try remoteMutation(for: doc)
+
+        XCTAssertThrowsError(try harness.engine.applyRemote(doc, from: mutation)) { error in
+            guard case DocumentEngine.DocumentEngineError.validationFailed = error else {
+                return XCTFail("expected validationFailed, got \(error)")
+            }
+        }
+        XCTAssertNil(try harness.engine.fetch(docType: "Note", id: "r-bad"),
+                     "rejected remote writes must not touch the documents table")
+    }
+
+    func testApplyRemoteEnforcesSubmitImmutabilityOnPeerMutations() throws {
+        let docType = TestSupport.makeDocType(
+            fields: [
+                TestSupport.textField("title", required: true, allowOnSubmit: false),
+                TestSupport.textField("memo", allowOnSubmit: true)
+            ],
+            isSubmittable: true
+        )
+        try harness.registry.register(docType)
+
+        // Save and submit locally.
+        var doc = TestSupport.makeDocument(
+            id: "r-imm",
+            fields: ["title": .string("Final"), "memo": .string("")]
+        )
+        try harness.engine.save(doc)
+        doc = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "r-imm"))
+        try harness.engine.submit(&doc)
+
+        // Craft a remote mutation that mutates a non-allowOnSubmit field.
+        var tampered = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "r-imm"))
+        tampered.fields["title"] = .string("Tampered by peer")
+        let mutation = try remoteMutation(for: tampered)
+
+        XCTAssertThrowsError(try harness.engine.applyRemote(tampered, from: mutation)) { error in
+            guard case DocumentEngine.DocumentEngineError.fieldImmutableAfterSubmit = error else {
+                return XCTFail("expected fieldImmutableAfterSubmit, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Mutation payload format (regression for UpsertPayload → full Document)
+
+    func testSavedMutationPayloadEncodesFullDocument() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "payload-1",
+            fields: ["title": .string("Round-trip me")]
+        ))
+
+        let payloadString = try XCTUnwrap(harness.database.read { db in
+            try String.fetchOne(db,
+                sql: "SELECT payload FROM sync_queue WHERE type = 'upsertDocument' ORDER BY localTimestamp DESC LIMIT 1"
+            )
+        })
+        let data = try XCTUnwrap(payloadString.data(using: .utf8))
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Document.self, from: data)
+
+        XCTAssertEqual(decoded.id, "payload-1")
+        XCTAssertEqual(decoded.fields["title"], .string("Round-trip me"))
+    }
+
     func testAmendCreatesDraftWithAmendedFromReference() throws {
         let docType = TestSupport.makeDocType(
             fields: [TestSupport.textField("title", required: true)],

--- a/mercantis coreTests/SyncEngineTests.swift
+++ b/mercantis coreTests/SyncEngineTests.swift
@@ -1,0 +1,208 @@
+//
+//  SyncEngineTests.swift
+//  mercantis coreTests
+//
+//  Covers the push/receive/apply flow (ADR-005) with a stub CloudAdapter,
+//  and verifies that sync-received writes now route through DocumentEngine
+//  (P0.2 regression — no more raw SQL bypass of the ValidationPipeline).
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class SyncEngineTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+    private var adapter: StubCloudAdapter!
+    private var sync: SyncEngine!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness()
+        adapter = StubCloudAdapter()
+        sync = SyncEngine(
+            database: harness.database,
+            documentEngine: harness.engine,
+            registry: harness.registry,
+            cloudAdapter: adapter
+        )
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        harness = nil
+        adapter = nil
+        sync = nil
+    }
+
+    // MARK: - Push
+
+    func testPushForwardsPendingMutationsWithFullDocumentPayload() async throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "push-1",
+            fields: ["title": .string("Original")]
+        ))
+
+        try await sync.pushPendingMutations()
+
+        XCTAssertEqual(adapter.pushed.count, 1)
+        let pushed = try XCTUnwrap(adapter.pushed.first)
+        XCTAssertEqual(pushed.type, .upsertDocument)
+
+        // Payload must be a full Codable Document, not a 4-field UpsertPayload.
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Document.self, from: pushed.payload)
+        XCTAssertEqual(decoded.id, "push-1")
+        XCTAssertEqual(decoded.fields["title"], .string("Original"))
+    }
+
+    // MARK: - Receive & Apply (P0.2 invariant)
+
+    func testApplyRemoteMutationsPersistsRemoteDocumentThroughDocumentEngine() async throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let remoteDoc = TestSupport.makeDocument(
+            id: "remote-1",
+            fields: ["title": .string("From peer")],
+            syncVersion: 3
+        )
+        let mutation = MutationRecord(
+            id: UUID(),
+            type: .upsertDocument,
+            payload: try encoder.encode(remoteDoc),
+            deviceId: "peer-device",
+            userId: "peer-user",
+            localTimestamp: Date(),
+            syncVersion: 3,
+            status: .applied
+        )
+
+        try await sync.applyRemoteMutations([mutation])
+
+        let fetched = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "remote-1"))
+        XCTAssertEqual(fetched.fields["title"], .string("From peer"))
+        XCTAssertEqual(fetched.syncState, .synced)
+
+        // No *new* upsertDocument mutation should be queued — the received one is the record.
+        let upsertQueueCount = try harness.database.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM sync_queue WHERE type = 'upsertDocument'") ?? 0
+        }
+        XCTAssertEqual(upsertQueueCount, 1)
+    }
+
+    func testApplyRemoteMutationsRejectsInvalidRemoteDocument() async throws {
+        let docType = TestSupport.makeDocType(fields: [
+            TestSupport.textField("title", required: true)
+        ])
+        try harness.registry.register(docType)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let invalidRemote = TestSupport.makeDocument(id: "bad-1", fields: [:])
+        let mutation = MutationRecord(
+            id: UUID(),
+            type: .upsertDocument,
+            payload: try encoder.encode(invalidRemote),
+            deviceId: "peer",
+            userId: "peer-user",
+            localTimestamp: Date(),
+            syncVersion: 1,
+            status: .applied
+        )
+
+        do {
+            try await sync.applyRemoteMutations([mutation])
+            XCTFail("expected applyRemoteMutations to propagate validationFailed")
+        } catch DocumentEngine.DocumentEngineError.validationFailed {
+            // expected
+        }
+
+        XCTAssertNil(try harness.engine.fetch(docType: "Note", id: "bad-1"),
+                     "rejected remote writes must not land in the documents table")
+    }
+
+    func testConflictedRemoteMarksLocalDocumentConflictedWithoutOverwriting() async throws {
+        let docType = TestSupport.makeDocType(syncPolicy: SyncPolicy(
+            conflictResolution: .versionChecked,
+            immutableAfterSubmit: true
+        ))
+        try harness.registry.register(docType)
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "conf-1",
+            fields: ["title": .string("Local version")]
+        ))
+        // Bump the local syncVersion to 5 to simulate a version mismatch.
+        try harness.database.write { db in
+            try db.execute(sql: "UPDATE documents SET syncVersion = 5 WHERE id = ?",
+                           arguments: ["conf-1"])
+        }
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let remoteDoc = TestSupport.makeDocument(
+            id: "conf-1",
+            fields: ["title": .string("Remote version")],
+            syncVersion: 2
+        )
+        let mutation = MutationRecord(
+            id: UUID(),
+            type: .upsertDocument,
+            payload: try encoder.encode(remoteDoc),
+            deviceId: "peer",
+            userId: "peer-user",
+            localTimestamp: Date(),
+            syncVersion: 2,
+            status: .applied
+        )
+
+        try await sync.applyRemoteMutations([mutation])
+
+        let fetched = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "conf-1"))
+        XCTAssertEqual(fetched.fields["title"], .string("Local version"),
+                       "conflicted remote must not overwrite local fields")
+        XCTAssertEqual(fetched.syncState, .conflicted)
+    }
+}
+
+// MARK: - Stub CloudAdapter
+
+/// Records pushed mutations and serves pre-seeded remote mutations back on pull.
+/// Deliberately synchronous-under-the-hood (actor-lite) since tests drive it serially.
+final class StubCloudAdapter: CloudAdapter, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _pushed: [MutationRecord] = []
+    private var _remote: [RemoteMutation] = []
+
+    var pushed: [MutationRecord] {
+        lock.lock(); defer { lock.unlock() }
+        return _pushed
+    }
+
+    func enqueueRemote(_ mutations: [RemoteMutation]) {
+        lock.lock(); defer { lock.unlock() }
+        _remote.append(contentsOf: mutations)
+    }
+
+    func pushMutations(_ mutations: [MutationRecord]) async throws -> [SyncAcknowledgement] {
+        lock.lock(); defer { lock.unlock() }
+        _pushed.append(contentsOf: mutations)
+        return mutations.enumerated().map { offset, record in
+            SyncAcknowledgement(mutationId: record.id, serverSequence: Int64(_pushed.count - mutations.count + offset + 1))
+        }
+    }
+
+    func pullMutations(since version: SyncVersion) async throws -> [RemoteMutation] {
+        lock.lock(); defer { lock.unlock() }
+        return _remote.filter { $0.serverSequence > version.serverSequence }
+    }
+}


### PR DESCRIPTION
Remote upserts received via SyncEngine no longer bypass the ValidationPipeline, the submit-immutability guard, and DocumentVersion diff recording. A peer mutation is now forced through the same rules as a local save (minus the mutation-log append — the remote record IS the mutation — and the optimistic-concurrency check, which is the ConflictResolver's job).

DocumentEngine:
- Factor save() into four private helpers (runValidationPipeline, loadExistingState, upsertDocumentRow, syncChildRows, appendMutation, recordDocumentVersion) so save() and the new applyRemote() can share the persistence core without duplication.
- Add public applyRemote(_:from:): validates + immutability-checks + upserts the row with syncState forced to .synced + records a DocumentVersion diff + fires DocumentSavedEvent. No sync_queue append; no timestamp concurrency check.
- Replace the 4-field `UpsertPayload` (id/docType/company/status) with encoding the full `Document` into the mutation payload. The old projection dropped field values on push, so any real cloud adapter would have received empty documents and remote applies would have written {} into the payload column.

SyncEngine:
- applyRemoteUpsert is now a thin dispatcher: decode the Document → ConflictResolver → delegate to DocumentEngine.applyRemote for `accepted` and `appendedAsNew`; the `conflicted` case still marks the local row and sync_queue status.

Tests:
- DocumentEngineTests: five new applyRemote tests (persist + sync state, no mutation appended, DocumentVersion recorded, validation failure rejects invalid remotes, submit-immutability applies to peer mutations) and one payload-format regression test.
- New SyncEngineTests.swift with a StubCloudAdapter: push carries a full Document round-trippable payload, applyRemoteMutations routes valid remotes through DocumentEngine, invalid remotes are rejected without touching the documents table, and a VCM conflict marks the local row without overwriting its fields.

Docs: IMPLEMENTATION-STATUS §2.6 and ENHANCEMENT-PROPOSAL P0.2 marked done. Flagged the known LinkValidation ordering caveat (child-before- parent) as a follow-up that assumes adapter-preserved commit order.