### PR TITLE
Refactor DocTypeBuilderView with collapsible collections and improved UX

### DIFF
--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -1,6 +1,6 @@
 # Enhancement Proposal
 
-_Last updated: 2026-04-22_
+_Last updated: 2026-04-23_
 
 Companion document to [`IMPLEMENTATION-STATUS.md`](./IMPLEMENTATION-STATUS.md). The status doc catalogues _what is_; this doc proposes _what to do next_. Each item is labelled with effort (S/M/L), risk, and the ADR it relates to so the backlog is obvious.
 
@@ -184,6 +184,23 @@ canAccessRow(document:, userRoles:, rowExpression: String?) -> Bool
 ---
 
 ## P2 — Structural improvements
+
+### P2.0 — Metadata workspace UX refactor [S, low risk] — ADR-016 / ADR-027 ✅ shipped 2026-04-23
+
+**Rationale:** `DocTypeBuilderView`, `Modules`, and `DocTypes` shared the same workspace chrome but did not read as one coherent family. Section headers (`MercantisSectionHeading`) were visually indistinguishable from interactive chips. Repeated collections (fields, permissions, indexes) were stacked full-form cards — noisy at any count above three.
+
+**Implemented:**
+
+- `MercantisSectionHeading` redesigned as a genuine structural header: uppercase tracking text, no background fill, no border-radius. Looks like a macOS grouped-table section label, not a button.
+- `DocTypeBuilderView` restructured into three logical groups:
+  - **Basic Info** — compact card for DocType ID, name, module, title field, search fields, flags.
+  - **Schema** — segmented tab (`Fields` / `Permissions`). Each collection renders compact single-line summary rows (key · type · Required badge; role · R/W/C/D/S/A matrix). Selecting a row expands an inline editor; other rows stay collapsed. Replaces the previous stacked full-form card-per-item layout.
+  - **Configuration** — sync policy card + compact Indexes collection, clearly separated from the schema concerns above.
+- `SelectedRecordHeader` given a surface background and bottom divider, making it a proper workspace entity banner. Shared by both Modules and DocTypes detail views.
+- `moduleSelectedRecordHeader` (NavigationShell) enriched with a `subtitle` ("Custom Module" / "System Module") and a DocType count badge derived from existing `tooling.navigableDocTypes`. No invented analytics.
+- External padding removed from `RecordCollectionHostView`'s `detailHeader` slot to avoid double-padding now that `SelectedRecordHeader` carries its own padding.
+
+**Non-goals respected:** no nav model change, no design-lab promotion, no fake dashboards, no extra color, FormBuilderView left structurally intact.
 
 ### P2.1 — Turn the ExpressionEvaluator into a real AST [M, low risk] — ADR-017
 

--- a/Docs/IMPLEMENTATION-STATUS.md
+++ b/Docs/IMPLEMENTATION-STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-_Last updated: 2026-04-22_
+_Last updated: 2026-04-23_
 
 A candid map between `ARCHITECTURE.md` / the ADR set and what is actually present in `mercantis core/`. Each entry is graded:
 
@@ -153,9 +153,22 @@ The `ValidationPipeline`'s `PermissionStage` calls into `PermissionEngine.canPer
 ### 2.17 UI Shell — §5.1
 
 - **Shipped** — `NavigationShell`, `CommandBarView`, `GenericFormView`, `GenericListView`, `FormBuilderView`, `DocTypeBuilderView`, `DocTypeListView`. Three-pane FormBuilder with dedicated `WindowGroup` works.
-- **Note** — UIShell is by far the largest subsystem (~4,900 lines — `NavigationShell.swift` alone is 925, `DocTypeBuilderView.swift` 905, `FormBuilderView.swift` 786). The core engine (DocumentEngine + SyncEngine + ExpressionEngine) totals ~1,850 lines. The balance of effort is ~60% UI, ~20% engine, ~20% everything else.
+- **Note** — UIShell is by far the largest subsystem. The core engine (DocumentEngine + SyncEngine + ExpressionEngine) totals ~1,850 lines. The balance of effort is ~60% UI, ~20% engine, ~20% everything else.
 - **Partial** — `AppManifest.dashboards: [DashboardDefinition]` decodes into the manifest, but there is no `DashboardView` or dashboard rendering code. The type exists; the runtime does not.
-- **Footgun** — `DocTypeBuilderView.swift:35` does `fatalError` when the metadata DB won't open. Acceptable for a builder surface, but it's the only `fatalError` in the codebase.
+- **Footgun** — `DocTypeBuilderView.swift` does `fatalError` when the metadata DB won't open. Acceptable for a builder surface, but it's the only `fatalError` in the codebase.
+
+#### Metadata workspace UX contract (shipped 2026-04-23)
+
+`Modules`, `DocTypes`, and builder surfaces now share a consistent metadata-workspace UX language:
+
+| Component | Role |
+|---|---|
+| `MercantisSectionHeading` | Structural section headers — uppercase tracking text, no background fill. Clearly non-interactive. |
+| `SelectedRecordHeader` | Workspace entity banner — surface background, bottom divider, title + subtitle + badge row. Used in Module and DocType detail views. |
+| `RecordCollectionHostView` + `RecordWorkspaceToolbarContent` | Shared workspace chrome for all metadata record collections. |
+| `DocTypeBuilderView` | Restructured into three groups: Basic Info / Schema (tabbed: Fields, Permissions) / Configuration (Sync + Indexes). Collections use compact list rows with inline expand-on-select editors. |
+
+Both `Modules` and `DocTypes` route through `RecordCollectionHostView`, so all shared chrome improvements (toolbar, view modes, `SelectedRecordHeader`) apply to both without duplication.
 
 ### 2.18 Reporting — §5.2
 

--- a/mercantis core/UIShell/DocTypeBuilderView.swift
+++ b/mercantis core/UIShell/DocTypeBuilderView.swift
@@ -462,6 +462,16 @@ public struct DocTypeBuilderView: View {
     @State private var validationError: String?
     @State private var didLoadExisting = false
 
+    @State private var selectedSchemaTab: SchemaTab = .fields
+    @State private var selectedFieldID: UUID?
+    @State private var selectedPermissionID: UUID?
+    @State private var selectedIndexID: UUID?
+
+    private enum SchemaTab: String, CaseIterable {
+        case fields = "Fields"
+        case permissions = "Permissions"
+    }
+
     public init(docType: DocType? = nil, onSave: (() -> Void)? = nil) {
         self.existingDocType = docType
         self.onSave = onSave
@@ -481,263 +491,9 @@ public struct DocTypeBuilderView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                MercantisSectionHeading(title: "Basic Info", tone: .accent, symbol: "doc.text")
-                VStack(alignment: .leading, spacing: 14) {
-                    HStack(alignment: .top, spacing: 14) {
-                        basicInfoInputRow("DocType ID") {
-                            TextField("DocType ID", text: $docTypeId)
-                                .mercantisInput()
-                        }
-                        basicInfoInputRow("Name") {
-                            TextField("Name", text: $name)
-                                .mercantisInput()
-                        }
-                    }
-                    HStack(alignment: .top, spacing: 14) {
-                        basicInfoInputRow("Module") {
-                            Picker("Module", selection: $module) {
-                                if module.isEmpty || !tooling.moduleNames.contains(module) {
-                                    Text("Select Module").tag("")
-                                }
-                                ForEach(tooling.moduleNames, id: \.self) { moduleName in
-                                    Text(moduleName).tag(moduleName)
-                                }
-                            }
-                            .pickerStyle(.menu)
-                            .labelsHidden()
-                            .mercantisPicker()
-                        }
-                        basicInfoInputRow("Title Field") {
-                            TextField("Title Field", text: $titleField)
-                                .mercantisInput()
-                        }
-                    }
-                    basicInfoInputRow("Search Fields") {
-                        TextField("comma-separated", text: $searchFields)
-                            .mercantisInput()
-                    }
-                    HStack(spacing: 18) {
-                        Toggle("Submittable", isOn: $isSubmittable)
-                        Toggle("Child Table", isOn: $isChildTable)
-                    }
-                    .font(MercantisType.sectionHead)
-                    .foregroundStyle(MercantisTheme.textPrimary)
-                }
-                .padding(18)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(MercantisTheme.surfaceElevated)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(MercantisTheme.accentBorder.opacity(0.65), lineWidth: 1)
-                )
-
-                MercantisSectionHeading(title: "Fields", tone: .info, symbol: "list.bullet.rectangle")
-                VStack(spacing: 10) {
-                    ForEach($fields) { $field in
-                        VStack(alignment: .leading, spacing: 10) {
-                            HStack {
-                                Text(field.key.isEmpty ? "New Field" : field.key)
-                                    .font(MercantisType.compactLabel)
-                                    .foregroundStyle(MercantisTheme.textMuted)
-                                Spacer()
-                            }
-                            labeledFormRow("Key") {
-                                TextField("field_key", text: $field.key)
-                                    .mercantisInput()
-                            }
-                            labeledFormRow("Label") {
-                                TextField("Field Label", text: $field.label)
-                                    .mercantisInput()
-                            }
-                            labeledFormRow("Type") {
-                                Picker("Type", selection: $field.type) {
-                                    ForEach(FieldType.allCases, id: \.self) { type in
-                                        Text(type.rawValue).tag(type)
-                                    }
-                                }
-                                .pickerStyle(.menu)
-                                .labelsHidden()
-                                .mercantisPicker()
-                            }
-                            checkboxRow("Required", isOn: $field.required)
-                            labeledFormRow("Options") {
-                                TextField("comma-separated options", text: $field.optionsText)
-                                    .mercantisInput()
-                            }
-                            labeledFormRow("Linked DocType") {
-                                TextField("Linked DocType", text: $field.linkedDocType)
-                                    .mercantisInput()
-                            }
-                            labeledFormRow("Child DocType") {
-                                TextField("Child DocType", text: $field.childDocType)
-                                    .mercantisInput()
-                            }
-                            labeledFormRow("Visibility") {
-                                TextField("Expression", text: $field.visibilityExpression)
-                                    .mercantisInput()
-                            }
-                            labeledFormRow("Section") {
-                                TextField("Section", text: $field.section)
-                                    .mercantisInput()
-                            }
-                            labeledFormRow("Column") {
-                                Stepper(value: $field.column, in: 0...4) {
-                                    Text(field.column <= 0 ? "Automatic" : "\(field.column)")
-                                }
-                            }
-                            Button("Remove Field", role: .destructive) {
-                                removeField(with: field.id)
-                            }
-                            .buttonStyle(MercantisDestructiveButtonStyle())
-                        }
-                        .padding(12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 9)
-                                .fill(MercantisTheme.surfaceMuted)
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 9)
-                                .stroke(MercantisTheme.border.opacity(0.55), lineWidth: 1)
-                        )
-                    }
-
-                    Button("Add Field") {
-                        fields.append(EditableField())
-                    }
-                    .buttonStyle(MercantisSecondaryButtonStyle())
-                }
-                .padding(14)
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(MercantisTheme.surface)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(MercantisTheme.border.opacity(0.6), lineWidth: 1)
-                )
-
-                MercantisSectionHeading(title: "Permission Rules", tone: .warning, symbol: "person.2.badge.gearshape")
-                VStack(spacing: 10) {
-                    ForEach($permissions) { $permission in
-                        VStack(alignment: .leading, spacing: 10) {
-                            HStack {
-                                Text(permission.role.isEmpty ? "New Role Rule" : permission.role)
-                                    .font(MercantisType.compactLabel)
-                                    .foregroundStyle(MercantisTheme.textMuted)
-                                Spacer()
-                            }
-                            labeledFormRow("Role") {
-                                TextField("Role", text: $permission.role)
-                                    .mercantisInput()
-                            }
-                            checkboxRow("Read", isOn: $permission.canRead)
-                            checkboxRow("Write", isOn: $permission.canWrite)
-                            checkboxRow("Create", isOn: $permission.canCreate)
-                            checkboxRow("Delete", isOn: $permission.canDelete)
-                            checkboxRow("Submit", isOn: $permission.canSubmit)
-                            checkboxRow("Amend", isOn: $permission.canAmend)
-                            Button("Remove Permission", role: .destructive) {
-                                removePermission(with: permission.id)
-                            }
-                            .buttonStyle(MercantisDestructiveButtonStyle())
-                        }
-                        .padding(12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 9)
-                                .fill(MercantisTheme.surfaceMuted)
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 9)
-                                .stroke(MercantisTheme.border.opacity(0.55), lineWidth: 1)
-                        )
-                    }
-
-                    Button("Add Permission Rule") {
-                        permissions.append(EditablePermission())
-                    }
-                    .buttonStyle(MercantisSecondaryButtonStyle())
-                }
-                .padding(14)
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(MercantisTheme.surface)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(MercantisTheme.border.opacity(0.6), lineWidth: 1)
-                )
-
-                MercantisSectionHeading(title: "Sync Policy", tone: .muted, symbol: "arrow.triangle.2.circlepath")
-                VStack(spacing: 12) {
-                    labeledFormRow("Conflict Resolution") {
-                        Picker("Conflict Resolution", selection: $conflictResolution) {
-                            ForEach(ConflictResolution.allCases, id: \.self) { value in
-                                Text(value.rawValue).tag(value)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .labelsHidden()
-                        .mercantisPicker()
-                    }
-                    checkboxRow("Immutable After Submit", isOn: $immutableAfterSubmit)
-                }
-                .padding(14)
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(MercantisTheme.surfaceMuted)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(MercantisTheme.border.opacity(0.5), lineWidth: 1)
-                )
-
-                MercantisSectionHeading(title: "Indexes", tone: .muted, symbol: "magnifyingglass")
-                VStack(spacing: 10) {
-                    ForEach($indexes) { $index in
-                        VStack(alignment: .leading, spacing: 10) {
-                            HStack {
-                                Text(index.fieldKey.isEmpty ? "New Index" : index.fieldKey)
-                                    .font(MercantisType.compactLabel)
-                                    .foregroundStyle(MercantisTheme.textMuted)
-                                Spacer()
-                            }
-                            labeledFormRow("Field Key") {
-                                TextField("Field Key", text: $index.fieldKey)
-                                    .mercantisInput()
-                            }
-                            checkboxRow("Unique", isOn: $index.unique)
-                            Button("Remove Index", role: .destructive) {
-                                removeIndex(with: index.id)
-                            }
-                            .buttonStyle(MercantisDestructiveButtonStyle())
-                        }
-                        .padding(12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 9)
-                                .fill(MercantisTheme.surfaceMuted)
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 9)
-                                .stroke(MercantisTheme.border.opacity(0.5), lineWidth: 1)
-                        )
-                    }
-
-                    Button("Add Index") {
-                        indexes.append(EditableIndex())
-                    }
-                    .buttonStyle(MercantisSecondaryButtonStyle())
-                }
-                .padding(14)
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(MercantisTheme.surfaceMuted.opacity(0.7))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(MercantisTheme.border.opacity(0.45), lineWidth: 1)
-                )
+                basicInfoGroup
+                schemaGroup
+                configurationGroup
             }
             .padding(16)
         }
@@ -766,6 +522,496 @@ public struct DocTypeBuilderView: View {
             didLoadExisting = true
         }
     }
+
+    // MARK: - Section groups
+
+    private var basicInfoGroup: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            MercantisSectionHeading(title: "Basic Info", symbol: "doc.text")
+
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top, spacing: 14) {
+                    basicInfoInputRow("DocType ID") {
+                        TextField("DocType ID", text: $docTypeId)
+                            .mercantisInput()
+                    }
+                    basicInfoInputRow("Name") {
+                        TextField("Name", text: $name)
+                            .mercantisInput()
+                    }
+                }
+                HStack(alignment: .top, spacing: 14) {
+                    basicInfoInputRow("Module") {
+                        Picker("Module", selection: $module) {
+                            if module.isEmpty || !tooling.moduleNames.contains(module) {
+                                Text("Select Module").tag("")
+                            }
+                            ForEach(tooling.moduleNames, id: \.self) { moduleName in
+                                Text(moduleName).tag(moduleName)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .labelsHidden()
+                        .mercantisPicker()
+                    }
+                    basicInfoInputRow("Title Field") {
+                        TextField("Title Field", text: $titleField)
+                            .mercantisInput()
+                    }
+                }
+                basicInfoInputRow("Search Fields") {
+                    TextField("comma-separated", text: $searchFields)
+                        .mercantisInput()
+                }
+                HStack(spacing: 18) {
+                    Toggle("Submittable", isOn: $isSubmittable)
+                    Toggle("Child Table", isOn: $isChildTable)
+                }
+                .font(MercantisType.sectionHead)
+                .foregroundStyle(MercantisTheme.textPrimary)
+            }
+            .padding(18)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(MercantisTheme.surfaceElevated)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(MercantisTheme.border.opacity(0.6), lineWidth: 1)
+            )
+        }
+    }
+
+    private var schemaGroup: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            MercantisSectionHeading(title: "Schema", symbol: "list.bullet.rectangle", showsDivider: true)
+
+            Picker("", selection: $selectedSchemaTab) {
+                ForEach(SchemaTab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            switch selectedSchemaTab {
+            case .fields:
+                fieldsCollection
+            case .permissions:
+                permissionsCollection
+            }
+        }
+    }
+
+    private var configurationGroup: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            MercantisSectionHeading(title: "Configuration", symbol: "gearshape", showsDivider: true)
+
+            VStack(spacing: 12) {
+                labeledFormRow("Conflict Resolution") {
+                    Picker("Conflict Resolution", selection: $conflictResolution) {
+                        ForEach(ConflictResolution.allCases, id: \.self) { value in
+                            Text(value.rawValue).tag(value)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .mercantisPicker()
+                }
+                checkboxRow("Immutable After Submit", isOn: $immutableAfterSubmit)
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(MercantisTheme.surfaceMuted)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(MercantisTheme.border.opacity(0.5), lineWidth: 1)
+            )
+
+            MercantisSectionHeading(title: "Indexes", symbol: "magnifyingglass")
+
+            indexesCollection
+        }
+    }
+
+    // MARK: - Collection: Fields
+
+    private var fieldsCollection: some View {
+        VStack(spacing: 0) {
+            if fields.isEmpty {
+                collectionEmptyState(message: "No fields — add the first one", icon: "list.bullet.rectangle")
+            } else {
+                ForEach($fields) { $field in
+                    let isSelected = selectedFieldID == field.id
+                    VStack(spacing: 0) {
+                        fieldSummaryRow(field: field, isSelected: isSelected) {
+                            withAnimation(.easeInOut(duration: 0.15)) {
+                                selectedFieldID = isSelected ? nil : field.id
+                            }
+                        }
+                        if isSelected {
+                            fieldEditorBody(for: $field)
+                        }
+                    }
+                    Divider()
+                }
+            }
+
+            Button {
+                let newField = EditableField()
+                fields.append(newField)
+                selectedFieldID = newField.id
+            } label: {
+                Label("Add Field", systemImage: "plus")
+            }
+            .buttonStyle(MercantisSecondaryButtonStyle())
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(MercantisTheme.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(MercantisTheme.border.opacity(0.6), lineWidth: 1)
+        )
+    }
+
+    private func fieldSummaryRow(field: EditableField, isSelected: Bool, onTap: @escaping () -> Void) -> some View {
+        Button(action: onTap) {
+            HStack(spacing: 10) {
+                Image(systemName: fieldIcon(for: field.type))
+                    .font(.system(size: 12))
+                    .frame(width: 16)
+                    .foregroundStyle(MercantisTheme.textMuted)
+
+                Text(field.key.isEmpty ? "(no key)" : field.key)
+                    .font(MercantisType.body)
+                    .foregroundStyle(field.key.isEmpty ? MercantisTheme.textMuted : MercantisTheme.textPrimary)
+
+                Text(field.type.rawValue)
+                    .font(MercantisType.meta)
+                    .foregroundStyle(MercantisTheme.textMuted)
+
+                Spacer()
+
+                if field.required {
+                    Text("Required")
+                        .mercantisSemanticBadge(tone: .warning)
+                }
+
+                Image(systemName: isSelected ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(MercantisTheme.textMuted)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isSelected ? MercantisTheme.selectionBackground : Color.clear)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func fieldEditorBody(for field: Binding<EditableField>) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            labeledFormRow("Key") {
+                TextField("field_key", text: field.key)
+                    .mercantisInput()
+            }
+            labeledFormRow("Label") {
+                TextField("Field Label", text: field.label)
+                    .mercantisInput()
+            }
+            labeledFormRow("Type") {
+                Picker("Type", selection: field.type) {
+                    ForEach(FieldType.allCases, id: \.self) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .mercantisPicker()
+            }
+            checkboxRow("Required", isOn: field.required)
+            labeledFormRow("Options") {
+                TextField("comma-separated options", text: field.optionsText)
+                    .mercantisInput()
+            }
+            labeledFormRow("Linked DocType") {
+                TextField("Linked DocType", text: field.linkedDocType)
+                    .mercantisInput()
+            }
+            labeledFormRow("Child DocType") {
+                TextField("Child DocType", text: field.childDocType)
+                    .mercantisInput()
+            }
+            labeledFormRow("Visibility") {
+                TextField("Expression", text: field.visibilityExpression)
+                    .mercantisInput()
+            }
+            labeledFormRow("Section") {
+                TextField("Section", text: field.section)
+                    .mercantisInput()
+            }
+            labeledFormRow("Column") {
+                Stepper(value: field.column, in: 0...4) {
+                    Text(field.column.wrappedValue <= 0 ? "Automatic" : "\(field.column.wrappedValue)")
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Remove Field", role: .destructive) {
+                    removeField(with: field.wrappedValue.id)
+                    selectedFieldID = nil
+                }
+                .buttonStyle(MercantisDestructiveButtonStyle())
+            }
+        }
+        .padding(14)
+        .background(MercantisTheme.surfaceMuted)
+    }
+
+    // MARK: - Collection: Permissions
+
+    private var permissionsCollection: some View {
+        VStack(spacing: 0) {
+            if permissions.isEmpty {
+                collectionEmptyState(message: "No permission rules — add the first one", icon: "person.2.badge.gearshape")
+            } else {
+                ForEach($permissions) { $permission in
+                    let isSelected = selectedPermissionID == permission.id
+                    VStack(spacing: 0) {
+                        permissionSummaryRow(permission: permission, isSelected: isSelected) {
+                            withAnimation(.easeInOut(duration: 0.15)) {
+                                selectedPermissionID = isSelected ? nil : permission.id
+                            }
+                        }
+                        if isSelected {
+                            permissionEditorBody(for: $permission)
+                        }
+                    }
+                    Divider()
+                }
+            }
+
+            Button {
+                let newPermission = EditablePermission()
+                permissions.append(newPermission)
+                selectedPermissionID = newPermission.id
+            } label: {
+                Label("Add Permission Rule", systemImage: "plus")
+            }
+            .buttonStyle(MercantisSecondaryButtonStyle())
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(MercantisTheme.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(MercantisTheme.border.opacity(0.6), lineWidth: 1)
+        )
+    }
+
+    private func permissionSummaryRow(permission: EditablePermission, isSelected: Bool, onTap: @escaping () -> Void) -> some View {
+        Button(action: onTap) {
+            HStack(spacing: 10) {
+                Image(systemName: "person.badge.key")
+                    .font(.system(size: 12))
+                    .frame(width: 16)
+                    .foregroundStyle(MercantisTheme.textMuted)
+
+                Text(permission.role.isEmpty ? "(no role)" : permission.role)
+                    .font(MercantisType.body)
+                    .foregroundStyle(permission.role.isEmpty ? MercantisTheme.textMuted : MercantisTheme.textPrimary)
+
+                Spacer()
+
+                HStack(spacing: 4) {
+                    if permission.canRead    { permBadge("R") }
+                    if permission.canWrite   { permBadge("W") }
+                    if permission.canCreate  { permBadge("C") }
+                    if permission.canDelete  { permBadge("D") }
+                    if permission.canSubmit  { permBadge("S") }
+                    if permission.canAmend   { permBadge("A") }
+                }
+
+                Image(systemName: isSelected ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(MercantisTheme.textMuted)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isSelected ? MercantisTheme.selectionBackground : Color.clear)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func permissionEditorBody(for permission: Binding<EditablePermission>) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            labeledFormRow("Role") {
+                TextField("Role", text: permission.role)
+                    .mercantisInput()
+            }
+            checkboxRow("Read",   isOn: permission.canRead)
+            checkboxRow("Write",  isOn: permission.canWrite)
+            checkboxRow("Create", isOn: permission.canCreate)
+            checkboxRow("Delete", isOn: permission.canDelete)
+            checkboxRow("Submit", isOn: permission.canSubmit)
+            checkboxRow("Amend",  isOn: permission.canAmend)
+
+            HStack {
+                Spacer()
+                Button("Remove Permission", role: .destructive) {
+                    removePermission(with: permission.wrappedValue.id)
+                    selectedPermissionID = nil
+                }
+                .buttonStyle(MercantisDestructiveButtonStyle())
+            }
+        }
+        .padding(14)
+        .background(MercantisTheme.surfaceMuted)
+    }
+
+    // MARK: - Collection: Indexes
+
+    private var indexesCollection: some View {
+        VStack(spacing: 0) {
+            if indexes.isEmpty {
+                collectionEmptyState(message: "No indexes defined", icon: "magnifyingglass")
+            } else {
+                ForEach($indexes) { $index in
+                    let isSelected = selectedIndexID == index.id
+                    VStack(spacing: 0) {
+                        indexSummaryRow(index: index, isSelected: isSelected) {
+                            withAnimation(.easeInOut(duration: 0.15)) {
+                                selectedIndexID = isSelected ? nil : index.id
+                            }
+                        }
+                        if isSelected {
+                            indexEditorBody(for: $index)
+                        }
+                    }
+                    Divider()
+                }
+            }
+
+            Button {
+                let newIndex = EditableIndex()
+                indexes.append(newIndex)
+                selectedIndexID = newIndex.id
+            } label: {
+                Label("Add Index", systemImage: "plus")
+            }
+            .buttonStyle(MercantisSecondaryButtonStyle())
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(MercantisTheme.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(MercantisTheme.border.opacity(0.6), lineWidth: 1)
+        )
+    }
+
+    private func indexSummaryRow(index: EditableIndex, isSelected: Bool, onTap: @escaping () -> Void) -> some View {
+        Button(action: onTap) {
+            HStack(spacing: 10) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 12))
+                    .frame(width: 16)
+                    .foregroundStyle(MercantisTheme.textMuted)
+
+                Text(index.fieldKey.isEmpty ? "(no key)" : index.fieldKey)
+                    .font(MercantisType.body)
+                    .foregroundStyle(index.fieldKey.isEmpty ? MercantisTheme.textMuted : MercantisTheme.textPrimary)
+
+                Spacer()
+
+                if index.unique {
+                    Text("Unique")
+                        .mercantisSemanticBadge(tone: .info)
+                }
+
+                Image(systemName: isSelected ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(MercantisTheme.textMuted)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isSelected ? MercantisTheme.selectionBackground : Color.clear)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func indexEditorBody(for index: Binding<EditableIndex>) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            labeledFormRow("Field Key") {
+                TextField("Field Key", text: index.fieldKey)
+                    .mercantisInput()
+            }
+            checkboxRow("Unique", isOn: index.unique)
+
+            HStack {
+                Spacer()
+                Button("Remove Index", role: .destructive) {
+                    removeIndex(with: index.wrappedValue.id)
+                    selectedIndexID = nil
+                }
+                .buttonStyle(MercantisDestructiveButtonStyle())
+            }
+        }
+        .padding(14)
+        .background(MercantisTheme.surfaceMuted)
+    }
+
+    // MARK: - Shared collection helpers
+
+    private func collectionEmptyState(message: String, icon: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .foregroundStyle(MercantisTheme.textMuted)
+            Text(message)
+                .font(MercantisType.body)
+                .foregroundStyle(MercantisTheme.textMuted)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func permBadge(_ letter: String) -> some View {
+        Text(letter)
+            .font(.system(size: 9, weight: .semibold, design: .monospaced))
+            .foregroundStyle(MercantisTheme.textMuted)
+            .frame(width: 16, height: 16)
+            .background(MercantisTheme.border.opacity(0.4), in: RoundedRectangle(cornerRadius: 3))
+    }
+
+    private func fieldIcon(for type: FieldType) -> String {
+        switch type {
+        case .text, .longText:          return "character.textbox"
+        case .number, .decimal:         return "number"
+        case .currency:                 return "dollarsign"
+        case .boolean:                  return "checkmark.square"
+        case .date:                     return "calendar"
+        case .datetime:                 return "calendar.badge.clock"
+        case .email:                    return "envelope"
+        case .phone:                    return "phone"
+        case .select, .multiselect:     return "list.bullet"
+        case .link:                     return "link"
+        case .table:                    return "tablecells"
+        case .formula:                  return "function"
+        case .attachment:               return "paperclip"
+        case .status:                   return "flag"
+        }
+    }
+
+    // MARK: - Builder header
 
     private var isCreatingDocType: Bool {
         existingDocType == nil
@@ -811,6 +1057,8 @@ public struct DocTypeBuilderView: View {
         )
     }
 
+    // MARK: - Form helpers
+
     private func basicInfoInputRow<Content: View>(_ label: String, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(label)
@@ -846,6 +1094,8 @@ public struct DocTypeBuilderView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
+
+    // MARK: - Mutation helpers
 
     private func removeField(with id: UUID) {
         fields.removeAll { $0.id == id }

--- a/mercantis core/UIShell/MercantisTheme.swift
+++ b/mercantis core/UIShell/MercantisTheme.swift
@@ -246,27 +246,22 @@ struct MercantisSectionHeading: View {
     var showsDivider: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 6) {
             if showsDivider {
                 Divider()
             }
-            HStack(spacing: 6) {
+            HStack(spacing: 5) {
                 if let symbol {
                     Image(systemName: symbol)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(MercantisTheme.tint(for: tone))
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(MercantisTheme.textMuted)
                 }
-                Text(title)
-                    .font(MercantisType.compactLabel)
-                    .foregroundStyle(MercantisTheme.tint(for: tone))
+                Text(title.uppercased())
+                    .font(.system(size: 10, weight: .semibold))
+                    .tracking(0.5)
+                    .foregroundStyle(MercantisTheme.textMuted)
                     .accessibilityAddTraits(.isHeader)
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 7)
-                    .fill(MercantisTheme.fillSoft(for: tone).opacity(0.9))
-            )
         }
     }
 }

--- a/mercantis core/UIShell/NavigationShell.swift
+++ b/mercantis core/UIShell/NavigationShell.swift
@@ -744,13 +744,19 @@ public struct NavigationShell: View {
         let moduleName = stringValue(for: BuiltInDocTypes.moduleNameFieldKey, in: document) ?? document.id
         let appId = stringValue(for: "app_id", in: document)
         let isCustom = boolValue(for: "is_custom", in: document) ?? false
-        var badges = [recordCustomizationBadge(isCustom: isCustom, nonCustomLabel: "System")]
-        if let appId {
+        let docTypeCount = tooling.navigableDocTypes.filter { $0.module == moduleName }.count
+
+        var badges: [String] = [recordCustomizationBadge(isCustom: isCustom, nonCustomLabel: "System")]
+        if let appId, !appId.isEmpty, appId != "custom.local" {
             badges.append(appId)
+        }
+        if docTypeCount > 0 {
+            badges.append("\(docTypeCount) DocType\(docTypeCount == 1 ? "" : "s")")
         }
 
         return SelectedRecordHeader(
             title: moduleName,
+            subtitle: isCustom ? "Custom Module" : "System Module",
             badges: badges
         )
     }

--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -122,8 +122,6 @@ public struct RecordCollectionHostView: View {
             VStack(alignment: .leading, spacing: 10) {
                 if let selectedDocument, let detailHeader {
                     detailHeader(selectedDocument)
-                        .padding(.horizontal)
-                        .padding(.top, 12)
                 }
 
                 GenericFormView(docType: docType, document: selectedDocumentBinding)

--- a/mercantis core/UIShell/RecordWorkspaceChrome.swift
+++ b/mercantis core/UIShell/RecordWorkspaceChrome.swift
@@ -82,28 +82,26 @@ public struct SelectedRecordHeader: View {
     }
 
     public var body: some View {
-        HStack(spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
-                    .font(.headline)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(MercantisTheme.textPrimary)
 
                 if let subtitle, !subtitle.isEmpty {
                     Text(subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(.subheadline)
+                        .foregroundStyle(MercantisTheme.textMuted)
                 }
 
                 if !badges.isEmpty {
                     HStack(spacing: 6) {
                         ForEach(badges.indices, id: \.self) { index in
                             Text(badges[index])
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 2)
-                                .background(.quaternary, in: Capsule())
+                                .mercantisSemanticBadge(tone: .muted)
                         }
                     }
+                    .padding(.top, 2)
                 }
             }
 
@@ -112,6 +110,13 @@ public struct SelectedRecordHeader: View {
             if let actions {
                 actions()
             }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MercantisTheme.surface)
+        .overlay(alignment: .bottom) {
+            Divider()
         }
     }
 }


### PR DESCRIPTION
## Summary

Restructured `DocTypeBuilderView` to improve usability and visual hierarchy. Replaced full-form card layouts for fields, permissions, and indexes with collapsible summary rows that expand on demand. Reorganized content into logical section groups and introduced a tabbed schema interface.

## Key Changes

- **Collapsible Collections**: Fields, permissions, and indexes now display as compact summary rows with chevron toggles. Clicking a row expands an editor panel below it, reducing visual noise and improving scannability.

- **Tabbed Schema Interface**: Added `SchemaTab` enum with `.fields` and `.permissions` cases. Schema section now uses a segmented picker to switch between field and permission management.

- **Section Reorganization**: Refactored view body into three logical groups:
  - `basicInfoGroup`: DocType ID, name, module, title field, search fields, and toggles
  - `schemaGroup`: Tabbed interface for fields and permissions
  - `configurationGroup`: Conflict resolution, immutable flag, and indexes

- **Selection State Management**: Added `@State` properties for `selectedFieldID`, `selectedPermissionID`, and `selectedIndexID` to track which collection item is expanded.

- **Summary Row Components**: Implemented `fieldSummaryRow()`, `permissionSummaryRow()`, and `indexSummaryRow()` that display key metadata (type, role, unique flag) with visual badges and icons.

- **Empty States**: Added `collectionEmptyState()` helper to show contextual messages when collections are empty.

- **Visual Refinements**:
  - Updated `MercantisSectionHeading` to use uppercase tracking text and muted styling instead of tone-based colors
  - Added `fieldIcon()` helper to map field types to SF Symbols
  - Added `permBadge()` helper to render permission abbreviations (R/W/C/D/S/A)
  - Improved border opacity consistency across containers

- **Minor UI Updates**: Updated `SelectedRecordHeader` typography and spacing in `RecordWorkspaceChrome.swift`

## Implementation Details

- Animations use `.easeInOut(duration: 0.15)` for smooth expand/collapse transitions
- Editor bodies are conditionally rendered only when their parent row is selected
- Dividers separate collection items for visual clarity
- "Add" buttons remain at the bottom of each collection with consistent styling
- Selection state is cleared when items are removed

https://claude.ai/code/session_01MRSQNSdzbfa8vgKaF2aL3G