### PR TITLE
Unify record creation as a modal sheet (P2.0a)

### DIFF
--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -202,6 +202,29 @@ canAccessRow(document:, userRoles:, rowExpression: String?) -> Bool
 
 **Non-goals respected:** no nav model change, no design-lab promotion, no fake dashboards, no extra color, FormBuilderView left structurally intact.
 
+### P2.0a — Unify record creation as a modal sheet across all entry points [S–M, low risk] — UX ✅ shipped 2026-04-23
+
+**Rationale:** "New" currently does three different things depending on where the user invokes it.
+
+| Entry point | Today | File |
+|---|---|---|
+| DocTypes workspace → New | `.sheet` presents `DocTypeBuilderView` (correct) | `DocTypeListView.swift:31-34, 60-71` |
+| Quick Create → "New Doctype" | `router.openDocType(...)` + pre-loads `activeDocument` in the generic `docTypeDetail` path, bypassing `DocTypeListView` | `NavigationShell.swift:310-317, 364-397` |
+| Command Bar → "New <X>" | Same as Quick Create | `NavigationShell.swift:575-588` |
+| Generic workspace toolbar → New | `RecordCollectionHostView.handleCreateDocument()` switches to `.detail` view mode and inlines `GenericFormView` | `RecordCollectionHostView.swift:186-194` |
+
+So for `Doctype` specifically — and for every other DocType — whether the user sees a proper modal or an inline-draft-in-the-content-pane depends on *which door they walked through*. This is the opposite of the macOS HIG pattern (Contacts, Reminders, Calendar, Things): "+" always presents a sheet; double-clicking an existing row edits inline.
+
+**Implemented:**
+
+- `CreateRecordSheet` — new sheet primitive (`UIShell/CreateRecordSheet.swift`) that hosts `GenericFormView` on a draft document with a macOS-style header (title "New <DocType.name>", module subtitle), inline error surface, and a Cancel (⎋) / Create (⌘↩) footer. Sheet dismisses on success; the draft is selected in the list via `selectedDocumentID`.
+- `RecordCollectionHostView` — `handleCreateDocument` no longer mutates `selectedViewMode`. Instead it sets `createSheetDraft`, which drives a `.sheet(item:)` presenting `CreateRecordSheet`. `onSaveDocument` is now `(Document) throws -> Void` so both the create sheet and the detail-pane Save can surface errors inline (previous code `try?`-swallowed them). A new optional `externalCreateTrigger: Binding<Bool>?` lets the workspace react to router-driven create requests the same way the toolbar "New" does.
+- `UIShellRouter` — new `pendingCreate: String?` published property plus `requestCreate(docTypeId:module:)` / `consumePendingCreate(_:)`. `requestCreate` navigates to the workspace responsible for that DocType *before* setting the signal so the workspace is already rendered when it observes it. The `Doctype` built-in is specifically routed through `openDocTypes()` so `DocTypeListView` — not the generic `docTypeDetail` — handles the request; this closes the gap where Quick Create → "New Doctype" previously went through the generic path.
+- Quick Create (`NavigationShell.swift`) and Command Bar now call `router.requestCreate(...)` instead of `router.openDocType(...)` + `activeDocument = tooling.createDraftDocument(...)`. No more pre-loaded inline drafts — every "New X" produces the same sheet.
+- `DocTypeListView` keeps its bespoke `DocTypeBuilderView` sheet (authoring DocType metadata is not a generic-form task) but now also listens to `router.pendingCreate == BuiltInDocTypes.docType.id` via the same `externalCreateTrigger`. Its `onCreateDocument` continues to return `nil` (short-circuiting the host's generic sheet) and flip `showNewDocTypeSheet = true`, so one trigger path covers both toolbar-invoked and Quick-Create-invoked creation.
+
+**Non-goals respected:** no changes to `FormBuilderView` or the visual-builder window; editing remains inline in detail/browse; no nav model changes beyond the `pendingCreate` signal.
+
 ### P2.1 — Turn the ExpressionEvaluator into a real AST [M, low risk] — ADR-017
 
 `ARCHITECTURE.md` §4.7 already advertises this ("typed AST", static field-reference analysis, constant folding, source positions). Lift the current evaluator to a two-phase design:

--- a/mercantis core/UIShell/CreateRecordSheet.swift
+++ b/mercantis core/UIShell/CreateRecordSheet.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+/// Modal sheet used to create a new record of a given `DocType`.
+///
+/// Rendered from every entry point that can initiate "New" — workspace toolbar,
+/// Quick Create, Command Bar — so users see the same dialog regardless of origin.
+/// For DocType-level metadata authoring, `DocTypeListView` presents its own
+/// `DocTypeBuilderView` sheet; this primitive is the generic fallback.
+struct CreateRecordSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let docType: DocType
+    @Binding var draft: Document
+    let onCreate: (Document) throws -> Void
+
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(MercantisTheme.danger)
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(MercantisTheme.fillSoft(for: .danger))
+            }
+
+            GenericFormView(docType: docType, document: $draft)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            Divider()
+            footer
+        }
+        .frame(minWidth: 560, idealWidth: 720, minHeight: 480, idealHeight: 620)
+        #if os(macOS)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        #endif
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("New \(docType.name)")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(MercantisTheme.textPrimary)
+                Text(docType.module)
+                    .font(.caption)
+                    .foregroundStyle(MercantisTheme.textMuted)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .background(MercantisTheme.surface)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            Spacer()
+            Button("Cancel") { dismiss() }
+                .buttonStyle(MercantisSecondaryButtonStyle())
+                .keyboardShortcut(.cancelAction)
+            Button("Create", action: performCreate)
+                .buttonStyle(MercantisPrimaryButtonStyle())
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(MercantisTheme.surface)
+    }
+
+    private func performCreate() {
+        errorMessage = nil
+        do {
+            try onCreate(draft)
+            dismiss()
+        } catch {
+            errorMessage = (error as NSError).localizedDescription
+        }
+    }
+}

--- a/mercantis core/UIShell/DocTypeListView.swift
+++ b/mercantis core/UIShell/DocTypeListView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 public struct DocTypeListView: View {
     @EnvironmentObject private var tooling: DocTypeToolingContext
+    @EnvironmentObject private var router: UIShellRouter
     #if os(macOS)
     @Environment(\.openWindow) private var openWindow
     #endif
@@ -29,6 +30,9 @@ public struct DocTypeListView: View {
             ),
             allowsDetailEditing: false,
             onCreateDocument: {
+                // DocType metadata is authored in `DocTypeBuilderView`, not the
+                // generic form. Returning nil short-circuits the host's sheet and
+                // lets our bespoke sheet below take over.
                 showNewDocTypeSheet = true
                 return nil
             },
@@ -38,7 +42,13 @@ public struct DocTypeListView: View {
             },
             detailHeader: { document in
                 AnyView(selectedDocTypeHeader(for: document))
-            }
+            },
+            externalCreateTrigger: Binding<Bool>(
+                get: { router.pendingCreate == BuiltInDocTypes.docType.id },
+                set: { newValue in
+                    if !newValue { router.consumePendingCreate(BuiltInDocTypes.docType.id) }
+                }
+            )
         )
         .onAppear {
             tooling.reload()

--- a/mercantis core/UIShell/NavigationShell.swift
+++ b/mercantis core/UIShell/NavigationShell.swift
@@ -17,6 +17,10 @@ final class UIShellRouter: ObservableObject {
     @Published var selectedSection: NavigationSection? = .home
     @Published var selectedModule: String?
     @Published var selectedItem: WorkspaceSelection?
+    /// Signals "the user has requested to create a new record of this DocType".
+    /// Workspaces observe this and present the shared `CreateRecordSheet`.
+    /// Set by Quick Create / Command Bar; cleared by the workspace that consumes it.
+    @Published var pendingCreate: String?
 
     func openDocTypes() {
         selectedSection = .docTypes
@@ -39,6 +43,24 @@ final class UIShellRouter: ObservableObject {
         selectedSection = .dashboards
         selectedModule = module
         selectedItem = .dashboard(dashboardId)
+    }
+
+    /// Request creation of a new record of `docTypeId`. The workspace responsible for that
+    /// DocType is navigated to first so it renders before consuming the signal.
+    func requestCreate(docTypeId: String, module: String?) {
+        if docTypeId == BuiltInDocTypes.docType.id {
+            openDocTypes()
+        } else {
+            openDocType(docTypeId, module: module)
+        }
+        pendingCreate = docTypeId
+    }
+
+    /// Called by a workspace after it has presented the create sheet for `docTypeId`.
+    func consumePendingCreate(_ docTypeId: String) {
+        if pendingCreate == docTypeId {
+            pendingCreate = nil
+        }
     }
 }
 
@@ -309,8 +331,7 @@ public struct NavigationShell: View {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 170), spacing: 8)], spacing: 8) {
                 ForEach(tooling.navigableDocTypes.prefix(8), id: \.id) { docType in
                     Button("New \(docType.name)") {
-                        router.openDocType(docType.id, module: docType.module)
-                        activeDocument = tooling.createDraftDocument(for: docType)
+                        router.requestCreate(docTypeId: docType.id, module: docType.module)
                         addRecent(.docType(docType.id))
                     }
                     .buttonStyle(MercantisSecondaryButtonStyle())
@@ -372,12 +393,13 @@ public struct NavigationShell: View {
                 configuration: recordCollectionConfiguration(),
                 onCreateDocument: {
                     let draft = tooling.createDraftDocument(for: docType)
-                    activeDocument = draft
                     addRecent(.docType(docType.id))
                     return draft
                 },
                 onSaveDocument: { document in
-                    try? tooling.saveDocument(document)
+                    try tooling.saveDocument(document)
+                    activeDocument = document
+                    addRecent(.record(docTypeId: docType.id, documentId: document.id))
                 },
                 initialSelectedDocumentID: activeDocument?.id,
                 onSelectionChange: { selected in
@@ -388,12 +410,24 @@ public struct NavigationShell: View {
                 },
                 detailHeader: docType.id == BuiltInDocTypes.module.id
                     ? { document in AnyView(moduleSelectedRecordHeader(for: document)) }
-                    : nil
+                    : nil,
+                externalCreateTrigger: createTriggerBinding(for: docType.id)
             )
         } else {
             Text("DocType not found")
                 .foregroundStyle(.secondary)
         }
+    }
+
+    /// Returns a `Binding<Bool>` that is `true` when the router is requesting a new record
+    /// of `docTypeId` and resets both the binding and the router's signal when consumed.
+    private func createTriggerBinding(for docTypeId: String) -> Binding<Bool> {
+        Binding<Bool>(
+            get: { router.pendingCreate == docTypeId },
+            set: { newValue in
+                if !newValue { router.consumePendingCreate(docTypeId) }
+            }
+        )
     }
 
     @ViewBuilder
@@ -582,8 +616,7 @@ public struct NavigationShell: View {
                 keywords: [docType.name, docType.id],
                 isQuickAction: true
             ) {
-                router.openDocType(docType.id, module: docType.module)
-                activeDocument = tooling.createDraftDocument(for: docType)
+                router.requestCreate(docTypeId: docType.id, module: docType.module)
             }
         }
 

--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -11,14 +11,17 @@ public struct RecordCollectionHostView: View {
     let primaryCreateActionTitle: String
     let onCreateDocument: (() -> Document?)?
     let workspaceOverflowMenu: (() -> AnyView)?
-    let onSaveDocument: ((Document) -> Void)?
+    let onSaveDocument: ((Document) throws -> Void)?
     let initialSelectedDocumentID: String?
     let onSelectionChange: ((Document?) -> Void)?
     let detailHeader: ((Document) -> AnyView)?
+    let externalCreateTrigger: Binding<Bool>?
 
     @State private var selectedDocument: Document?
     @State private var selectedDocumentID: String?
     @State private var selectedViewMode: RecordViewMode
+    @State private var createSheetDraft: Document?
+    @State private var detailSaveError: String?
 
     public init(
         preferenceKey: String,
@@ -31,10 +34,11 @@ public struct RecordCollectionHostView: View {
         primaryCreateActionTitle: String = "New",
         onCreateDocument: (() -> Document?)? = nil,
         workspaceOverflowMenu: (() -> AnyView)? = nil,
-        onSaveDocument: ((Document) -> Void)? = nil,
+        onSaveDocument: ((Document) throws -> Void)? = nil,
         initialSelectedDocumentID: String? = nil,
         onSelectionChange: ((Document?) -> Void)? = nil,
-        detailHeader: ((Document) -> AnyView)? = nil
+        detailHeader: ((Document) -> AnyView)? = nil,
+        externalCreateTrigger: Binding<Bool>? = nil
     ) {
         self.preferenceKey = preferenceKey
         self.docType = docType
@@ -50,6 +54,7 @@ public struct RecordCollectionHostView: View {
         self.initialSelectedDocumentID = initialSelectedDocumentID
         self.onSelectionChange = onSelectionChange
         self.detailHeader = detailHeader
+        self.externalCreateTrigger = externalCreateTrigger
         _selectedViewMode = State(initialValue: configuration.defaultViewMode)
     }
 
@@ -57,9 +62,22 @@ public struct RecordCollectionHostView: View {
         contentPane
         .navigationTitle(workspaceTitle)
         .toolbar(content: workspaceToolbar)
+        .sheet(item: $createSheetDraft) { _ in
+            CreateRecordSheet(
+                docType: docType,
+                draft: Binding(
+                    get: { createSheetDraft ?? emptyDocument(for: docType.id) },
+                    set: { createSheetDraft = $0 }
+                ),
+                onCreate: performCreate(_:)
+            )
+        }
         .onAppear {
             restorePersistedViewMode()
             syncSelection(from: initialSelectedDocumentID)
+            if externalCreateTrigger?.wrappedValue == true {
+                consumeExternalCreateTrigger()
+            }
         }
         .onChange(of: selectedViewMode) { _, mode in
             persistViewMode(mode)
@@ -69,6 +87,9 @@ public struct RecordCollectionHostView: View {
         }
         .onChange(of: initialSelectedDocumentID) { _, selectedId in
             syncSelection(from: selectedId)
+        }
+        .onChange(of: externalCreateTrigger?.wrappedValue ?? false) { _, requested in
+            if requested { consumeExternalCreateTrigger() }
         }
     }
 
@@ -127,12 +148,25 @@ public struct RecordCollectionHostView: View {
                 GenericFormView(docType: docType, document: selectedDocumentBinding)
                     .disabled(!allowsDetailEditing)
 
+                if let detailSaveError {
+                    Text(detailSaveError)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(MercantisTheme.danger)
+                        .padding(10)
+                        .background(MercantisTheme.fillSoft(for: .danger), in: RoundedRectangle(cornerRadius: 8))
+                        .padding(.horizontal)
+                }
+
                 if let onSaveDocument {
                     HStack {
                         Spacer()
                         Button("Save") {
-                            if let selectedDocument {
-                                onSaveDocument(selectedDocument)
+                            guard let selectedDocument else { return }
+                            do {
+                                try onSaveDocument(selectedDocument)
+                                detailSaveError = nil
+                            } catch {
+                                detailSaveError = (error as NSError).localizedDescription
                             }
                         }
                         .buttonStyle(MercantisPrimaryButtonStyle())
@@ -184,13 +218,25 @@ public struct RecordCollectionHostView: View {
     }
 
     private func handleCreateDocument() {
+        // Parents (e.g. `DocTypeListView`) return nil from `onCreateDocument`
+        // when they present their own bespoke sheet (`DocTypeBuilderView`).
+        // In that case, `onCreateDocument` has already triggered the sheet as a
+        // side-effect and we simply short-circuit here.
         guard let draft = onCreateDocument?() else { return }
-        if configuration.supportedViewModes.contains(.detail) {
-            selectedViewMode = .detail
-        } else if configuration.supportedViewModes.contains(.browse) {
-            selectedViewMode = .browse
-        }
-        selectDocument(draft)
+        createSheetDraft = draft
+    }
+
+    private func consumeExternalCreateTrigger() {
+        guard let externalCreateTrigger else { return }
+        handleCreateDocument()
+        externalCreateTrigger.wrappedValue = false
+    }
+
+    private func performCreate(_ draft: Document) throws {
+        try onSaveDocument?(draft)
+        // Queue selection for when the fresh `documents` list re-renders with
+        // the new row; `onChange(of: documentIDs)` will pick it up and syncSelection.
+        selectedDocumentID = draft.id
     }
 
     private func syncSelection(from documentID: String?) {


### PR DESCRIPTION
Every "New" gesture — workspace toolbar, Quick Create, Command Bar — now produces the same CreateRecordSheet instead of diverging between a proper dialog (DocTypes workspace) and an inline draft in the content pane (Quick Create / generic workspaces).

- Add CreateRecordSheet: GenericFormView wrapped in a macOS-style Cancel (Esc) / Create (Cmd+Return) sheet with inline error surface.
- RecordCollectionHostView: handleCreateDocument now presents a sheet via .sheet(item:) instead of switching selectedViewMode. onSaveDocument is throwing so both the create sheet and detail-pane Save surface errors inline (previous code try?-swallowed them). New externalCreateTrigger binding lets workspaces observe router-driven create requests.
- UIShellRouter: pendingCreate signal plus requestCreate / consumePendingCreate. Routes the Doctype built-in through openDocTypes() so DocTypeListView, not the generic docTypeDetail path, handles Quick-Create-initiated Doctype creation.
- Quick Create and Command Bar call router.requestCreate(...) instead of pre-loading activeDocument inline.
- DocTypeListView: keeps its bespoke DocTypeBuilderView sheet (metadata authoring is not a generic-form task) but now also listens to router.pendingCreate via externalCreateTrigger.

Documented as P2.0a in Docs/ENHANCEMENT-PROPOSAL.md.

https://claude.ai/code/session_0173PtP6tcDZ7s8D1VdLexdf