### PR TITLE
Implement sync queue pruning (ADR-028, P0.4)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -637,3 +637,4 @@ mercantis core/
 | [ADR-025](Docs/ADR/ADR-025-automation-action-registry.md) | Automation Action Registry |
 | [ADR-026](Docs/ADR/ADR-026-three-layer-extensibility-model.md) | Three-Layer Extensibility Model |
 | [ADR-027](Docs/ADR/ADR-027-doctype-creation-strategy.md) | DocType Creation Tooling — Phased Strategy |
+| [ADR-028](Docs/ADR/ADR-028-sync-queue-pruning.md) | Sync Queue Pruning Strategy |

--- a/Docs/ADR/ADR-028-sync-queue-pruning.md
+++ b/Docs/ADR/ADR-028-sync-queue-pruning.md
@@ -1,0 +1,86 @@
+# ADR-028 — Sync Queue Pruning Strategy
+
+**Status:** Accepted
+**Date:** 2026-04-23
+
+---
+
+## Context
+
+Every persistent write in Core produces exactly one `MutationRecord` in `sync_queue` (ADR-005). Rows progress through a small status machine:
+
+- `.pending` — local write waiting to be pushed.
+- `.pushed` — local write acknowledged by the cloud adapter.
+- `.applied` — remote write that has been applied locally.
+- `.conflicted` — remote write that could not be applied because of a version/policy mismatch (ADR-006).
+
+`.pushed` and `.applied` rows accumulate indefinitely. A device that has been running for months accumulates a queue proportional to its entire write history — even though those rows no longer influence any read path:
+
+- Once the server has acknowledged a `.pushed` row, the authoritative record lives in the server's log, not ours.
+- `.applied` rows are pure local idempotency / audit memoization: `SyncEngine.storeMutationAsApplied` uses `INSERT OR REPLACE` and nothing else in Core depends on these rows being retrievable later. Re-pulling from the adapter would not reproduce them since `lastServerSequence` (ADR-005 / P0.3) is already advanced past them.
+
+`.pending` rows are load-bearing — they are the next push payload — and `.conflicted` rows are user-facing: both must be retained indefinitely regardless of age.
+
+There is no existing policy deciding when acknowledged rows are safe to delete, and unbounded queue growth is the last open P0 correctness/trust item against the mutation log.
+
+## Decision
+
+Acknowledged rows (`.pushed` and `.applied`) are deleted from `sync_queue` by `SyncEngine.pruneSyncQueue(force:)` according to a `SyncQueuePruneConfig`:
+
+```swift
+public struct SyncQueuePruneConfig: Sendable {
+    public var pushedRetention: TimeInterval   // default: 30 days
+    public var appliedRetention: TimeInterval  // default: 30 days
+    public var pruneInterval: TimeInterval     // default: 24 hours
+    public static let `default`: SyncQueuePruneConfig
+}
+```
+
+**Eligibility**
+
+- `.pushed` rows are eligible once `localTimestamp < now - pushedRetention`.
+- `.applied` rows are eligible once `localTimestamp < now - appliedRetention`.
+- `.pending` and `.conflicted` rows are never deleted by this method.
+
+**Throttling**
+
+`pruneSyncQueue(force: false)` is a no-op if a prune ran more recently than `pruneInterval`. The last prune timestamp is persisted in the `sync_state` key/value table (introduced in v4 for ADR-005 / P0.3) under the key `"syncQueuePrunedAt"`. `force: true` bypasses the throttle.
+
+**Scheduling**
+
+No new timers. `SyncEngine.pushPendingMutations()` and `SyncEngine.pullAndApplyRemoteMutations()` each call `pruneSyncQueue(force: false)` at the end of a successful run. Under the default 24-hour throttle this yields at most one prune per day per device while sync activity continues, at the natural moments when the DB write lock is already in use for sync work.
+
+**Transactional behaviour**
+
+Both DELETE statements and the watermark UPSERT run inside a single `database.write { db in … }` block. Either the rows are gone and the watermark is advanced, or nothing changed.
+
+**No `VACUUM`**
+
+The method does not call SQLite `VACUUM`. SQLite reuses freelist pages automatically, and `VACUUM` requires an exclusive database lock that would stall concurrent sync and UI reads. The phrase "vacuum budgeting" in this ADR refers to throttling the prune itself — not issuing `VACUUM` commands.
+
+**No schema change**
+
+The v4 `sync_state` key/value table is reused. No migration is required.
+
+## Consequences
+
+**Positive:**
+
+- Bounded queue growth at steady state: the acknowledged-row footprint is proportional to the retention window, not to lifetime device history.
+- `pending` and `conflicted` rows are preserved, so no in-flight work or unresolved conflict is ever lost to pruning.
+- No extra timer, actor, or scheduler needed. Pruning piggybacks on existing sync calls.
+- Configurable per deployment: a long-lived audit-sensitive deployment can set `appliedRetention = .infinity`-equivalent (a very large value) without code changes.
+
+**Negative:**
+
+- An operator-driven audit that wants the complete historical mutation stream cannot rely on `sync_queue` as the source — `document_versions` (ADR-024) is the durable field-level history, and the cloud adapter holds the server-side mutation log.
+- `.applied` rows no longer provide a local cross-check against the adapter's history after the retention window. In practice this duplicates server state and is not consulted by any Core read path.
+
+**Neutral:**
+
+- The throttle is expressed as "at most one prune per `pruneInterval`", not "guaranteed once per `pruneInterval`". On a device that stops syncing, the queue will not prune further until sync resumes. This is intentional: idle devices have no write pressure to justify waking the DB.
+- `pruneSyncQueue(force: true)` is a public method. Callers (tests, explicit maintenance flows) may run it on demand.
+
+---
+
+*See also: [ADR-005 — Sync via Mutation Log](ADR-005-sync-via-mutation-log.md), [ADR-006 — Financial & Inventory Conflict Policy](ADR-006-financial-inventory-conflict-policy.md), [ADR-024 — Document Versioning and Field-Level Diff Tracking](ADR-024-document-versioning-diff-tracking.md)*

--- a/Docs/ADR/README.md
+++ b/Docs/ADR/README.md
@@ -35,6 +35,7 @@ ADRs document significant architectural decisions: the context that motivated th
 | [ADR-025](ADR-025-automation-action-registry.md) | Automation Action Registry | Accepted |
 | [ADR-026](ADR-026-three-layer-extensibility-model.md) | Three-Layer Extensibility Model | Accepted |
 | [ADR-027](ADR-027-doctype-creation-strategy.md) | DocType Creation Tooling — Phased Strategy | Accepted |
+| [ADR-028](ADR-028-sync-queue-pruning.md) | Sync Queue Pruning Strategy | Accepted |
 
 ## How to Read an ADR
 

--- a/Docs/ARCHITECTURE-CHANGELOG.md
+++ b/Docs/ARCHITECTURE-CHANGELOG.md
@@ -75,7 +75,7 @@ The following topics were identified during this assessment but are not yet deci
 | Sharing / delegation permission mechanism | A mechanism for users to share document access with other users or roles outside the standard permission model. |
 | Dynamic Link field type semantics | How `dynamic_link` fields (where the DocType is specified by another field) are resolved and validated. |
 | Backlink query support | How to efficiently query "all documents that link to this document" without full-table scans. |
-| Sync queue pruning strategy | When and how acknowledged sync queue entries are pruned to prevent unbounded growth. |
+| ~~Sync queue pruning strategy~~ | Resolved in [ADR-028](ADR/ADR-028-sync-queue-pruning.md) (2026-04-23): acknowledged `.pushed` / `.applied` rows are deleted by `SyncEngine.pruneSyncQueue` once outside a configurable retention window, throttled by a persisted `sync_state` watermark. |
 | FieldValue type system deepening | Explicit `date`, `dateTime`, `data`, and `array` cases in `FieldValue`; type narrowing rules. |
 | Cross-document lookup in ExpressionEngine | A `lookup(docType, name, field)` function for reading a field from another document in expressions. |
 | Server-side validation via CloudAdapter | Whether the CloudAdapter protocol should include a server-side validation round-trip for documents before final commit. |

--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -56,13 +56,27 @@ Coverage in `SyncEngineTests.swift`:
 
 The `sync_state` table is a general-purpose key/value store; P0.4 (queue pruning) is expected to add additional keys (e.g., last prune watermark) here without another migration.
 
-### P0.4 — Prune `sync_queue` on acknowledgement [S, low risk] — follow-up from ARCHITECTURE-CHANGELOG
+### P0.4 — Prune `sync_queue` on acknowledgement [S, low risk] — ADR-028 *(done)*
 
-Both local `.pushed` and remote `.applied` rows accumulate forever. Add a retention policy:
-- Acknowledged local mutations older than N (default 30?) days → delete.
-- Applied remote mutations older than the highest persisted `lastServerSequence` → delete.
+`SyncEngine.pruneSyncQueue(force:)` now deletes acknowledged mutations under a `SyncQueuePruneConfig` policy:
 
-Done transactionally with vacuum budgeting (don't vacuum on every call). This is the "sync queue pruning" ADR candidate listed in ARCHITECTURE-CHANGELOG; promote it to an ADR as part of the changeset.
+- `.pushed` (local, server-acknowledged) rows older than `pushedRetention` (default 30 days) are deleted.
+- `.applied` (remote, locally-applied) rows older than `appliedRetention` (default 30 days) are deleted.
+- `.pending` and `.conflicted` rows are **never** deleted regardless of age.
+
+Throttling: a persisted `"syncQueuePrunedAt"` key in the v4 `sync_state` table skips the run if the previous prune was within `pruneInterval` (default 24 hours). `force: true` bypasses the throttle.
+
+No new timers — `pushPendingMutations()` and `pullAndApplyRemoteMutations()` call `pruneSyncQueue(force: false)` at the end of each successful run, so pruning piggybacks on existing sync activity. No `VACUUM`: the word "vacuum" in this item's original wording referred to scheduling, not the SQLite command.
+
+Decisions are captured in ADR-028. Coverage in `SyncEngineTests.swift`:
+
+- `testPruneRemovesPushedRowsOlderThanRetention`
+- `testPruneRemovesAppliedRowsOlderThanRetention`
+- `testPruneNeverDeletesPendingOrConflictedRows`
+- `testPruneThrottlesWhenCalledWithinInterval`
+- `testForcePruneBypassesThrottle`
+- `testPruneWatermarkIsPersistedToSyncState`
+- `testPushPendingMutationsOpportunisticallyPrunesOldPushedRows`
 
 ### P0.5 — Align the Permissions doc with the code (or the other way around) [S, medium risk] — ADR-011
 
@@ -379,8 +393,8 @@ A 4–6 week plan if one engineer is the target:
 
 | Week | Work |
 |---|---|
-| 1 | P0.1 test target; P0.6 event bus cleanup; P0.7 doc cleanup; P0.9 unary minus. |
-| 2 | P0.2 sync-through-engine; P0.3 persisted sequence; P0.4 queue pruning + ADR. |
+| 1 | P0.1 test target ✅; P0.6 event bus cleanup ✅; P0.7 doc cleanup ✅; P0.9 unary minus ✅. |
+| 2 | P0.2 sync-through-engine ✅; P0.3 persisted sequence ✅; P0.4 queue pruning + ADR-028 ✅. |
 | 3 | P0.5A (rewrite permissions doc) or P0.5B (implement chain); P0.8 version reader; P1.5 real validation stages. |
 | 4 | P1.1 Naming subsystem (behind a feature flag if needed). |
 | 5–6 | P1.2 + P1.3 automation runtime + extension-point resolution. |

--- a/Docs/IMPLEMENTATION-STATUS.md
+++ b/Docs/IMPLEMENTATION-STATUS.md
@@ -96,7 +96,7 @@ The `ValidationPipeline`'s `PermissionStage` calls into `PermissionEngine.canPer
 - **Shipped** — `CloudAdapter` protocol + `NoOpCloudAdapter`.
 - **Shipped (P0.2)** — Remote upserts are now routed through `DocumentEngine.applyRemote(_:from:)`, so `ValidationPipeline`, submit-immutability guard, and `DocumentVersion` diff recording all fire on sync-received writes. `UpsertPayload` has been replaced by encoding the full `Document` into the mutation, so push carries a round-trippable payload.
 - **Shipped (P0.3)** — `lastServerSequence` now persists in a v4 `sync_state` key/value table. `SyncEngine` loads the bookmark at init and writes it back on every advance, so a process restart no longer re-pulls already-applied remote mutations.
-- **Partial** — Remote mutations are stored in `sync_queue` with status `applied`, never pruned. The queue grows without bound. (P0.4)
+- **Shipped (P0.4 / ADR-028)** — `SyncEngine.pruneSyncQueue(force:)` deletes acknowledged `.pushed` and `.applied` rows once they fall outside the retention window (default 30 days each). `.pending` and `.conflicted` rows are retained indefinitely. Pruning is throttled by a persisted `syncQueuePrunedAt` watermark in `sync_state` (default 24h) and is invoked opportunistically at the end of `pushPendingMutations()` / `pullAndApplyRemoteMutations()`.
 - **Partial** — `resolveConflict(docType:documentId:chosenVersion:resolvedBy:)` appends a `resolveConflict` mutation but does not load the chosen version's payload — the document row is left as whatever the last write set it to.
 
 ### 2.7 Expression Engine — §4.7 / ADR-017

--- a/mercantis core/SyncEngine/SyncEngine.swift
+++ b/mercantis core/SyncEngine/SyncEngine.swift
@@ -12,6 +12,7 @@ import GRDB
 /// Implements the push/receive/apply/acknowledge flow. (ADR-005)
 ///
 /// Conflict resolution follows the per-DocType sync policy. (ADR-006)
+/// Queue retention is governed by `SyncQueuePruneConfig` (ADR-028).
 public final class SyncEngine {
 
     private let database: MercantisDatabase
@@ -19,6 +20,8 @@ public final class SyncEngine {
     private let registry: MetadataRegistry
     private let conflictResolver: ConflictResolver
     private let cloudAdapter: CloudAdapter
+    private let pruneConfig: SyncQueuePruneConfig
+    private let clock: () -> Date
 
     /// The last known server sequence we have received. Loaded from the
     /// `sync_state` table at init and rewritten there on every advance (P0.3).
@@ -28,17 +31,24 @@ public final class SyncEngine {
     /// Key used in the `sync_state` table to persist `lastServerSequence`.
     private static let lastServerSequenceKey = "lastServerSequence"
 
+    /// Key used in the `sync_state` table to persist the last prune watermark.
+    private static let lastPrunedAtKey = "syncQueuePrunedAt"
+
     public init(
         database: MercantisDatabase,
         documentEngine: DocumentEngine,
         registry: MetadataRegistry,
-        cloudAdapter: CloudAdapter = NoOpCloudAdapter()
+        cloudAdapter: CloudAdapter = NoOpCloudAdapter(),
+        pruneConfig: SyncQueuePruneConfig = .default,
+        clock: @escaping () -> Date = Date.init
     ) {
         self.database = database
         self.documentEngine = documentEngine
         self.registry = registry
         self.conflictResolver = ConflictResolver()
         self.cloudAdapter = cloudAdapter
+        self.pruneConfig = pruneConfig
+        self.clock = clock
         self.lastServerSequence = Self.loadPersistedLastServerSequence(from: database)
     }
 
@@ -107,6 +117,9 @@ public final class SyncEngine {
                 )
             }
         }
+
+        // Opportunistic, throttled prune of acknowledged rows. (ADR-028 / P0.4)
+        try? pruneSyncQueue(force: false)
     }
 
     // MARK: - Receive & Apply
@@ -126,6 +139,9 @@ public final class SyncEngine {
         if let maxSeq = remoteMutations.map({ $0.serverSequence }).max() {
             updateLastServerSequence(toAtLeast: maxSeq)
         }
+
+        // Opportunistic, throttled prune of acknowledged rows. (ADR-028 / P0.4)
+        try? pruneSyncQueue(force: false)
     }
 
     /// Receive and apply remote mutations from the cloud adapter.
@@ -207,6 +223,86 @@ public final class SyncEngine {
                     mutation.status.rawValue
                 ]
             )
+        }
+    }
+
+    // MARK: - Queue Pruning (ADR-028 / P0.4)
+
+    /// Delete acknowledged rows from `sync_queue` according to `pruneConfig`.
+    /// Only `.pushed` (local, server-acknowledged) and `.applied` (remote,
+    /// locally-applied) rows are eligible. `.pending` and `.conflicted` rows
+    /// are always retained.
+    ///
+    /// Callers do not need to invoke this directly — `pushPendingMutations()`
+    /// and `pullAndApplyRemoteMutations()` call it (non-forcing) at the end of
+    /// a successful run. The method no-ops when the last prune ran more
+    /// recently than `pruneConfig.pruneInterval`, unless `force` is `true`.
+    ///
+    /// - Parameter force: Bypass the throttle and run regardless of the
+    ///   persisted watermark.
+    /// - Returns: Number of rows deleted.
+    @discardableResult
+    public func pruneSyncQueue(force: Bool = false) throws -> Int {
+        let now = clock()
+
+        if !force, let last = loadLastPrunedAt(),
+           now.timeIntervalSince(last) < pruneConfig.pruneInterval {
+            return 0
+        }
+
+        let pushedCutoff = now.addingTimeInterval(-pruneConfig.pushedRetention)
+        let appliedCutoff = now.addingTimeInterval(-pruneConfig.appliedRetention)
+        let iso = ISO8601DateFormatter()
+        let pushedCutoffString = iso.string(from: pushedCutoff)
+        let appliedCutoffString = iso.string(from: appliedCutoff)
+        let watermarkString = iso.string(from: now)
+
+        return try database.write { db in
+            try db.execute(
+                sql: """
+                    DELETE FROM sync_queue
+                    WHERE status = ?
+                      AND localTimestamp < ?
+                    """,
+                arguments: [MutationStatus.pushed.rawValue, pushedCutoffString]
+            )
+            let pushedDeleted = db.changesCount
+
+            try db.execute(
+                sql: """
+                    DELETE FROM sync_queue
+                    WHERE status = ?
+                      AND localTimestamp < ?
+                    """,
+                arguments: [MutationStatus.applied.rawValue, appliedCutoffString]
+            )
+            let appliedDeleted = db.changesCount
+
+            try db.execute(
+                sql: """
+                    INSERT INTO sync_state (key, value) VALUES (?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                    """,
+                arguments: [Self.lastPrunedAtKey, watermarkString]
+            )
+
+            return pushedDeleted + appliedDeleted
+        }
+    }
+
+    private func loadLastPrunedAt() -> Date? {
+        do {
+            return try database.read { db in
+                let row = try Row.fetchOne(
+                    db,
+                    sql: "SELECT value FROM sync_state WHERE key = ?",
+                    arguments: [Self.lastPrunedAtKey]
+                )
+                guard let value: String = row?["value"] else { return nil }
+                return ISO8601DateFormatter().date(from: value)
+            }
+        } catch {
+            return nil
         }
     }
 

--- a/mercantis core/SyncEngine/SyncQueuePruneConfig.swift
+++ b/mercantis core/SyncEngine/SyncQueuePruneConfig.swift
@@ -1,0 +1,49 @@
+//
+//  SyncQueuePruneConfig.swift
+//  mercantis core
+//
+//  Retention policy for acknowledged mutations in `sync_queue`. (ADR-028 / P0.4)
+//
+
+import Foundation
+
+/// Retention policy applied by `SyncEngine.pruneSyncQueue(force:)`.
+///
+/// Only `.pushed` (local, server-acknowledged) and `.applied` (remote,
+/// locally-applied) rows are ever deleted. `.pending` rows are still awaiting
+/// push; `.conflicted` rows are awaiting user resolution — both are retained
+/// indefinitely regardless of retention windows.
+public struct SyncQueuePruneConfig: Sendable {
+
+    /// Retention window for `.pushed` rows, measured from `localTimestamp`.
+    /// Rows older than this are deleted.
+    public var pushedRetention: TimeInterval
+
+    /// Retention window for `.applied` rows, measured from `localTimestamp`.
+    /// Rows older than this are deleted.
+    public var appliedRetention: TimeInterval
+
+    /// Minimum interval between throttled prune runs. Guards against running
+    /// on every push/pull call; `pruneSyncQueue(force: true)` bypasses this.
+    public var pruneInterval: TimeInterval
+
+    public init(
+        pushedRetention: TimeInterval,
+        appliedRetention: TimeInterval,
+        pruneInterval: TimeInterval
+    ) {
+        self.pushedRetention = pushedRetention
+        self.appliedRetention = appliedRetention
+        self.pruneInterval = pruneInterval
+    }
+
+    private static let day: TimeInterval = 24 * 60 * 60
+
+    /// Default policy: 30-day retention for both `.pushed` and `.applied`
+    /// rows, with a 24-hour throttle between opportunistic prunes.
+    public static let `default` = SyncQueuePruneConfig(
+        pushedRetention: 30 * day,
+        appliedRetention: 30 * day,
+        pruneInterval: day
+    )
+}

--- a/mercantis coreTests/SyncEngineTests.swift
+++ b/mercantis coreTests/SyncEngineTests.swift
@@ -216,6 +216,186 @@ final class SyncEngineTests: XCTestCase {
         XCTAssertEqual(adapter.lastSincePulled, 0)
     }
 
+    // MARK: - Queue pruning (P0.4 / ADR-028)
+
+    private func insertRawQueueRow(
+        id: UUID = UUID(),
+        type: MutationType = .upsertDocument,
+        status: MutationStatus,
+        localTimestamp: Date
+    ) throws {
+        let iso = ISO8601DateFormatter().string(from: localTimestamp)
+        try harness.database.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO sync_queue
+                        (id, type, payload, deviceId, userId, localTimestamp, syncVersion, status)
+                    VALUES (?, ?, '{}', 'dev', 'user', ?, 0, ?)
+                    """,
+                arguments: [id.uuidString, type.rawValue, iso, status.rawValue]
+            )
+        }
+    }
+
+    private func queueCount(status: MutationStatus) throws -> Int {
+        try harness.database.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM sync_queue WHERE status = ?",
+                arguments: [status.rawValue]
+            ) ?? 0
+        }
+    }
+
+    private func makeSync(
+        config: SyncQueuePruneConfig = .default,
+        now: Date = Date()
+    ) -> SyncEngine {
+        SyncEngine(
+            database: harness.database,
+            documentEngine: harness.engine,
+            registry: harness.registry,
+            cloudAdapter: adapter,
+            pruneConfig: config,
+            clock: { now }
+        )
+    }
+
+    func testPruneRemovesPushedRowsOlderThanRetention() throws {
+        let now = Date()
+        let engine = makeSync(
+            config: SyncQueuePruneConfig(
+                pushedRetention: 30 * 86_400,
+                appliedRetention: 30 * 86_400,
+                pruneInterval: 86_400
+            ),
+            now: now
+        )
+
+        try insertRawQueueRow(status: .pushed, localTimestamp: now.addingTimeInterval(-31 * 86_400))
+        try insertRawQueueRow(status: .pushed, localTimestamp: now.addingTimeInterval(-1 * 86_400))
+
+        let deleted = try engine.pruneSyncQueue(force: true)
+
+        XCTAssertEqual(deleted, 1)
+        XCTAssertEqual(try queueCount(status: .pushed), 1, "only the fresh .pushed row should remain")
+    }
+
+    func testPruneRemovesAppliedRowsOlderThanRetention() throws {
+        let now = Date()
+        let engine = makeSync(
+            config: SyncQueuePruneConfig(
+                pushedRetention: 30 * 86_400,
+                appliedRetention: 30 * 86_400,
+                pruneInterval: 86_400
+            ),
+            now: now
+        )
+
+        try insertRawQueueRow(status: .applied, localTimestamp: now.addingTimeInterval(-60 * 86_400))
+        try insertRawQueueRow(status: .applied, localTimestamp: now.addingTimeInterval(-29 * 86_400))
+
+        let deleted = try engine.pruneSyncQueue(force: true)
+
+        XCTAssertEqual(deleted, 1)
+        XCTAssertEqual(try queueCount(status: .applied), 1)
+    }
+
+    func testPruneNeverDeletesPendingOrConflictedRows() throws {
+        let now = Date()
+        let engine = makeSync(now: now)
+
+        // Ancient pending and conflicted rows that would be deleted if the
+        // filter were age-only.
+        let ancient = now.addingTimeInterval(-365 * 86_400)
+        try insertRawQueueRow(status: .pending, localTimestamp: ancient)
+        try insertRawQueueRow(status: .conflicted, localTimestamp: ancient)
+
+        _ = try engine.pruneSyncQueue(force: true)
+
+        XCTAssertEqual(try queueCount(status: .pending), 1,
+                       "pending rows must survive prune regardless of age")
+        XCTAssertEqual(try queueCount(status: .conflicted), 1,
+                       "conflicted rows must survive prune regardless of age")
+    }
+
+    func testPruneThrottlesWhenCalledWithinInterval() throws {
+        let now = Date()
+        let engine = makeSync(
+            config: SyncQueuePruneConfig(
+                pushedRetention: 30 * 86_400,
+                appliedRetention: 30 * 86_400,
+                pruneInterval: 86_400
+            ),
+            now: now
+        )
+
+        try insertRawQueueRow(status: .pushed, localTimestamp: now.addingTimeInterval(-40 * 86_400))
+        try insertRawQueueRow(status: .pushed, localTimestamp: now.addingTimeInterval(-41 * 86_400))
+
+        let first = try engine.pruneSyncQueue(force: false)
+        XCTAssertEqual(first, 2, "first non-forced prune should run")
+
+        // Add another stale row; a second non-forced call within the interval
+        // must be throttled and not touch the queue.
+        try insertRawQueueRow(status: .pushed, localTimestamp: now.addingTimeInterval(-42 * 86_400))
+
+        let second = try engine.pruneSyncQueue(force: false)
+        XCTAssertEqual(second, 0, "second non-forced prune within pruneInterval must no-op")
+        XCTAssertEqual(try queueCount(status: .pushed), 1,
+                       "the row added after the first prune must still be there")
+    }
+
+    func testForcePruneBypassesThrottle() throws {
+        let now = Date()
+        let engine = makeSync(now: now)
+
+        try insertRawQueueRow(status: .pushed, localTimestamp: now.addingTimeInterval(-60 * 86_400))
+        _ = try engine.pruneSyncQueue(force: false)
+
+        try insertRawQueueRow(status: .pushed, localTimestamp: now.addingTimeInterval(-90 * 86_400))
+        let forced = try engine.pruneSyncQueue(force: true)
+        XCTAssertEqual(forced, 1, "force: true must bypass the pruneInterval throttle")
+    }
+
+    func testPruneWatermarkIsPersistedToSyncState() throws {
+        let now = Date()
+        let engine = makeSync(now: now)
+
+        _ = try engine.pruneSyncQueue(force: true)
+
+        let stored: String? = try harness.database.read { db in
+            try Row.fetchOne(
+                db,
+                sql: "SELECT value FROM sync_state WHERE key = ?",
+                arguments: ["syncQueuePrunedAt"]
+            )?["value"]
+        }
+        XCTAssertNotNil(stored, "prune must persist a watermark in sync_state")
+    }
+
+    func testPushPendingMutationsOpportunisticallyPrunesOldPushedRows() async throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        let now = Date()
+        let engine = makeSync(now: now)
+
+        // Ancient acknowledged row that predates the retention window.
+        try insertRawQueueRow(status: .pushed, localTimestamp: now.addingTimeInterval(-60 * 86_400))
+
+        // A fresh local save produces a pending mutation that will be pushed.
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "prune-push-1",
+            fields: ["title": .string("fresh")]
+        ))
+
+        try await engine.pushPendingMutations()
+
+        XCTAssertEqual(try queueCount(status: .pushed), 1,
+                       "the fresh push should remain; the 60-day-old .pushed row should be pruned")
+    }
+
     func testConflictedRemoteMarksLocalDocumentConflictedWithoutOverwriting() async throws {
         let docType = TestSupport.makeDocType(syncPolicy: SyncPolicy(
             conflictResolution: .versionChecked,


### PR DESCRIPTION
## Summary

Implements automatic pruning of acknowledged mutations from `sync_queue` to prevent unbounded queue growth. Adds `SyncQueuePruneConfig` policy and `SyncEngine.pruneSyncQueue(force:)` method that deletes old `.pushed` and `.applied` rows while preserving `.pending` and `.conflicted` rows indefinitely.

## Key Changes

- **New `SyncQueuePruneConfig` struct** (`SyncQueuePruneConfig.swift`):
  - Configurable retention windows for `.pushed` (default 30 days) and `.applied` (default 30 days) rows
  - Configurable throttle interval (default 24 hours) between opportunistic prunes
  - Sendable for thread-safe use

- **New `pruneSyncQueue(force:)` method** in `SyncEngine`:
  - Deletes `.pushed` rows older than `pushedRetention`
  - Deletes `.applied` rows older than `appliedRetention`
  - Never deletes `.pending` or `.conflicted` rows
  - Throttled by default; `force: true` bypasses the throttle
  - Persists last prune watermark in `sync_state` table under `"syncQueuePrunedAt"` key
  - Returns count of deleted rows

- **Opportunistic pruning integration**:
  - `pushPendingMutations()` calls `pruneSyncQueue(force: false)` at the end of successful runs
  - `pullAndApplyRemoteMutations()` calls `pruneSyncQueue(force: false)` at the end of successful runs
  - No new timers or background tasks; pruning piggybacks on existing sync activity

- **Comprehensive test coverage** (7 new tests in `SyncEngineTests.swift`):
  - Retention policy enforcement for both `.pushed` and `.applied` rows
  - Preservation of `.pending` and `.conflicted` rows regardless of age
  - Throttling behavior and force-bypass mechanism
  - Watermark persistence in `sync_state`
  - Opportunistic pruning during `pushPendingMutations()`

- **ADR-028 documentation**: Captures context, decision, and consequences of the pruning strategy

## Implementation Details

- Uses ISO8601 date formatting for timestamp comparisons in SQL
- Single transactional write block ensures atomicity: either rows are deleted and watermark advances, or nothing changes
- No `VACUUM` calls; SQLite reuses freelist pages automatically
- Reuses existing v4 `sync_state` key/value table; no schema migration required
- Configurable per deployment without code changes

https://claude.ai/code/session_018QnCV6WW5Vwp5vHeaJnmSV