### PR TITLE
Align permissions documentation with shipped flat API

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,8 +45,8 @@ Core is deliberately domain-agnostic. It knows about *documents*, *DocTypes*, *w
 │         │           │          │           │            │                   │
 │   ┌─────▼──────┐  ┌─▼──────────▼──┐  ┌────▼──────┐  ┌─▼──────────────┐   │
 │   │ Permission │  │ WorkflowEngine │  │  Typed    │  │  NamingService │   │
-│   │ Evaluator  │  │ (state machine)│  │ EventBus  │  │SchedulerService│   │
-│   │ Chain      │  └───────┬────────┘  └───────────┘  └────────────────┘   │
+│   │ Engine     │  │ (state machine)│  │ EventBus  │  │SchedulerService│   │
+│   │ (flat API) │  └───────┬────────┘  └───────────┘  └────────────────┘   │
 │   └─────┬──────┘          │                                                 │
 │         │                 │                                                 │
 │   ┌─────▼─────────────────▼──────────────────────────────────────────┐     │
@@ -123,7 +123,7 @@ Key responsibilities:
 4. `UniqueConstraintStage` — unique fields/indexes have no collisions.
 5. `ValidationRuleStage` — `ValidationRule` expressions evaluate to true.
 6. `WorkflowGuardStage` — workflow transition is allowed.
-7. `PermissionStage` — permission evaluator chain passes.
+7. `PermissionStage` — `PermissionEngine.canPerform` grants the operation.
 
 Validation failures produce structured errors with stage, field, and message. See [ADR-022](Docs/ADR/ADR-022-document-validation-pipeline.md).
 
@@ -168,23 +168,30 @@ See [ADR-002](Docs/ADR/ADR-002-sqlite-local-source-of-truth.md).
 
 **Location:** `mercantis core/Permissions/`
 
-The Permissions Engine evaluates multi-level access rules before any document operation proceeds. It is implemented as an **evaluator chain** — each permission level is a `PermissionEvaluator` protocol conformance:
+`PermissionEngine` is a small, flat class with three public methods — one per permission scope. Callers (DocumentEngine, WorkflowEngine, UI shell, the `PermissionStage` of the `ValidationPipeline`) invoke the method that matches the check they need.
 
 ```swift
-protocol PermissionEvaluator {
-    func evaluate(context: PermissionContext) -> PermissionDecision
+public final class PermissionEngine {
+    public init()
+
+    func canPerform(operation: DocumentOperation, on: DocType,
+                    userRoles: Set<String>) -> Bool
+    func canAccessField(fieldKey: String, on: DocType,
+                        userRoles: Set<String>, operation: FieldOperation) -> Bool
+    func canAccessRow(document: Document, userRoles: Set<String>,
+                      rowFilter: [String: FieldValue]?) -> Bool
 }
-enum PermissionDecision { case allowed, denied(reason: String), abstain }
 ```
 
-Chain (evaluated in order):
-1. **`AppLevelEvaluator`** — Is the user's role allowed to use this module/app at all?
-2. **`DocTypeLevelEvaluator`** — `PermissionRule` per role: read, write, create, delete, submit, amend.
-3. **`FieldLevelEvaluator`** — `FieldPermission.readRoles` / `writeRoles` per field.
-4. **`RowLevelEvaluator`** — Arbitrary condition filter (e.g. user can only see documents for their warehouse).
-5. **`WorkflowLevelEvaluator`** — `WorkflowTransition.allowedRoles` guards each transition.
+- **DocType-level** (`canPerform`) — walks `DocType.permissions` (`[PermissionRule]`), keeps rules whose role is in `userRoles`, and returns `true` on the first rule that grants the requested `DocumentOperation` (`.read` / `.write` / `.create` / `.delete` / `.submit` / `.amend`).
+- **Field-level** (`canAccessField`) — consults `FieldDefinition.permissions` (`FieldPermission?`). A field with no `permissions` block is reachable by anyone who already passed the DocType check. If the block is present, membership of `readRoles` or `writeRoles` (per `FieldOperation`) decides.
+- **Row-level** (`canAccessRow`) — `rowFilter` is a `[String: FieldValue]` dictionary of required values; the user can see the document only if every entry equals the document's value for that key. A `nil` or empty filter grants access. Row-level filters are equality-only; expression-backed filters are tracked in `Docs/ENHANCEMENT-PROPOSAL.md` P1.7.
 
-All evaluators must return `.allowed` or `.abstain`. Evaluation short-circuits on the first `.denied`. Each evaluator is independently testable. New evaluators can be appended to the chain without modifying existing ones.
+**Out of scope for `PermissionEngine` today:**
+- App / module gating — nothing in Core asks "is this role allowed to use this module at all?" A future evaluator (tracked as a P1 enhancement) may be added.
+- Workflow transition role gates — these are enforced inside `WorkflowEngine.availableTransitions` via `WorkflowTransition.allowedRoles`, not through `PermissionEngine`.
+
+ADR-011 previously described an evaluator-chain design (a `PermissionEvaluator` protocol with concrete `AppLevel` / `DocTypeLevel` / `FieldLevel` / `RowLevel` / `WorkflowLevel` evaluators, short-circuiting on the first `.denied`). That design is a future candidate, not the shipped engine. See the revised ADR-011 for why the flat surface is the current contract.
 
 See [ADR-011](Docs/ADR/ADR-011-multi-level-permission-model.md).
 
@@ -352,7 +359,7 @@ Apps declare extension points in their manifest under `extensionPoints`:
 Compiled-in code subscribes to typed events via the `EventEmitter`. Type-safe, lifecycle-managed via `SubscriptionToken`. Not available to downloaded apps.
 
 **Layer 3 — Compiled-in extension protocols:**
-First-party code provides custom `NamingStrategy`, `AutomationActionHandler`, or `PermissionEvaluator` conformances compiled into Core. Not available to downloaded apps.
+First-party code provides custom `NamingStrategy` or `AutomationActionHandler` conformances compiled into Core. Not available to downloaded apps. (A `PermissionEvaluator` protocol was proposed in earlier revisions of ADR-011 but is not shipped; the current `PermissionEngine` exposes three flat methods rather than a pluggable protocol.)
 
 At install time, `AppInstaller` resolves Layer 1 declarations into typed event subscriptions or `SchedulerService` registrations.
 
@@ -402,7 +409,7 @@ Key API points:
 - `DocumentEngine` — `save(_:)`, `delete(docType:id:)`, `fetch(docType:id:)`, `list(docType:filters:)`, `submit(_:)`, `cancel(_:)`, `amend(_:)` *(sort/limit on `list` are planned — see `Docs/ENHANCEMENT-PROPOSAL.md` P2.5)*
 - `MetadataRegistry` — `register(_:)`, `get(docType:)`, `all()`, `unregister(docType:)`
 - `MetaComposer` — `resolve(docType:)` → `ResolvedMeta`
-- `PermissionEngine` — `canPerform(operation:on:userRoles:)`, `canAccessField(fieldKey:on:userRoles:operation:)`, `canAccessRow(document:userRoles:rowFilter:)` *(evaluator chain described in ADR-011 is not yet implemented — see `Docs/IMPLEMENTATION-STATUS.md` §2.4)*
+- `PermissionEngine` — `canPerform(operation:on:userRoles:)`, `canAccessField(fieldKey:on:userRoles:operation:)`, `canAccessRow(document:userRoles:rowFilter:)`
 - `WorkflowEngine` — `availableTransitions(...)`, `transition(...)`
 - `SyncEngine` — `pushPendingMutations()`, `pullAndApplyRemoteMutations()`, `applyRemoteMutations(_:)`, `resolveConflict(docType:documentId:chosenVersion:resolvedBy:)`
 - `ExpressionEvaluator` — `evaluateBool(expression:context:)`, `evaluateFormula(expression:context:)`
@@ -561,7 +568,7 @@ mercantis core/
 ├── Notifications/
 │   └── EventEmitter.swift        # Typed event bus: subscribe<E>(_:handler:) → SubscriptionToken
 ├── Permissions/
-│   └── PermissionEngine.swift    # canPerform / canAccessField / canAccessRow (flat; evaluator chain is planned, see ADR-011)
+│   └── PermissionEngine.swift    # canPerform / canAccessField / canAccessRow
 ├── Reporting/
 │   └── ReportEngine.swift        # ReportEngine, ReportResult
 ├── Storage/

--- a/Docs/ADR/ADR-011-multi-level-permission-model.md
+++ b/Docs/ADR/ADR-011-multi-level-permission-model.md
@@ -1,7 +1,7 @@
-# ADR-011 — Multi-Level Permission Evaluation Model
+# ADR-011 — Multi-Level Permission Model
 
-**Status:** Accepted  
-**Date:** 2026-04-14
+**Status:** Accepted (revised 2026-04-23 to match shipped code; see §P0.5 in `Docs/ENHANCEMENT-PROPOSAL.md`)
+**Date:** 2026-04-14 · revised 2026-04-23
 
 ---
 
@@ -11,50 +11,73 @@ Frappe implements a 5+ level permission system: DocPerm (role-based CRUD per Doc
 
 Mercantis Core needs an equivalent permission model that runs entirely on-device and integrates cleanly with the offline-first document lifecycle.
 
+An earlier revision of this ADR described an **evaluator chain** (a `PermissionEvaluator` protocol, a `PermissionDecision` enum, and five concrete evaluators) modelled on the `ValidationPipeline` in ADR-022. That design remains the intended long-term direction. It has not been implemented. The shipped code is a flat `PermissionEngine` class with three direct methods, and this ADR has been rewritten so the document matches the code.
+
 ## Decision
 
-Mercantis Core implements permission evaluation as an **evaluator chain**. Each permission level is a `PermissionEvaluator` protocol conformance:
+Mercantis Core evaluates permissions through a single `PermissionEngine` class (`mercantis core/Permissions/PermissionEngine.swift`) with three public methods — one per permission scope:
 
 ```swift
-protocol PermissionEvaluator {
-    func evaluate(context: PermissionContext) -> PermissionDecision
-}
+public final class PermissionEngine {
+    public init()
 
-enum PermissionDecision {
-    case allowed
-    case denied(reason: String)
-    case abstain
+    // DocType-level: does any of the user's roles grant this operation?
+    public func canPerform(
+        operation: DocumentOperation,          // .read / .write / .create / .delete / .submit / .amend
+        on docType: DocType,
+        userRoles: Set<String>
+    ) -> Bool
+
+    // Field-level: per-field read/write gates via `FieldDefinition.permissions`.
+    public func canAccessField(
+        fieldKey: String,
+        on docType: DocType,
+        userRoles: Set<String>,
+        operation: FieldOperation              // .read / .write
+    ) -> Bool
+
+    // Row-level: equality filter over a `[String: FieldValue]` dictionary.
+    public func canAccessRow(
+        document: Document,
+        userRoles: Set<String>,
+        rowFilter: [String: FieldValue]?
+    ) -> Bool
 }
 ```
 
-The chain consists of five evaluators executed in order:
+### Scope-by-scope behaviour
 
-1. **`AppLevelEvaluator`** — Is the user's role allowed to use this module/app at all?
-2. **`DocTypeLevelEvaluator`** — `PermissionRule` per role: read, write, create, delete, submit, amend.
-3. **`FieldLevelEvaluator`** — `readRoles` / `writeRoles` per field definition.
-4. **`RowLevelEvaluator`** — A condition expression filter evaluated by `ExpressionEngine` (e.g. `warehouse == userDefaults.warehouse`).
-5. **`WorkflowLevelEvaluator`** — `allowedRoles` on each workflow transition.
+- **DocType-level (`canPerform`)** — Iterates `docType.permissions` (`[PermissionRule]`), keeps rules whose `role` is in `userRoles`, and returns `true` on the first matching rule whose CRUD/lifecycle flag is set for the requested `DocumentOperation`. Returns `false` if no matching rule grants the operation.
+- **Field-level (`canAccessField`)** — Looks up the field by key. If the field has no `permissions: FieldPermission?` block, access is granted (DocType-level already gated the operation). If it does, membership of `readRoles` or `writeRoles` — depending on `FieldOperation` — decides.
+- **Row-level (`canAccessRow`)** — `rowFilter` is a `[String: FieldValue]` dictionary of required field values. Access is granted when every entry equals the document's value for the same key. A `nil` or empty `rowFilter` grants access. There is no expression support at this layer today.
 
-All evaluators must return `.allowed` or `.abstain` for an operation to proceed. Evaluation short-circuits on the first `.denied` result. An evaluator that returns `.abstain` defers to the next in the chain.
+### What is **not** in the shipped engine
 
-Each evaluator is independently testable. New evaluators can be appended to the chain without modifying existing ones.
+- No `PermissionEvaluator` protocol and no `PermissionDecision` enum. The earlier revision introduced both; neither exists in code.
+- No app-level / module-level check. Nothing today asks "is the user's role allowed to use this module at all?" — the engine has no opinion on it, and callers do not consult one.
+- No workflow-level evaluator. Workflow transition role gates live inside `WorkflowEngine.availableTransitions`, not behind `PermissionEngine`. That remains appropriate — they consult `WorkflowTransition.allowedRoles` directly.
+- No row-level expression support. `canAccessRow` compares literal `FieldValue`s; it does not evaluate a predicate via `ExpressionEvaluator`. Moving to an expression-backed row filter is tracked in `Docs/ENHANCEMENT-PROPOSAL.md` P1.7.
+
+### Integration
+
+- `ValidationPipeline`'s `PermissionStage` (ADR-022) calls `PermissionEngine.canPerform` before a save proceeds. Today `PermissionStage` is narrower than that — see P1.5 for its final shape — but the integration point is the flat `canPerform` method on this engine, not a chain.
+- `DocumentEngine`, `WorkflowEngine`, and the UI shell all call into `PermissionEngine` directly. The method surface above is the complete public contract.
 
 ## Consequences
 
 **Positive:**
-- Predictable, ordered evaluation: every denial has a clear level and reason.
-- Fine-grained access control down to individual fields prevents data leakage in shared DocTypes.
-- Consistent enforcement — the same `PermissionEngine` chain is called by DocumentEngine, WorkflowEngine, and the UI Shell.
-- Each evaluator is independently testable in isolation.
+- The public API is small, synchronous, and free of side effects — easy to call from the `ValidationPipeline`, from `WorkflowEngine`, and from the UI shell.
+- Each method covers one concern (DocType / field / row), so callers pick the check they need without building a context object.
+- Rules are data, not code: `DocType.permissions` and `FieldDefinition.permissions` live on the metadata, so `MetaComposer` / `ResolvedMeta` (ADR-021) already carry everything the engine needs.
 
 **Negative:**
-- 5-level evaluation adds overhead to every document operation.
-- Complex permission configurations are difficult to debug.
-- No "sharing" mechanism (planned for a future ADR).
+- App/module-level gating and workflow-level gating are not part of this engine. Callers that need those checks must go elsewhere (workflow role checks are in `WorkflowEngine`; module gating is not enforced today).
+- Row-level filters are equality-only. Expression-based row filters are a P1 enhancement (`Docs/ENHANCEMENT-PROPOSAL.md` P1.7), not shipped.
+- The three methods are separate entry points rather than a single `evaluate(context:)` call, so a future migration to a chain-style evaluator (see below) is an API-surface change, not a purely internal refactor.
 
 **Neutral:**
-- The chain is extensible — new evaluators can be inserted without breaking existing ones.
+- A chain-style design (a `PermissionEvaluator` protocol with an ordered list of concrete evaluators, short-circuiting on the first denial) is still on the table for a future ADR. It is appropriate when app-level and row-expression evaluators land and the number of concerns outgrows three hand-written methods. Until then, the flat surface matches what callers actually need.
 
 ---
 
-*See also: [ADR-003 — Metadata-Defined DocTypes](ADR-003-metadata-defined-doctypes.md)*
+*See also: [ADR-003 — Metadata-Defined DocTypes](ADR-003-metadata-defined-doctypes.md), [ADR-022 — Document Validation Pipeline](ADR-022-document-validation-pipeline.md)*

--- a/Docs/ADR/ADR-025-automation-action-registry.md
+++ b/Docs/ADR/ADR-025-automation-action-registry.md
@@ -49,7 +49,7 @@ New action types are added by registering a new `AutomationActionHandler` confor
 - Registry must be initialised before any automation executes; startup order matters.
 
 **Neutral:**
-- The registry pattern is consistent with `NamingStrategy` (ADR-014) and `PermissionEvaluator` (ADR-011).
+- The registry pattern is consistent with `NamingStrategy` (ADR-014). (An analogous `PermissionEvaluator` pattern was proposed for ADR-011 but is not shipped; `PermissionEngine` is currently a flat class, not a registry of protocol conformances.)
 
 ---
 

--- a/Docs/ADR/ADR-026-three-layer-extensibility-model.md
+++ b/Docs/ADR/ADR-026-three-layer-extensibility-model.md
@@ -51,7 +51,8 @@ The deepest layer. First-party code compiled into Core can provide custom confor
 - `NamingStrategy` — Custom document naming logic (ADR-014).
 - `AutomationActionHandler` — Custom automation action types (ADR-025).
 - `ConflictResolutionPolicy` — Custom sync conflict resolution strategies (ADR-006).
-- `PermissionEvaluator` — Additional permission levels (ADR-011).
+
+An earlier revision of this document also listed a `PermissionEvaluator` protocol as a Layer 3 extension point. That protocol is not shipped — `PermissionEngine` is a flat class today (see revised ADR-011). Reopening Layer 3 to permission evaluators would require a real chain implementation first.
 
 These conformances are registered at startup and are indistinguishable from built-in implementations at runtime. They are not available to downloaded apps.
 

--- a/Docs/ARCHITECTURE-CHANGELOG.md
+++ b/Docs/ARCHITECTURE-CHANGELOG.md
@@ -1,5 +1,31 @@
 # Mercantis Core — Architecture Changelog
 
+## Revision: 2026-04-23 (Permissions doc alignment — P0.5 option A)
+
+This revision realigns the Permissions documentation with the shipped `PermissionEngine` code. The 2026-04-14 revision introduced an evaluator-chain design (`PermissionEvaluator` protocol, `PermissionDecision` enum, five concrete evaluators) that was never implemented; the code has always been a flat class with three public methods. `Docs/ENHANCEMENT-PROPOSAL.md` P0.5 picked option A (fix the doc) over option B (implement the chain) as the near-term resolution. The chain remains a candidate direction for a future revision alongside P1.7 (row-level expressions) and a yet-to-be-defined app-/module-level gate.
+
+### Updated Files
+
+| Section | Summary of Change |
+|---|---|
+| `ARCHITECTURE.md` §3 Architecture Diagram | Renamed the "Permission Evaluator Chain" block to "Permission Engine (flat API)". |
+| `ARCHITECTURE.md` §4.2 Document Engine | `PermissionStage` now described as calling `PermissionEngine.canPerform`, not an evaluator chain. |
+| `ARCHITECTURE.md` §4.4 Permissions Engine | Rewritten to describe the three shipped methods (`canPerform`, `canAccessField`, `canAccessRow`) and what is explicitly out of scope (app/module gate, workflow-level evaluator, row-level expression predicates). |
+| `ARCHITECTURE.md` §4.12 Extension Points | Removed `PermissionEvaluator` from the Layer 3 list. Added a brief note that the chain is not shipped. |
+| `ARCHITECTURE.md` §4.15 Public API Surface | Removed the "evaluator chain is not yet implemented" caveat on `PermissionEngine`. |
+| `ARCHITECTURE.md` §7 Directory Structure | Removed the "flat; evaluator chain is planned" qualifier on `PermissionEngine.swift`. |
+| `Docs/ADR/ADR-011-multi-level-permission-model.md` | Rewritten to describe the shipped flat surface. Kept the context/positioning; removed the `PermissionEvaluator` protocol / `PermissionDecision` enum / five-evaluator chain definitions. Added explicit out-of-scope notes and a forward pointer to the chain as a possible future direction. |
+| `Docs/ADR/ADR-025-automation-action-registry.md` | Reframed the "consistent with `PermissionEvaluator`" line — the registry pattern is consistent with `NamingStrategy`; `PermissionEvaluator` is not shipped. |
+| `Docs/ADR/ADR-026-three-layer-extensibility-model.md` | Removed `PermissionEvaluator` from the Layer 3 protocol list with a note that reintroducing it requires a chain implementation first. |
+| `Docs/IMPLEMENTATION-STATUS.md` §1, §2.4, §5 | `Permissions/` row is no longer "shape doesn't match"; §2.4 now grades `PermissionEngine` against the revised doc (Shipped / Partial / out-of-scope) rather than describing a documentation gap; §5 entry updated to note P0.5 closed the drift. |
+| `Docs/ENHANCEMENT-PROPOSAL.md` P0.5 | Marked done (option A). Sequencing table updated. |
+
+### Not changed
+
+No Swift source files were modified; this is purely a documentation change. `PermissionEngine.swift` and the `PermissionStage` integration already matched the new description.
+
+---
+
 ## Revision: 2026-04-14
 
 This revision reflects an architecture assessment comparing Mercantis Core against Frappe v16. The goal was to identify areas where the architecture documentation needed to be made more explicit and to ensure the ADR set accurately reflects the intended foundation. Mercantis's original direction (offline-first, pure client-side, declarative-only plugins, metadata-driven) is preserved.

--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -78,13 +78,21 @@ Decisions are captured in ADR-028. Coverage in `SyncEngineTests.swift`:
 - `testPruneWatermarkIsPersistedToSyncState`
 - `testPushPendingMutationsOpportunisticallyPrunesOldPushedRows`
 
-### P0.5 — Align the Permissions doc with the code (or the other way around) [S, medium risk] — ADR-011
+### P0.5 — Align the Permissions doc with the code [S, medium risk] — ADR-011 *(done — option A, 2026-04-23)*
 
-Either:
-- **A. Fix the doc.** Rewrite §4.4 and ADR-011 to describe the flat `canPerform` / `canAccessField` / `canAccessRow` that actually exists, and remove references to `PermissionEvaluator`, `PermissionDecision`, and the evaluator chain.
-- **B. Implement the chain.** Introduce the `PermissionEvaluator` protocol, five concrete evaluators, and a chain runner. Replace `PermissionStage` in the pipeline to call the chain.
+Option A shipped: §4.4 and ADR-011 now describe the flat `PermissionEngine` — `canPerform(operation:on:userRoles:)`, `canAccessField(fieldKey:on:userRoles:operation:)`, `canAccessRow(document:userRoles:rowFilter:)` — that actually exists, and references to `PermissionEvaluator`, `PermissionDecision`, and the evaluator chain have been removed (or reframed as "not shipped" historical notes) from:
 
-B is the stated direction (and matches how `ValidationPipeline` is already structured), but it's a larger change. A unblocks P0.2 and P0.8 immediately. **Recommendation: do A now, schedule B.**
+- `ARCHITECTURE.md` §3 (architecture diagram), §4.2 (ValidationPipeline `PermissionStage`), §4.4 (Permissions Engine — fully rewritten), §4.12 (Layer 3 extension protocols), §4.15 (Public API Surface), §7 (directory tree).
+- `Docs/ADR/ADR-011-multi-level-permission-model.md` — rewritten to describe the shipped flat surface and its out-of-scope checks (app / module gating; workflow-level role checks remain inside `WorkflowEngine`).
+- `Docs/ADR/ADR-025-automation-action-registry.md` — the "consistent with `PermissionEvaluator`" line reframed.
+- `Docs/ADR/ADR-026-three-layer-extensibility-model.md` — removed `PermissionEvaluator` from the Layer 3 list; added a note that reintroducing it requires implementing the chain first.
+- `Docs/IMPLEMENTATION-STATUS.md` §1, §2.4, §5 — removed "shape doesn't match" entries; §2.4 now reads as a regular Shipped / Partial breakdown.
+
+Option B (implement the chain — introduce a `PermissionEvaluator` protocol, five concrete evaluators, and a chain runner; replace `PermissionStage` to call the chain) remains the stated long-term direction, scheduled alongside:
+- **P1.7** — row-level expression support (`canAccessRow` predicate via `ExpressionEvaluator`).
+- **App-/module-level gating** — not yet in the engine; a future ADR.
+
+Until then, §4.4 / ADR-011 accurately document what ships.
 
 ### P0.6 — Resolve `EventBus` / `EventEmitter` duality [S, low risk] — ADR-020
 
@@ -395,7 +403,7 @@ A 4–6 week plan if one engineer is the target:
 |---|---|
 | 1 | P0.1 test target ✅; P0.6 event bus cleanup ✅; P0.7 doc cleanup ✅; P0.9 unary minus ✅. |
 | 2 | P0.2 sync-through-engine ✅; P0.3 persisted sequence ✅; P0.4 queue pruning + ADR-028 ✅. |
-| 3 | P0.5A (rewrite permissions doc) or P0.5B (implement chain); P0.8 version reader; P1.5 real validation stages. |
+| 3 | P0.5A (rewrite permissions doc) ✅; P0.5B (implement chain) deferred; P0.8 version reader; P1.5 real validation stages. |
 | 4 | P1.1 Naming subsystem (behind a feature flag if needed). |
 | 5–6 | P1.2 + P1.3 automation runtime + extension-point resolution. |
 

--- a/Docs/IMPLEMENTATION-STATUS.md
+++ b/Docs/IMPLEMENTATION-STATUS.md
@@ -31,7 +31,7 @@ The goal is not to assign blame; it's to give future contributors an honest star
 | `Metadata/` | Yes | Matches §4.1. |
 | `Naming/` | **No** | §4.11 / ADR-014 describe `NamingStrategy`, `UUIDv7Strategy`, `NamingSeriesStrategy`, `FieldDerivedStrategy`, `PromptStrategy`, `FormatStrategy`, `NamingService`, `DocumentNamingRule`. None exist. `DocType.autoname: String?` is the only breadcrumb, and it is unused in save flow. |
 | `Notifications/` | Yes | Has **both** `EventBus.swift` (ADR-012, superseded) and `EventEmitter.swift` (ADR-020). `DocumentEngine` still requires an `EventBus` in its initializer, so the old path has not been retired. |
-| `Permissions/` | Yes (shape doesn't match) | Only `PermissionEngine.swift`. Missing `PermissionContext.swift`, `PermissionEvaluators.swift`. See §4.4 deviation below. |
+| `Permissions/` | Yes | `PermissionEngine.swift` is the only file and matches the revised §4.4 / ADR-011 (flat surface — see P0.5). `PermissionContext.swift` and `PermissionEvaluators.swift` were documented by earlier revisions but are no longer part of the target shape. |
 | `Printing/` | **No** | `LetterHead.swift`, `PDFGenerator.swift`, `PrintFormat.swift` absent. (Docs correctly mark §4.17 _planned_, but §7's tree still lists them.) |
 | `Reporting/` | Yes | `ReportEngine.swift` only. |
 | `Scheduling/` | **No** | §4.13 describes `SchedulerService.swift`, `ScheduledTask.swift`. Neither exists. |
@@ -71,19 +71,12 @@ The goal is not to assign blame; it's to give future contributors an honest star
 - **Partial** — Migrations are forward-only (as intended) but there is no test suite asserting schema shape.
 - **Partial** — `audit_log` has neither a writer nor a reader API. Created, never used.
 
-### 2.4 Permissions Engine — §4.4 (documentation gap)
+### 2.4 Permissions Engine — §4.4
 
-**The documentation and ADR-011 describe something the code doesn't implement.**
-
-| Docs say | Code has |
-|---|---|
-| `PermissionEvaluator` protocol + `PermissionDecision` enum | Neither exists. |
-| Evaluator chain (`AppLevel`, `DocTypeLevel`, `FieldLevel`, `RowLevel`, `WorkflowLevel`) | A flat class `PermissionEngine` with three hard-coded methods. |
-| Row-level arbitrary condition filter | `canAccessRow(document:userRoles:rowFilter:)` only does equality match on a `[String: FieldValue]` dict. No expression support. |
-| AppLevel evaluator | Not implemented. Nothing checks "is the user's role allowed to use this module/app at all?". |
-| WorkflowLevel evaluator | Workflow role checks happen inside `WorkflowEngine.availableTransitions`, not via an evaluator. |
-
-The `ValidationPipeline`'s `PermissionStage` calls into `PermissionEngine.canPerform`, so the pipeline does integrate — but the overall model in the doc is aspirational. **Either implement the chain or rewrite §4.4 + ADR-011 to describe what is actually there.**
+- **Shipped** — `PermissionEngine` exposes `canPerform(operation:on:userRoles:)`, `canAccessField(fieldKey:on:userRoles:operation:)`, and `canAccessRow(document:userRoles:rowFilter:)`. `ValidationPipeline`'s `PermissionStage` calls into `canPerform`.
+- **Aligned (P0.5 — 2026-04-23)** — §4.4 and ADR-011 now describe the flat method surface that actually ships. The earlier `PermissionEvaluator` / `PermissionDecision` evaluator-chain wording was removed from §4.4, ADR-011, ADR-025, and ADR-026.
+- **Partial vs. original intent** — `canAccessRow` is still an equality-only dictionary filter, not an expression predicate (expression-backed row filters are tracked as `Docs/ENHANCEMENT-PROPOSAL.md` P1.7).
+- **Not implemented** — There is no app-/module-level gate (nothing checks "is this role allowed to use this module at all?"). Workflow transition role checks live inside `WorkflowEngine.availableTransitions` and are not routed through `PermissionEngine`.
 
 ### 2.5 Workflow Engine — §4.5
 
@@ -207,7 +200,7 @@ This is a useful parallel tool but also a **duplicate installer code path**. The
 If you open the repo today expecting to find everything ARCHITECTURE.md §7 advertises, here is the short list of what _to stop looking for_:
 
 - `Automation/`, `Cache/`, `Files/`, `ImportExport/`, `Naming/`, `Printing/`, `Scheduling/` — do not exist.
-- `PermissionEvaluator` chain — does not exist; `PermissionEngine` is a flat class.
+- A chain-style `PermissionEvaluator` protocol — does not exist; `PermissionEngine` is a flat class, and §4.4 / ADR-011 now describe it as such (P0.5).
 - AST in `ExpressionEvaluator` — does not exist; direct-eval recursive descent.
 - Role-filtered `availableReports` — does not exist; returns all.
 - Any XCTest target — does not exist.


### PR DESCRIPTION
## Summary

This PR realigns the architecture documentation and ADR-011 to accurately describe the shipped `PermissionEngine` implementation. The code has always been a flat class with three public methods (`canPerform`, `canAccessField`, `canAccessRow`), but the documentation described an aspirational evaluator-chain design that was never implemented. This change fixes the documentation to match reality.

## Key Changes

- **ADR-011 rewritten** — Removed descriptions of `PermissionEvaluator` protocol, `PermissionDecision` enum, and the five-evaluator chain. Now documents the actual flat `PermissionEngine` surface with three scope-specific methods.

- **ARCHITECTURE.md §4.4 updated** — Replaced the evaluator-chain description with the shipped implementation: `canPerform` (DocType-level), `canAccessField` (field-level), and `canAccessRow` (row-level equality filters). Explicitly notes what is out of scope: app/module-level gating, workflow-level role checks (handled in `WorkflowEngine`), and expression-backed row filters.

- **ARCHITECTURE.md diagram and other sections aligned** — Updated §3 (architecture diagram), §4.2 (ValidationPipeline integration), §4.12 (extension protocols), §4.15 (public API surface), and §7 (directory structure) to remove references to the unimplemented evaluator chain.

- **IMPLEMENTATION-STATUS.md clarified** — Removed "shape doesn't match" entry for `Permissions/`. §2.4 now correctly grades the engine as Shipped (flat surface) with Partial support (equality-only row filters, no app-level gate).

- **ENHANCEMENT-PROPOSAL.md P0.5 marked done** — Option A (fix the doc) completed. Option B (implement the chain) deferred as a future enhancement alongside P1.7 (row-level expressions) and app-/module-level gating.

- **ADR-025 and ADR-026 updated** — Removed or reframed references to `PermissionEvaluator` as a Layer 3 extension point, noting that the protocol is not shipped.

## Implementation Details

- No Swift source files were modified; `PermissionEngine.swift` and the `PermissionStage` integration already matched the new description.
- The chain design remains a candidate for a future revision when app-level and row-expression evaluators land and the number of concerns outgrows three hand-written methods.
- All out-of-scope checks (app gating, workflow role gates, expression predicates) are now explicitly documented with forward pointers to relevant enhancement proposals.

https://claude.ai/code/session_01PuwSwgyyf2hPZZdWrh788E