### PR TITLE
Add DocumentVersion reader API on DocumentEngine (P0.8 / ADR-024)

### DIFF
--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -112,16 +112,24 @@ ADR-012 already says "superseded"; the code should reflect it.
 - Correct the `PermissionEngine.canPerform` signature in §4.15 to `canPerform(operation:on:userRoles:)`.
 - (Already done in this changeset: ADR-027 added to §8.)
 
-### P0.8 — `DocumentVersion` stores the full old/new not just a diff summary [S, low risk] — ADR-024
+### P0.8 — `DocumentVersion` stores the full old/new not just a diff summary [S, low risk] — ADR-024 *(done — 2026-04-23)*
 
-Today `DocumentVersion.fieldDiffs` is computed but there is no reader API. Add:
+`DocumentEngine` now exposes two reader APIs that make the append-only `document_versions` history consumable:
 
 ```swift
 public func versions(of documentId: String) throws -> [DocumentVersion]
 public func version(of documentId: String, at timestamp: Date) throws -> DocumentVersion?
 ```
 
-…on `DocumentEngine`. Without a reader, the feature is write-only and gives "complete field-level change history for audit-sensitive documents" (§4.2) no way to be consumed.
+`versions(of:)` returns the full history ordered oldest first. `version(of:at:)` returns the version that was **in effect at** `timestamp` — the most recent version with `savedAt <= timestamp` — or `nil` if no version was recorded at or before that instant. Both read straight from the v3 `document_versions` table; saves that produce no field changes still do not write a row, so the history surface matches the write path one-for-one.
+
+Coverage in `DocumentEngineTests.swift`:
+
+- `testVersionsReturnsEmptyForUnknownDocument`
+- `testVersionsReturnsChronologicalHistoryWithCorrectDiffs`
+- `testVersionAtBeforeFirstSaveReturnsNil`
+- `testVersionAtReturnsLatestSaveAtOrBeforeTimestamp`
+- `testSaveWithoutFieldChangesDoesNotAppendAVersion`
 
 ### P0.9 — Fix unary minus in `ExpressionEvaluator` [S, low risk] — ADR-017
 
@@ -403,7 +411,7 @@ A 4–6 week plan if one engineer is the target:
 |---|---|
 | 1 | P0.1 test target ✅; P0.6 event bus cleanup ✅; P0.7 doc cleanup ✅; P0.9 unary minus ✅. |
 | 2 | P0.2 sync-through-engine ✅; P0.3 persisted sequence ✅; P0.4 queue pruning + ADR-028 ✅. |
-| 3 | P0.5A (rewrite permissions doc) ✅; P0.5B (implement chain) deferred; P0.8 version reader; P1.5 real validation stages. |
+| 3 | P0.5A (rewrite permissions doc) ✅; P0.5B (implement chain) deferred; P0.8 version reader ✅; P1.5 real validation stages. |
 | 4 | P1.1 Naming subsystem (behind a feature flag if needed). |
 | 5–6 | P1.2 + P1.3 automation runtime + extension-point resolution. |
 

--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -420,6 +420,51 @@ public final class DocumentEngine {
         return documents
     }
 
+    // MARK: - Versions (ADR-024, P0.8)
+
+    /// Return the full append-only version history for a document, oldest first.
+    ///
+    /// Each `DocumentVersion` captures the field-level diff that was applied by a single
+    /// `DocumentEngine.save` (or `applyRemote`). Saves that produce no field changes do not
+    /// write a version row, so consecutive timestamps need not imply a visible change.
+    public func versions(of documentId: String) throws -> [DocumentVersion] {
+        let rows = try database.read { db in
+            try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT id, documentId, docType, savedAt, savedBy, fieldDiffs
+                    FROM document_versions
+                    WHERE documentId = ?
+                    ORDER BY savedAt ASC
+                    """,
+                arguments: [documentId]
+            )
+        }
+        return try rows.map { try documentVersionFromRow($0) }
+    }
+
+    /// Return the document version that was in effect at `timestamp` — i.e. the most
+    /// recent version whose `savedAt` is less than or equal to `timestamp`. Returns `nil`
+    /// if no version was recorded at or before that instant.
+    public func version(of documentId: String, at timestamp: Date) throws -> DocumentVersion? {
+        let cutoff = ISO8601DateFormatter().string(from: timestamp)
+        let row = try database.read { db in
+            try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT id, documentId, docType, savedAt, savedBy, fieldDiffs
+                    FROM document_versions
+                    WHERE documentId = ? AND savedAt <= ?
+                    ORDER BY savedAt DESC
+                    LIMIT 1
+                    """,
+                arguments: [documentId, cutoff]
+            )
+        }
+        guard let row = row else { return nil }
+        return try documentVersionFromRow(row)
+    }
+
     // MARK: - Private Helpers
 
     /// Run the full ValidationPipeline for a document under its DocType. (ADR-022)
@@ -617,6 +662,30 @@ public final class DocumentEngine {
                 version.savedBy,
                 diffsString
             ]
+        )
+    }
+
+    /// Decode a `DocumentVersion` from a `document_versions` row. (ADR-024, P0.8)
+    private func documentVersionFromRow(_ row: Row) throws -> DocumentVersion {
+        let id: String = row["id"] ?? ""
+        let documentId: String = row["documentId"] ?? ""
+        let docType: String = row["docType"] ?? ""
+        let savedBy: String = row["savedBy"] ?? ""
+        let savedAtStr: String = row["savedAt"] ?? ""
+        guard !id.isEmpty, let savedAt = ISO8601DateFormatter().date(from: savedAtStr) else {
+            throw DocumentEngineError.malformedRow
+        }
+        let diffsString: String = row["fieldDiffs"] ?? "[]"
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let diffs = try decoder.decode([FieldDiff].self, from: Data(diffsString.utf8))
+        return DocumentVersion(
+            id: id,
+            documentId: documentId,
+            docType: docType,
+            savedAt: savedAt,
+            savedBy: savedBy,
+            fieldDiffs: diffs
         )
     }
 

--- a/mercantis coreTests/DocumentEngineTests.swift
+++ b/mercantis coreTests/DocumentEngineTests.swift
@@ -133,6 +133,85 @@ final class DocumentEngineTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(try documentVersionCount(for: "note-v"), 1)
     }
 
+    // MARK: - Version readers (ADR-024, P0.8)
+
+    func testVersionsReturnsEmptyForUnknownDocument() throws {
+        XCTAssertTrue(try harness.engine.versions(of: "does-not-exist").isEmpty)
+    }
+
+    func testVersionsReturnsChronologicalHistoryWithCorrectDiffs() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        try harness.engine.save(TestSupport.makeDocument(id: "note-h",
+                                                         fields: ["title": .string("v1")]))
+        // ISO8601DateFormatter stores savedAt at second precision; sleep past the
+        // next second boundary so the two versions are distinguishable.
+        Thread.sleep(forTimeInterval: 1.1)
+
+        var second = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "note-h"))
+        second.fields["title"] = .string("v2")
+        try harness.engine.save(second)
+
+        let versions = try harness.engine.versions(of: "note-h")
+        XCTAssertEqual(versions.count, 2)
+        XCTAssertLessThanOrEqual(versions[0].savedAt, versions[1].savedAt)
+
+        XCTAssertEqual(versions[0].fieldDiffs.first?.fieldKey, "title")
+        XCTAssertNil(versions[0].fieldDiffs.first?.oldValue)
+        XCTAssertEqual(versions[0].fieldDiffs.first?.newValue, .string("v1"))
+
+        XCTAssertEqual(versions[1].fieldDiffs.first?.oldValue, .string("v1"))
+        XCTAssertEqual(versions[1].fieldDiffs.first?.newValue, .string("v2"))
+    }
+
+    func testVersionAtBeforeFirstSaveReturnsNil() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        let before = Date()
+        Thread.sleep(forTimeInterval: 1.1)
+        try harness.engine.save(TestSupport.makeDocument(id: "note-p",
+                                                         fields: ["title": .string("v1")]))
+
+        XCTAssertNil(try harness.engine.version(of: "note-p", at: before))
+    }
+
+    func testVersionAtReturnsLatestSaveAtOrBeforeTimestamp() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        try harness.engine.save(TestSupport.makeDocument(id: "note-pit",
+                                                         fields: ["title": .string("v1")]))
+        Thread.sleep(forTimeInterval: 1.1)
+        let cutoff = Date()
+        Thread.sleep(forTimeInterval: 1.1)
+
+        var second = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "note-pit"))
+        second.fields["title"] = .string("v2")
+        try harness.engine.save(second)
+
+        let snapshot = try XCTUnwrap(harness.engine.version(of: "note-pit", at: cutoff))
+        XCTAssertEqual(snapshot.fieldDiffs.first?.newValue, .string("v1"),
+                       "cutoff between v1 and v2 saves must resolve to the v1 version")
+    }
+
+    func testSaveWithoutFieldChangesDoesNotAppendAVersion() throws {
+        let docType = TestSupport.makeDocType()
+        try harness.registry.register(docType)
+
+        try harness.engine.save(TestSupport.makeDocument(id: "note-nop",
+                                                         fields: ["title": .string("v1")]))
+        let countAfterFirstSave = try harness.engine.versions(of: "note-nop").count
+
+        // Re-save with identical field values (refetch to pick up fresh updatedAt).
+        let refetched = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "note-nop"))
+        try harness.engine.save(refetched)
+
+        XCTAssertEqual(try harness.engine.versions(of: "note-nop").count, countAfterFirstSave,
+                       "a save that changes no fields must not append a version row")
+    }
+
     // MARK: - Delete
 
     func testDeleteRemovesRowAndAppendsMutation() throws {


### PR DESCRIPTION
Expose the append-only document_versions history through two public readers:
  - versions(of:) returns the full history oldest first
  - version(of:at:) returns the version in effect at a point in time (latest savedAt <= timestamp), or nil if none

Before this change, DocumentVersion diffs were written on every save but unreachable through the public API, making the audit trail write-only. The schema and write path are unchanged.

Covered in DocumentEngineTests by five new cases: empty history, chronological ordering with correct diff content, at-before-first-save returns nil, at-between-saves resolves to the earlier version, and a no-op save does not append a version row.