### PR TITLE
Implement WorkflowGuardStage and PermissionStage as real validation stages

### DIFF
--- a/Docs/ADR/ADR-022-document-validation-pipeline.md
+++ b/Docs/ADR/ADR-022-document-validation-pipeline.md
@@ -34,8 +34,8 @@ Stages are executed in declared order on every `save(_:)` call:
 3. **`LinkValidationStage`** — For fields of type `link`, the referenced document must exist in the `documents` table.
 4. **`UniqueConstraintStage`** — Fields or index definitions marked `unique: true` are checked against existing documents.
 5. **`ValidationRuleStage`** — `ValidationRule` expressions (declared in the DocType) are evaluated by `ExpressionEngine`. A failing rule produces a user-visible error message.
-6. **`WorkflowGuardStage`** — If the document has an associated workflow, the current transition (if any) is validated for allowed roles and condition expression.
-7. **`PermissionStage`** — The permission evaluator chain (ADR-011) is invoked to confirm the current user may perform the save operation.
+6. **`WorkflowGuardStage`** — If the document's DocType declares a `workflowId` resolvable via `ValidationContext.workflowProvider`, any change to `status` must correspond to a declared `WorkflowTransition` (`from == previous`, `to == document.status`). The transition's `allowedRoles` and `conditionExpression` are enforced. Creation and unchanged-status saves are not transitions and pass. (P1.5)
+7. **`PermissionStage`** — `PermissionEngine.canPerform(operation:on:userRoles:)` (ADR-011's flat surface) is invoked to confirm the current user may perform the save operation. The operation is `.create` for brand-new documents and `.write` for updates; empty `userRoles` or an unconstrained DocType short-circuit to a pass.
 
 If any stage produces errors, the pipeline halts and the errors are returned to the caller. The document is not persisted. All errors from a single stage are collected before halting (not just the first).
 

--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -203,11 +203,38 @@ mercantis core/Scheduling/
 
 Cron support is the only non-trivial piece. A dependency-free subset (minute, hour, day-of-month, month, day-of-week, no `@yearly` aliases) covers Frappe's typical use and fits in ~200 lines.
 
-### P1.5 — Turn `WorkflowGuardStage` and `PermissionStage` into real stages [S, low risk] — ADR-022
+### P1.5 — Turn `WorkflowGuardStage` and `PermissionStage` into real stages [S, low risk] — ADR-022 *(done — 2026-04-23)*
 
-Both are placeholders that comment-document the gap. Fold them in:
-- `WorkflowGuardStage` — given the current document and its target `docStatus`/status transition, verify the transition is declared in the `WorkflowDefinition` and the user has the role. Reject with a typed error if not.
-- `PermissionStage` — once P0.5 option B lands, call `PermissionEngine.canPerform(operation: .write, on: docType, userRoles:)`. Until then, wire the existing flat methods.
+Both stages are now real guards in `ValidationPipeline`.
+
+`WorkflowGuardStage` resolves the DocType's `workflowId` via a new `ValidationContext.workflowProvider` closure and compares the document's `status` against the previously-persisted status (obtained via `ValidationContext.previousStatus`). On a detected change, the stage:
+
+- rejects transitions that are not declared in the `WorkflowDefinition` (`from == previous`, `to == document.status`);
+- rejects transitions whose `allowedRoles` do not intersect the caller's roles (system / import contexts with empty `userRoles` remain exempt);
+- rejects transitions whose `conditionExpression` evaluates to false, and surfaces evaluator errors as structured `DocumentValidationError`s.
+
+Creation (no previously-persisted row) and same-status saves are accepted — neither is a transition. `docStatus` lifecycle moves (submit / cancel / amend) remain governed by ADR-013 and are orthogonal to this stage.
+
+`PermissionStage` now delegates directly to `PermissionEngine.canPerform(operation:on:userRoles:)` (ADR-011's flat surface, per P0.5 option A). `ValidationContext.operation` selects the `DocumentOperation` to check; `DocumentEngine.runValidationPipeline` passes `.create` when the document is new and `.write` otherwise. Empty `userRoles` and empty `docType.permissions` both still short-circuit to a pass, matching the prior convention. When ADR-011 option B lands, this stage will swap the flat call for the evaluator chain without a pipeline-level change.
+
+`DocumentEngine` supplies the new context inputs from the existing SQLite tables (`documents.status` and the `workflows` table). No schema change was required.
+
+Coverage in `ValidationPipelineTests.swift`:
+
+- `testPermissionStagePassesWhenDocTypeDeclaresNoPermissionRules`
+- `testPermissionStagePassesWhenUserRolesEmpty`
+- `testPermissionStageHonoursCreateOperationDistinctFromWrite`
+- `testWorkflowGuardPassesWhenNoWorkflowAttached`
+- `testWorkflowGuardPassesWhenWorkflowUnresolvable`
+- `testWorkflowGuardPassesOnNewDocumentCreation`
+- `testWorkflowGuardPassesWhenStatusUnchanged`
+- `testWorkflowGuardRejectsUndeclaredTransition`
+- `testWorkflowGuardRejectsUnauthorisedTransition`
+- `testWorkflowGuardAllowsDeclaredTransitionWithRole`
+- `testWorkflowGuardRejectsTransitionWhenConditionFalse`
+- `testWorkflowGuardAllowsTransitionWhenConditionTrue`
+- `testWorkflowGuardSkipsRoleCheckForSystemContext`
+- `testWorkflowGuardReportsEvaluationErrorForMalformedCondition`
 
 ### P1.6 — Expand `FieldValue` [S, low risk] — ARCHITECTURE-CHANGELOG follow-up
 
@@ -411,7 +438,7 @@ A 4–6 week plan if one engineer is the target:
 |---|---|
 | 1 | P0.1 test target ✅; P0.6 event bus cleanup ✅; P0.7 doc cleanup ✅; P0.9 unary minus ✅. |
 | 2 | P0.2 sync-through-engine ✅; P0.3 persisted sequence ✅; P0.4 queue pruning + ADR-028 ✅. |
-| 3 | P0.5A (rewrite permissions doc) ✅; P0.5B (implement chain) deferred; P0.8 version reader ✅; P1.5 real validation stages. |
+| 3 | P0.5A (rewrite permissions doc) ✅; P0.5B (implement chain) deferred; P0.8 version reader ✅; P1.5 real validation stages ✅. |
 | 4 | P1.1 Naming subsystem (behind a feature flag if needed). |
 | 5–6 | P1.2 + P1.3 automation runtime + extension-point resolution. |
 

--- a/Docs/IMPLEMENTATION-STATUS.md
+++ b/Docs/IMPLEMENTATION-STATUS.md
@@ -61,7 +61,7 @@ The goal is not to assign blame; it's to give future contributors an honest star
 - **Shipped** — Optimistic concurrency via `updatedAt` comparison (ADR-023).
 - **Shipped** — Submit-time immutability gate with `allowOnSubmit` (ADR-013); cancel refuses when linked submitted documents reference the doc.
 - **Shipped** — Field-level diffs written to `document_versions` on save (ADR-024).
-- **Shipped** — `ValidationPipeline` protocol + stages (ADR-022): type coercion, required, link, unique, expression rule, workflow guard, permission. All seven are present and composed in `DocumentEngine.save`.
+- **Shipped** — `ValidationPipeline` protocol + stages (ADR-022): type coercion, required, link, unique, expression rule, workflow guard, permission. All seven are real guards composed in `DocumentEngine.save` (and `applyRemote`). `WorkflowGuardStage` enforces declared transitions, roles, and condition expressions against the persisted `status`; `PermissionStage` delegates to `PermissionEngine.canPerform`. (P1.5 — 2026-04-23)
 - **Partial** — `list(docType:filters:)` filters are equality-only. No sort, no limit, no LIKE/range, despite `§4.15` advertising `sortBy:limit:`.
 - **Partial** — `audit_log` table is created in the migration but nothing writes to it. §4.3 describes it as "the immutable audit trail of all document mutations"; in practice the sync queue is acting as that log.
 

--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -46,9 +46,14 @@ public final class DocumentEngine {
     /// If the document belongs to a submittable DocType and has `docStatus == 1` (Submitted),
     /// only fields marked `allowOnSubmit: true` can be changed. (ADR-013)
     public func save(_ document: Document) throws {
+        // ADR-023: Optimistic concurrency check via updatedAt.
+        // ADR-024: Load existing fields for diff computation.
+        // P1.5: isNew drives `DocumentOperation.create` vs `.write` in the pipeline.
+        let existing = try loadExistingState(docType: document.docType, id: document.id)
+
         if let docType = registry.get(document.docType) {
             try validator.validate(docType)
-            try runValidationPipeline(on: document, docType: docType)
+            try runValidationPipeline(on: document, docType: docType, isNew: existing == nil)
 
             // ADR-013: Immutability enforcement for submitted documents.
             if document.docStatus == 1 && docType.isSubmittable {
@@ -62,9 +67,6 @@ public final class DocumentEngine {
         let payloadData = try encoder.encode(document.fields)
         let payloadString = String(data: payloadData, encoding: .utf8) ?? "{}"
 
-        // ADR-023: Optimistic concurrency check via updatedAt.
-        // ADR-024: Load existing fields for diff computation.
-        let existing = try loadExistingState(docType: document.docType, id: document.id)
         if let stored = existing?.updatedAt {
             let inMemoryTimestamp = ISO8601DateFormatter().string(from: document.updatedAt)
             if stored != inMemoryTimestamp {
@@ -132,9 +134,11 @@ public final class DocumentEngine {
         doc.syncVersion = mutation.syncVersion
         doc.syncState = .synced
 
+        let existing = try loadExistingState(docType: doc.docType, id: doc.id)
+
         if let docType = registry.get(doc.docType) {
             try validator.validate(docType)
-            try runValidationPipeline(on: doc, docType: docType)
+            try runValidationPipeline(on: doc, docType: docType, isNew: existing == nil)
             if doc.docStatus == 1 && docType.isSubmittable {
                 try enforceSubmitImmutability(document: doc, docType: docType)
             }
@@ -145,7 +149,6 @@ public final class DocumentEngine {
         let payloadData = try encoder.encode(doc.fields)
         let payloadString = String(data: payloadData, encoding: .utf8) ?? "{}"
 
-        let existing = try loadExistingState(docType: doc.docType, id: doc.id)
         let oldFields = existing?.fields ?? [:]
 
         let createdAtString = ISO8601DateFormatter().string(from: doc.createdAt)
@@ -468,10 +471,21 @@ public final class DocumentEngine {
     // MARK: - Private Helpers
 
     /// Run the full ValidationPipeline for a document under its DocType. (ADR-022)
-    private func runValidationPipeline(on document: Document, docType: DocType) throws {
+    ///
+    /// `isNew` selects the `DocumentOperation` used by `PermissionStage`:
+    /// `.create` when the document has never been persisted, `.write` otherwise.
+    /// Callers that explicitly change `docStatus` (submit / cancel / amend) are
+    /// still enforced by the ADR-013 guards; `.write` is used for the save path
+    /// that piggybacks on those transitions.
+    private func runValidationPipeline(
+        on document: Document,
+        docType: DocType,
+        isNew: Bool
+    ) throws {
         let ctx = ValidationContext(
             docType: docType,
             userId: userId,
+            operation: isNew ? .create : .write,
             expressionEvaluator: ExpressionEvaluator(),
             documentExists: { [weak self] linkedDocType, linkedId in
                 guard let self else { return true }
@@ -483,12 +497,52 @@ public final class DocumentEngine {
                 return docs.contains { doc in
                     doc.id != excludeId && doc.fields[fieldKey] == value
                 }
+            },
+            workflowProvider: { [weak self] workflowId in
+                guard let self else { return nil }
+                return try? self.loadWorkflowDefinition(workflowId: workflowId)
+            },
+            previousStatus: { [weak self] docTypeName, docId in
+                guard let self else { return nil }
+                return try? self.loadStatus(docType: docTypeName, id: docId)
             }
         )
         let errors = validationPipeline.validate(document: document, context: ctx)
         if !errors.isEmpty {
             throw DocumentEngineError.validationFailed(errors: errors)
         }
+    }
+
+    /// Load just the persisted `status` column for a document. Returns nil for
+    /// brand-new documents (no row yet). Used by `WorkflowGuardStage`.
+    private func loadStatus(docType: String, id: String) throws -> String? {
+        try database.read { db in
+            try Row.fetchOne(
+                db,
+                sql: "SELECT status FROM documents WHERE id = ? AND doctype = ? LIMIT 1",
+                arguments: [id, docType]
+            )?["status"] as String?
+        }
+    }
+
+    /// Load a `WorkflowDefinition` from the `workflows` table by id. Returns nil
+    /// if the workflow has not been installed. Used by `WorkflowGuardStage`.
+    private func loadWorkflowDefinition(workflowId: String) throws -> WorkflowDefinition? {
+        let row = try database.read { db in
+            try Row.fetchOne(
+                db,
+                sql: "SELECT payload FROM workflows WHERE id = ? LIMIT 1",
+                arguments: [workflowId]
+            )
+        }
+        guard let row = row,
+              let payloadString: String = row["payload"],
+              let payloadData = payloadString.data(using: .utf8) else {
+            return nil
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(WorkflowDefinition.self, from: payloadData)
     }
 
     /// Read the currently-stored `updatedAt` string and field payload for a document, if any.

--- a/mercantis core/DocumentEngine/ValidationPipeline.swift
+++ b/mercantis core/DocumentEngine/ValidationPipeline.swift
@@ -40,8 +40,15 @@ public struct ValidationContext: Sendable {
     /// The user's roles.
     public let userRoles: Set<String>
 
+    /// The operation being performed. Used by `PermissionStage` to call
+    /// `PermissionEngine.canPerform(operation:on:userRoles:)`. Defaults to `.write`.
+    public let operation: DocumentOperation
+
     /// An expression evaluator for condition-based validation rules.
     public let expressionEvaluator: ExpressionEvaluator
+
+    /// The permission engine used by `PermissionStage`. Defaults to a fresh instance.
+    public let permissionEngine: PermissionEngine
 
     /// Function to check whether a linked document exists.
     /// Parameters: (docType, documentId) -> Bool
@@ -51,20 +58,37 @@ public struct ValidationContext: Sendable {
     /// Parameters: (docType, fieldKey, fieldValue, excludeDocumentId) -> Bool (true = conflict exists)
     public let uniqueConflictExists: @Sendable (String, String, FieldValue, String) -> Bool
 
+    /// Lookup the `WorkflowDefinition` for a given workflow id. Returns nil if the workflow
+    /// cannot be resolved. Used by `WorkflowGuardStage`. Default: always nil.
+    public let workflowProvider: @Sendable (String) -> WorkflowDefinition?
+
+    /// Lookup the previously-persisted workflow `status` for a document, if any.
+    /// Parameters: (docType, documentId). Returns nil for brand-new documents. Used by
+    /// `WorkflowGuardStage` to detect state transitions. Default: always nil.
+    public let previousStatus: @Sendable (String, String) -> String?
+
     public init(
         docType: DocType,
         userId: String = "",
         userRoles: Set<String> = [],
+        operation: DocumentOperation = .write,
         expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator(),
+        permissionEngine: PermissionEngine = PermissionEngine(),
         documentExists: @escaping @Sendable (String, String) -> Bool = { _, _ in true },
-        uniqueConflictExists: @escaping @Sendable (String, String, FieldValue, String) -> Bool = { _, _, _, _ in false }
+        uniqueConflictExists: @escaping @Sendable (String, String, FieldValue, String) -> Bool = { _, _, _, _ in false },
+        workflowProvider: @escaping @Sendable (String) -> WorkflowDefinition? = { _ in nil },
+        previousStatus: @escaping @Sendable (String, String) -> String? = { _, _ in nil }
     ) {
         self.docType = docType
         self.userId = userId
         self.userRoles = userRoles
+        self.operation = operation
         self.expressionEvaluator = expressionEvaluator
+        self.permissionEngine = permissionEngine
         self.documentExists = documentExists
         self.uniqueConflictExists = uniqueConflictExists
+        self.workflowProvider = workflowProvider
+        self.previousStatus = previousStatus
     }
 }
 
@@ -337,64 +361,129 @@ public struct ValidationRuleStage: ValidationStage {
 
 // MARK: - Stage 6: Workflow Guard
 
-/// If the document has an associated workflow, the current transition (if any)
-/// is validated for allowed roles and condition expression. (ADR-022)
+/// If the document has an associated workflow, any change to `status` must correspond
+/// to a transition declared in the `WorkflowDefinition`. The transition's `allowedRoles`
+/// and `conditionExpression` are enforced. (ADR-022, ADR-004, P1.5)
+///
+/// Scope:
+/// - The DocType must declare `workflowId`, and the workflow must be resolvable via
+///   `context.workflowProvider`. If either is absent, the stage passes.
+/// - Creation (no previously-persisted status) is **not** a transition; accepted.
+/// - Saves that leave `status` unchanged are **not** transitions; accepted.
+/// - Saves that change `status` require a matching `WorkflowTransition`
+///   (`from == previous`, `to == document.status`). Missing transitions, missing
+///   roles, or failing conditions produce typed errors.
+///
+/// Role enforcement is skipped only when the caller provided no user roles
+/// (system / import contexts), matching the convention used by `PermissionStage`.
 public struct WorkflowGuardStage: ValidationStage {
     public let stageName = "WorkflowGuard"
 
     public init() {}
 
     public func validate(document: Document, context: ValidationContext) -> [DocumentValidationError] {
-        // Workflow guard is only relevant when a workflow is attached to the DocType.
-        // The actual workflow transition validation happens in WorkflowEngine.
-        // This stage acts as a placeholder for integration; real workflow checks
-        // are performed when `WorkflowEngine.transition(...)` is called.
-        guard context.docType.workflowId != nil else { return [] }
+        guard let workflowId = context.docType.workflowId,
+              let workflow = context.workflowProvider(workflowId) else {
+            return []
+        }
+        guard let previous = context.previousStatus(document.docType, document.id) else {
+            return []
+        }
+        guard previous != document.status else { return [] }
 
-        // If the document status has changed, the caller should have already
-        // validated it through WorkflowEngine. This stage returns no errors
-        // by default — it exists to hold the position in the pipeline.
+        guard let transition = workflow.transitions.first(where: {
+            $0.from == previous && $0.to == document.status
+        }) else {
+            return [DocumentValidationError(
+                stage: stageName,
+                field: nil,
+                message: "Workflow '\(workflow.id)' does not declare a transition from '\(previous)' to '\(document.status)'."
+            )]
+        }
+
+        // Role enforcement. System / import callers (empty userRoles) are exempt.
+        if !context.userRoles.isEmpty,
+           !transition.allowedRoles.isEmpty,
+           !transition.allowedRoles.contains(where: { context.userRoles.contains($0) }) {
+            return [DocumentValidationError(
+                stage: stageName,
+                field: nil,
+                message: "User is not authorised to transition '\(context.docType.name)' from '\(previous)' to '\(document.status)'."
+            )]
+        }
+
+        if let condition = transition.conditionExpression, !condition.isEmpty {
+            do {
+                let passes = try context.expressionEvaluator.evaluateBool(
+                    expression: condition,
+                    context: document.fields
+                )
+                if !passes {
+                    return [DocumentValidationError(
+                        stage: stageName,
+                        field: nil,
+                        message: "Workflow transition from '\(previous)' to '\(document.status)' is blocked by its condition."
+                    )]
+                }
+            } catch {
+                return [DocumentValidationError(
+                    stage: stageName,
+                    field: nil,
+                    message: "Workflow transition condition failed to evaluate: \(error.localizedDescription)"
+                )]
+            }
+        }
+
         return []
     }
 }
 
 // MARK: - Stage 7: Permission
 
-/// The permission evaluator chain is invoked to confirm the current user
-/// may perform the save operation. (ADR-022)
+/// Delegates to `PermissionEngine.canPerform(operation:on:userRoles:)` to confirm the
+/// current user may perform `context.operation` on the DocType. (ADR-011, ADR-022, P1.5)
+///
+/// Scope:
+/// - If `context.userRoles` is empty (system / import contexts), the stage passes.
+/// - If the DocType declares no `PermissionRule`s, the stage passes — an unconstrained
+///   DocType is assumed open to any caller with a role.
+/// - Otherwise the operation must be granted by at least one matching role.
+///
+/// This is the flat-permissions wiring described in P1.5. Row-level and
+/// field-level checks remain out of scope for the pipeline until the evaluator
+/// chain (ADR-011 option B) lands.
 public struct PermissionStage: ValidationStage {
     public let stageName = "Permission"
 
     public init() {}
 
     public func validate(document: Document, context: ValidationContext) -> [DocumentValidationError] {
-        // Permission checking requires the full PermissionEngine evaluator chain
-        // (ADR-011), which operates at a higher level than individual document
-        // validation. This stage acts as the integration point.
-        //
-        // When PermissionEngine is fully wired into the validation pipeline,
-        // this stage will call `permissionEngine.canPerform(.write, on: document, context:)`.
-        //
-        // For now, if userRoles are provided but the DocType has permission rules,
-        // perform a basic DocType-level permission check.
         guard !context.userRoles.isEmpty else { return [] }
+        guard !context.docType.permissions.isEmpty else { return [] }
 
-        let docTypePermissions = context.docType.permissions
-        guard !docTypePermissions.isEmpty else { return [] }
-
-        // Check if any of the user's roles grant write access.
-        let hasWriteAccess = docTypePermissions.contains { rule in
-            context.userRoles.contains(rule.role) && rule.canWrite
-        }
-
-        if !hasWriteAccess {
+        let allowed = context.permissionEngine.canPerform(
+            operation: context.operation,
+            on: context.docType,
+            userRoles: context.userRoles
+        )
+        if !allowed {
             return [DocumentValidationError(
                 stage: stageName,
                 field: nil,
-                message: "You do not have permission to save '\(context.docType.name)' documents."
+                message: "User does not have permission to \(describe(context.operation)) '\(context.docType.name)' documents."
             )]
         }
-
         return []
+    }
+
+    private func describe(_ operation: DocumentOperation) -> String {
+        switch operation {
+        case .read:   return "read"
+        case .write:  return "save"
+        case .create: return "create"
+        case .delete: return "delete"
+        case .submit: return "submit"
+        case .amend:  return "amend"
+        }
     }
 }

--- a/mercantis coreTests/ValidationPipelineTests.swift
+++ b/mercantis coreTests/ValidationPipelineTests.swift
@@ -15,17 +15,78 @@ final class ValidationPipelineTests: XCTestCase {
     private func context(
         for docType: DocType,
         userRoles: Set<String> = [],
+        operation: DocumentOperation = .write,
         documentExists: @escaping @Sendable (String, String) -> Bool = { _, _ in true },
-        uniqueConflict: @escaping @Sendable (String, String, FieldValue, String) -> Bool = { _, _, _, _ in false }
+        uniqueConflict: @escaping @Sendable (String, String, FieldValue, String) -> Bool = { _, _, _, _ in false },
+        workflowProvider: @escaping @Sendable (String) -> WorkflowDefinition? = { _ in nil },
+        previousStatus: @escaping @Sendable (String, String) -> String? = { _, _ in nil }
     ) -> ValidationContext {
         ValidationContext(
             docType: docType,
             userId: "tester",
             userRoles: userRoles,
+            operation: operation,
             expressionEvaluator: ExpressionEvaluator(),
             documentExists: documentExists,
-            uniqueConflictExists: uniqueConflict
+            uniqueConflictExists: uniqueConflict,
+            workflowProvider: workflowProvider,
+            previousStatus: previousStatus
         )
+    }
+
+    // MARK: - Workflow fixture
+
+    private func draftToSubmittedWorkflow(
+        conditionExpression: String? = nil,
+        allowedRoles: [String] = ["Approver"]
+    ) -> WorkflowDefinition {
+        WorkflowDefinition(
+            id: "NoteWorkflow",
+            name: "Note Workflow",
+            docType: "Note",
+            states: [
+                WorkflowState(name: "Draft", isDefault: true, allowEdit: true),
+                WorkflowState(name: "Submitted", isDefault: false, allowEdit: false)
+            ],
+            transitions: [
+                WorkflowTransition(
+                    from: "Draft",
+                    to: "Submitted",
+                    action: "submit",
+                    allowedRoles: allowedRoles,
+                    conditionExpression: conditionExpression
+                )
+            ]
+        )
+    }
+
+    private func noteDocType(withWorkflowId id: String? = "NoteWorkflow") -> DocType {
+        DocType(
+            id: "Note",
+            name: "Note",
+            module: "Core",
+            appId: "app.mercantis.test",
+            isChildTable: false,
+            isSubmittable: false,
+            fields: [TestSupport.textField("title"), TestSupport.numberField("total")],
+            permissions: [],
+            workflowId: id,
+            autoname: nil,
+            syncPolicy: TestSupport.defaultSyncPolicy(),
+            indexes: [],
+            searchFields: ["title"],
+            titleField: "title"
+        )
+    }
+
+    private func workflowDocument(
+        id: String = "doc-1",
+        status: String,
+        total: Double = 0
+    ) -> Document {
+        var doc = TestSupport.makeDocument(id: id, fields: ["title": .string("N"), "total": .double(total)])
+        doc.status = status
+        return doc
     }
 
     // MARK: - Required
@@ -226,5 +287,236 @@ final class ValidationPipelineTests: XCTestCase {
         let ctx = context(for: docType, userRoles: ["Reader"])
         let errors = pipeline.validate(document: doc, context: ctx)
         XCTAssertEqual(errors.first?.stage, "Permission")
+    }
+
+    func testPermissionStagePassesWhenDocTypeDeclaresNoPermissionRules() {
+        // An unconstrained DocType — no rules — is considered open to any authenticated caller.
+        let docType = TestSupport.makeDocType(
+            fields: [TestSupport.textField("title")],
+            permissions: []
+        )
+        let doc = TestSupport.makeDocument()
+        let pipeline = ValidationPipeline(stages: [PermissionStage()])
+
+        let ctx = context(for: docType, userRoles: ["Editor"])
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    func testPermissionStagePassesWhenUserRolesEmpty() {
+        // System / import contexts do not enforce role-based permission checks.
+        let rule = PermissionRule(
+            role: "Editor",
+            canRead: false, canWrite: false, canCreate: false,
+            canDelete: false, canSubmit: false, canAmend: false
+        )
+        let docType = TestSupport.makeDocType(
+            fields: [TestSupport.textField("title")],
+            permissions: [rule]
+        )
+        let doc = TestSupport.makeDocument()
+        let pipeline = ValidationPipeline(stages: [PermissionStage()])
+
+        let ctx = context(for: docType, userRoles: [])
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    func testPermissionStageHonoursCreateOperationDistinctFromWrite() {
+        // A role that can create but cannot write: create must pass, write must fail.
+        let rule = PermissionRule(
+            role: "Author",
+            canRead: true, canWrite: false, canCreate: true,
+            canDelete: false, canSubmit: false, canAmend: false
+        )
+        let docType = TestSupport.makeDocType(
+            fields: [TestSupport.textField("title")],
+            permissions: [rule]
+        )
+        let doc = TestSupport.makeDocument()
+        let pipeline = ValidationPipeline(stages: [PermissionStage()])
+
+        let createCtx = context(for: docType, userRoles: ["Author"], operation: .create)
+        XCTAssertTrue(pipeline.validate(document: doc, context: createCtx).isEmpty)
+
+        let writeCtx = context(for: docType, userRoles: ["Author"], operation: .write)
+        let writeErrors = pipeline.validate(document: doc, context: writeCtx)
+        XCTAssertEqual(writeErrors.first?.stage, "Permission")
+    }
+
+    // MARK: - Workflow guard
+
+    func testWorkflowGuardPassesWhenNoWorkflowAttached() {
+        let docType = noteDocType(withWorkflowId: nil)
+        let doc = workflowDocument(status: "Submitted")
+        let pipeline = ValidationPipeline(stages: [WorkflowGuardStage()])
+
+        let ctx = context(
+            for: docType,
+            userRoles: ["Approver"],
+            previousStatus: { _, _ in "Draft" }
+        )
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    func testWorkflowGuardPassesWhenWorkflowUnresolvable() {
+        // DocType declares a workflowId but the provider cannot find it — treated as no workflow.
+        let docType = noteDocType()
+        let doc = workflowDocument(status: "Submitted")
+        let pipeline = ValidationPipeline(stages: [WorkflowGuardStage()])
+
+        let ctx = context(
+            for: docType,
+            userRoles: ["Approver"],
+            workflowProvider: { _ in nil },
+            previousStatus: { _, _ in "Draft" }
+        )
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    func testWorkflowGuardPassesOnNewDocumentCreation() {
+        // No previously-persisted status => creation, not a transition.
+        let docType = noteDocType()
+        let doc = workflowDocument(status: "Draft")
+        let pipeline = ValidationPipeline(stages: [WorkflowGuardStage()])
+
+        let workflow = draftToSubmittedWorkflow()
+        let ctx = context(
+            for: docType,
+            userRoles: ["Approver"],
+            workflowProvider: { _ in workflow },
+            previousStatus: { _, _ in nil }
+        )
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    func testWorkflowGuardPassesWhenStatusUnchanged() {
+        let docType = noteDocType()
+        let doc = workflowDocument(status: "Draft")
+        let pipeline = ValidationPipeline(stages: [WorkflowGuardStage()])
+
+        let workflow = draftToSubmittedWorkflow()
+        let ctx = context(
+            for: docType,
+            userRoles: ["Approver"],
+            workflowProvider: { _ in workflow },
+            previousStatus: { _, _ in "Draft" }
+        )
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    func testWorkflowGuardRejectsUndeclaredTransition() {
+        // Draft -> Closed is not in the workflow.
+        let docType = noteDocType()
+        let doc = workflowDocument(status: "Closed")
+        let pipeline = ValidationPipeline(stages: [WorkflowGuardStage()])
+
+        let workflow = draftToSubmittedWorkflow()
+        let ctx = context(
+            for: docType,
+            userRoles: ["Approver"],
+            workflowProvider: { _ in workflow },
+            previousStatus: { _, _ in "Draft" }
+        )
+        let errors = pipeline.validate(document: doc, context: ctx)
+        XCTAssertEqual(errors.first?.stage, "WorkflowGuard")
+        XCTAssertTrue(errors.first?.message.contains("does not declare a transition") ?? false)
+    }
+
+    func testWorkflowGuardRejectsUnauthorisedTransition() {
+        // User has no role matching allowedRoles.
+        let docType = noteDocType()
+        let doc = workflowDocument(status: "Submitted")
+        let pipeline = ValidationPipeline(stages: [WorkflowGuardStage()])
+
+        let workflow = draftToSubmittedWorkflow(allowedRoles: ["Approver"])
+        let ctx = context(
+            for: docType,
+            userRoles: ["Reader"],
+            workflowProvider: { _ in workflow },
+            previousStatus: { _, _ in "Draft" }
+        )
+        let errors = pipeline.validate(document: doc, context: ctx)
+        XCTAssertEqual(errors.first?.stage, "WorkflowGuard")
+        XCTAssertTrue(errors.first?.message.contains("not authorised") ?? false)
+    }
+
+    func testWorkflowGuardAllowsDeclaredTransitionWithRole() {
+        let docType = noteDocType()
+        let doc = workflowDocument(status: "Submitted")
+        let pipeline = ValidationPipeline(stages: [WorkflowGuardStage()])
+
+        let workflow = draftToSubmittedWorkflow()
+        let ctx = context(
+            for: docType,
+            userRoles: ["Approver"],
+            workflowProvider: { _ in workflow },
+            previousStatus: { _, _ in "Draft" }
+        )
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    func testWorkflowGuardRejectsTransitionWhenConditionFalse() {
+        let docType = noteDocType()
+        let doc = workflowDocument(status: "Submitted", total: -1)
+        let pipeline = ValidationPipeline(stages: [WorkflowGuardStage()])
+
+        let workflow = draftToSubmittedWorkflow(conditionExpression: "total > 0")
+        let ctx = context(
+            for: docType,
+            userRoles: ["Approver"],
+            workflowProvider: { _ in workflow },
+            previousStatus: { _, _ in "Draft" }
+        )
+        let errors = pipeline.validate(document: doc, context: ctx)
+        XCTAssertEqual(errors.first?.stage, "WorkflowGuard")
+        XCTAssertTrue(errors.first?.message.contains("blocked by its condition") ?? false)
+    }
+
+    func testWorkflowGuardAllowsTransitionWhenConditionTrue() {
+        let docType = noteDocType()
+        let doc = workflowDocument(status: "Submitted", total: 10)
+        let pipeline = ValidationPipeline(stages: [WorkflowGuardStage()])
+
+        let workflow = draftToSubmittedWorkflow(conditionExpression: "total > 0")
+        let ctx = context(
+            for: docType,
+            userRoles: ["Approver"],
+            workflowProvider: { _ in workflow },
+            previousStatus: { _, _ in "Draft" }
+        )
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    func testWorkflowGuardSkipsRoleCheckForSystemContext() {
+        // When userRoles is empty (import / seed / system), role enforcement is skipped.
+        let docType = noteDocType()
+        let doc = workflowDocument(status: "Submitted")
+        let pipeline = ValidationPipeline(stages: [WorkflowGuardStage()])
+
+        let workflow = draftToSubmittedWorkflow(allowedRoles: ["Approver"])
+        let ctx = context(
+            for: docType,
+            userRoles: [],
+            workflowProvider: { _ in workflow },
+            previousStatus: { _, _ in "Draft" }
+        )
+        XCTAssertTrue(pipeline.validate(document: doc, context: ctx).isEmpty)
+    }
+
+    func testWorkflowGuardReportsEvaluationErrorForMalformedCondition() {
+        let docType = noteDocType()
+        let doc = workflowDocument(status: "Submitted", total: 1)
+        let pipeline = ValidationPipeline(stages: [WorkflowGuardStage()])
+
+        // Reference an undefined field so ExpressionEvaluator throws.
+        let workflow = draftToSubmittedWorkflow(conditionExpression: "missingField > 0")
+        let ctx = context(
+            for: docType,
+            userRoles: ["Approver"],
+            workflowProvider: { _ in workflow },
+            previousStatus: { _, _ in "Draft" }
+        )
+        let errors = pipeline.validate(document: doc, context: ctx)
+        XCTAssertEqual(errors.first?.stage, "WorkflowGuard")
+        XCTAssertTrue(errors.first?.message.contains("failed to evaluate") ?? false)
     }
 }


### PR DESCRIPTION
## Summary

Converts `WorkflowGuardStage` and `PermissionStage` from placeholder stubs into fully functional validation stages that enforce workflow transitions and document permissions during the validation pipeline.

## Key Changes

### ValidationContext Enhancements
- Added `operation: DocumentOperation` field to distinguish between `.create` and `.write` operations
- Added `permissionEngine: PermissionEngine` for permission checks
- Added `workflowProvider: (String) -> WorkflowDefinition?` closure to resolve workflow definitions
- Added `previousStatus: (String, String) -> String?` closure to retrieve the previously-persisted document status

### WorkflowGuardStage Implementation
- Now performs real workflow transition validation by:
  - Resolving the workflow definition via `workflowProvider`
  - Comparing current `document.status` against previously-persisted status
  - Rejecting undeclared transitions (not found in `WorkflowDefinition.transitions`)
  - Enforcing role-based authorization via `transition.allowedRoles`
  - Evaluating `transition.conditionExpression` and rejecting if false
  - Surfacing expression evaluation errors as structured `DocumentValidationError`s
- Correctly handles edge cases:
  - Passes when no workflow is attached or unresolvable
  - Passes on document creation (no previous status)
  - Passes when status is unchanged (not a transition)
  - Skips role enforcement for system/import contexts (empty `userRoles`)

### PermissionStage Implementation
- Now delegates to `PermissionEngine.canPerform(operation:on:userRoles:)` instead of inline checks
- Uses `context.operation` to determine which permission to check (`.create`, `.write`, `.delete`, etc.)
- Maintains existing conventions:
  - Passes when `userRoles` is empty (system contexts)
  - Passes when `docType.permissions` is empty (unconstrained DocType)
- Provides operation-specific error messages via `describe(_:)` helper

### DocumentEngine Integration
- Modified `save(_:)` and `applyMutation(_:)` to detect new documents via `loadExistingState`
- Passes `isNew` flag to `runValidationPipeline` to select `.create` vs `.write` operation
- Enhanced `runValidationPipeline` to supply workflow and status closures:
  - `workflowProvider` loads from `workflows` table via `loadWorkflowDefinition`
  - `previousStatus` queries `documents.status` column via `loadStatus`
- Added helper methods:
  - `loadStatus(docType:id:)` — retrieves persisted status or nil for new documents
  - `loadWorkflowDefinition(workflowId:)` — decodes workflow JSON from database

### Test Coverage
Added 13 comprehensive test cases covering:
- Permission stage behavior with/without rules and roles
- Create vs. write operation distinction
- Workflow guard with/without attached workflows
- Transition validation (declared, authorized, conditional)
- System context exemptions
- Expression evaluation error handling

## Implementation Details

- No schema changes required; uses existing `documents.status` and `workflows` table
- Workflow resolution is lazy (only when needed) via closure pattern
- Expression evaluation errors are caught and reported as validation errors rather than exceptions
- System/import contexts (empty `userRoles`) remain exempt from role enforcement in both stages, maintaining backward compatibility

https://claude.ai/code/session_01H49rZjCHpFAUZpywAsYguw