### PR TITLE
Implement extension-point resolution at install time (P1.3 / ADR-015)

### DIFF
--- a/Docs/ADR/ADR-015-declarative-hooks-app-extension.md
+++ b/Docs/ADR/ADR-015-declarative-hooks-app-extension.md
@@ -40,7 +40,11 @@ First-party code can provide custom `NamingStrategy`, `AutomationActionHandler`,
 - Untraceable execution — no static analysis can determine what code runs on a given event.
 - Circular dependency risk — hooks from different apps can form undeclared dependency cycles.
 
-At install time, `AppInstaller` resolves each `documentEventSubscription` and `schedulerEvent` declaration into a typed `EventBus` subscription or a `SchedulerService` registration. Since no executable code is downloaded, subscription "handlers" are limited to built-in action types (ADR-025).
+At install time, `AppInstaller` delegates to `ExtensionPointResolver`, which binds each `documentEventSubscription` to the typed `EventEmitter` (ADR-020) and forwards each `schedulerEvent` to an `ExtensionSchedulerRegistrar`. The resolver keeps per-app `SubscriptionToken` and scheduler handle arrays so `AppInstaller.uninstall` releases them cleanly. Reinstall clears prior bindings before rebinding; restarts rebind via `AppInstaller.restoreExtensionPoints()` against the persisted `apps` table.
+
+Action dispatch routes through the `ExtensionActionDispatcher` protocol so P1.2's `AutomationActionRegistry` (ADR-025) can plug in without a resolver-level change. Scheduler registration routes through `ExtensionSchedulerRegistrar` for the same reason — `SchedulerService` (P1.4) is the eventual conformer. Since no executable code is downloaded, subscription "handlers" remain limited to built-in action types (ADR-025).
+
+`DocumentEventTrigger` is a closed Swift enum (`on_save`, `on_update`, `on_change`, `on_submit`, `on_cancel`, `on_amend`, `on_trash`, `on_delete`). Manifests declaring unlisted triggers fail at `AppManifest` JSON decoding — there is no silent-no-op failure mode. Frappe's `after_insert` requires a future "isNew" flag on `DocumentSavedEvent` and is not yet in the enum.
 
 ## Consequences
 

--- a/Docs/ARCHITECTURE-CHANGELOG.md
+++ b/Docs/ARCHITECTURE-CHANGELOG.md
@@ -1,5 +1,40 @@
 # Mercantis Core — Architecture Changelog
 
+## Revision: 2026-04-24 (Extension-point resolution shipped — P1.3)
+
+This revision records the implementation of declarative extension-point resolution in `AppInstaller`. ADR-015 previously promised that installing a manifest would bind `documentEventSubscriptions` to `EventEmitter` and `schedulerEvents` to `SchedulerService`; with P1.1 complete, P1.3 became the next load-bearing piece and ships in this revision.
+
+### Code added
+
+| File | Summary |
+|---|---|
+| `mercantis core/AppRuntime/ExtensionPoints.swift` | `ExtensionPoints`, `DocumentEventSubscription`, `DocumentEventTrigger` (closed enum: `on_save`, `on_update`, `on_change`, `on_submit`, `on_cancel`, `on_amend`, `on_trash`, `on_delete`), `SchedulerEventDeclaration`, `ScheduleInterval`, `ExtensionActionDeclaration`. |
+| `mercantis core/AppRuntime/ExtensionPointResolver.swift` | `ExtensionPointResolver` + `ExtensionActionDispatcher` / `ExtensionSchedulerRegistrar` protocol seams. Default `LoggingExtensionActionDispatcher` and `RecordingExtensionSchedulerRegistrar` record activity without side effects so P1.2 / P1.4 can plug in real implementations later. |
+| `mercantis coreTests/ExtensionPointsTests.swift` | 10 tests covering decode backward-compat, install/uninstall lifecycle, reinstall idempotency, docType selector behaviour, wildcard matching, scheduler register/release, and process-restart re-bind. |
+
+### Code updated
+
+| File | Summary |
+|---|---|
+| `mercantis core/AppRuntime/AppManifest.swift` | Added `extensionPoints: ExtensionPoints` with `.empty` default and a `decodeIfPresent` init so pre-P1.3 manifests still decode. |
+| `mercantis core/AppRuntime/AppInstaller.swift` | New optional `extensionResolver` init parameter; `install` applies it after DocType registration; `uninstall` clears bindings; new `restoreExtensionPoints()` re-binds on process restart by replaying `apps.payload`. |
+
+### Doc updates
+
+| File | Summary |
+|---|---|
+| `Docs/ADR/ADR-015-declarative-hooks-app-extension.md` | Replaced the "at install time AppInstaller resolves…" paragraph with the shipped design — `ExtensionPointResolver`, token tracking, `ExtensionActionDispatcher` / `ExtensionSchedulerRegistrar` seams, closed trigger enum. |
+| `Docs/IMPLEMENTATION-STATUS.md` §2.8, §2.9, §5 | Removed the "EventBus still exists" partial note (P0.6 closed that before this revision); marked §2.9 Layer-1 resolution shipped with scope notes; updated §5's closing paragraph so the remaining gap list drops "automated events from manifests". |
+| `Docs/ENHANCEMENT-PROPOSAL.md` P1.3 | Marked done. Sequencing table updated to list P1.3 in week 5 and P1.2 in week 6. |
+
+### Known follow-ups
+
+- The main app (`mercantis_coreApp.swift`) does not yet construct an `AppInstaller` or call `restoreExtensionPoints()` at launch. That wiring belongs to the Hub / app-shell layer (P2.6 / P2.7).
+- Subscriptions observe post-commit events. Pre-commit blocking actions (`validate` in ADR-025) require the automation runtime (P1.2) to run inside the save transaction.
+- `after_insert` needs an "isNew" flag on `DocumentSavedEvent`; the trigger enum deliberately omits it and manifests using it fail at decode.
+
+---
+
 ## Revision: 2026-04-23 (Permissions doc alignment — P0.5 option A)
 
 This revision realigns the Permissions documentation with the shipped `PermissionEngine` code. The 2026-04-14 revision introduced an evaluator-chain design (`PermissionEvaluator` protocol, `PermissionDecision` enum, five concrete evaluators) that was never implemented; the code has always been a flat class with three public methods. `Docs/ENHANCEMENT-PROPOSAL.md` P0.5 picked option A (fix the doc) over option B (implement the chain) as the near-term resolution. The chain remains a candidate direction for a future revision alongside P1.7 (row-level expressions) and a yet-to-be-defined app-/module-level gate.

--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -1,6 +1,6 @@
 # Enhancement Proposal
 
-_Last updated: 2026-04-23 (P1.1 — Naming subsystem shipped)_
+_Last updated: 2026-04-24 (P1.3 — Extension-point resolution shipped)_
 
 Companion document to [`IMPLEMENTATION-STATUS.md`](./IMPLEMENTATION-STATUS.md). The status doc catalogues _what is_; this doc proposes _what to do next_. Each item is labelled with effort (S/M/L), risk, and the ADR or architecture section it closes.
 
@@ -94,15 +94,9 @@ Option B (implement the chain — introduce a `PermissionEvaluator` protocol, fi
 
 Until then, §4.4 / ADR-011 accurately document what ships.
 
-### P0.6 — Resolve `EventBus` / `EventEmitter` duality [S, low risk] — ADR-020
+### P0.6 — Resolve `EventBus` / `EventEmitter` duality [S, low risk] — ADR-020 *(done)*
 
-`EventBus.swift` is still alive and `DocumentEngine`/`WorkflowEngine` still require it in their init. The replacement is in place; finish the job:
-1. Delete the `eventBus` parameter from `DocumentEngine.init` and `WorkflowEngine.init`.
-2. Remove `EventEmitter(legacyBus:)` and the legacy bridge.
-3. Delete `EventBus.swift`.
-4. Update call sites in `mercantis_coreApp.swift` / CLI / any tests.
-
-ADR-012 already says "superseded"; the code should reflect it.
+`EventBus.swift` is gone; `EventEmitter(legacyBus:)` and the bridge are gone; `DocumentEngine.init` / `WorkflowEngine.init` no longer take an `eventBus` parameter. ADR-012's "superseded" status now matches the code.
 
 ### P0.7 — Update ARCHITECTURE.md §7 directory tree [S, zero risk] — doc hygiene
 
@@ -131,9 +125,9 @@ Coverage in `DocumentEngineTests.swift`:
 - `testVersionAtReturnsLatestSaveAtOrBeforeTimestamp`
 - `testSaveWithoutFieldChangesDoesNotAppendAVersion`
 
-### P0.9 — Fix unary minus in `ExpressionEvaluator` [S, low risk] — ADR-017
+### P0.9 — Fix unary minus in `ExpressionEvaluator` [S, low risk] — ADR-017 *(done)*
 
-The tokeniser treats `-` as a negative-number prefix only when `tokens.isEmpty`. `1 + -2` is parsed as `1`, `+`, `2` (silently wrong). Make unary minus a real parser case in `parseFactor` / `parseUnary`. Cover with `ExpressionEvaluatorTests`.
+`-` is now always an operator at the lexer level; `parseFactor` (arithmetic) and `parseValue` (comparison) handle unary `+` / `-` prefixes. `ExpressionEvaluatorTests` covers `1 + -2 == -1` and `3 * -2 == -6`.
 
 ---
 
@@ -179,23 +173,67 @@ mercantis core/Automation/
 
 Depends on P1.3 (extension-point resolution) to actually bind a manifest's rule set to the event bus at install time.
 
-### P1.3 — Implement extension-point resolution at install time [M, medium risk] — ADR-015 / ADR-026
+### P1.3 — Implement extension-point resolution at install time [M, medium risk] — ADR-015 / ADR-026 *(done — 2026-04-24)*
 
-`AppManifest` does not yet declare `extensionPoints`. Add:
+`AppManifest.extensionPoints: ExtensionPoints` now ships. Manifests declare two
+kinds of extension points:
 
-```swift
-public struct ExtensionPoints: Codable, Sendable {
-    public var documentEventSubscriptions: [DocumentEventSubscription]
-    public var schedulerEvents: [SchedulerEventDeclaration]
-}
+```
+mercantis core/AppRuntime/
+├── ExtensionPoints.swift            // ExtensionPoints, DocumentEventSubscription,
+│                                    // DocumentEventTrigger, SchedulerEventDeclaration,
+│                                    // ScheduleInterval, ExtensionActionDeclaration
+└── ExtensionPointResolver.swift     // resolver + dispatcher / registrar seams
 ```
 
-…and in `AppInstaller.install`, for each declaration:
-- Resolve the handler against the action registry.
-- Subscribe the resulting closure to `EventEmitter` (or register with `SchedulerService`).
-- Keep the returned `SubscriptionToken`s in a per-app dictionary so `uninstall` can release them.
+`ExtensionPointResolver.apply(manifest:)` binds every `documentEventSubscription`
+to the matching `MercantisEvent` on `EventEmitter` and forwards every
+`schedulerEvent` to an `ExtensionSchedulerRegistrar`. Tokens and scheduler
+handles are kept in per-app dictionaries; `resolver.clear(appId:)` — called
+from `AppInstaller.uninstall` — cancels every handle idempotently. Reinstall
+clears prior bindings before rebinding, so upgrades don't accumulate duplicate
+subscriptions.
 
-This is the load-bearing piece that turns the declarative model from a pretty JSON document into a running system.
+`AppInstaller.restoreExtensionPoints()` walks the `apps` table and reapplies
+every stored manifest's extension points on launch, since in-memory
+subscriptions don't survive a process restart.
+
+Two protocol seams keep P1.2 and P1.4 out of P1.3's critical path:
+
+- `ExtensionActionDispatcher` — P1.2's `AutomationActionRegistry` will conform.
+  Until then, `LoggingExtensionActionDispatcher` records every dispatched
+  action on a testable trail so wiring can be verified without handlers.
+- `ExtensionSchedulerRegistrar` — P1.4's `SchedulerService` will conform.
+  Until then, `RecordingExtensionSchedulerRegistrar` records declarations
+  without arming a timer.
+
+`DocumentEventTrigger` is a closed enum with raw values `on_save`, `on_update`,
+`on_change`, `on_submit`, `on_cancel`, `on_amend`, `on_trash`, `on_delete`.
+Manifests that declare unsupported triggers (e.g. Frappe's `after_insert`) fail
+at `AppManifest` JSON decoding time rather than silently binding nothing.
+
+Coverage in `ExtensionPointsTests.swift`:
+
+- `testManifestDecodesWithoutExtensionPointsField` — pre-P1.3 manifests decode to `.empty`.
+- `testManifestRejectsUnsupportedTrigger` — `"after_insert"` fails at decode.
+- `testInstallAppliesExtensionPointsAndUninstallReleasesThem` — install/uninstall lifecycle.
+- `testReinstallIsIdempotent` — rebinding clears prior tokens.
+- `testSchedulerDeclarationsRegisterAndReleaseWithApp` — scheduler registrar round-trip.
+- `testOnSubmitSubscriptionFiresOnMatchingDocType` — end-to-end dispatch via `DocumentEngine.submit`.
+- `testDocTypeSelectorSkipsNonMatchingDocTypes` — selector filtering.
+- `testWildcardSelectorMatchesEveryDocType` — `"*"` selector.
+- `testUninstallStopsDispatchingEventsForThatApp` — uninstall releases the subscription.
+- `testRestoreReappliesBindingsForAlreadyInstalledApps` — process-restart re-bind.
+
+**Known follow-ups (not scoped to P1.3):**
+- `documentEventSubscriptions` observe *after*-commit events. Pre-commit
+  blocking actions (the `validate` handler shape in ADR-025) require P1.2's
+  automation runtime to run inside the save transaction.
+- `after_insert` semantics need `DocumentSavedEvent` to carry an "isNew" flag;
+  tracked alongside future event refinements.
+- The main app (`mercantis_coreApp.swift`) does not yet construct an
+  `AppInstaller` or call `restoreExtensionPoints()` at launch; Hub/app-shell
+  integration is the consumer for that wiring.
 
 ### P1.4 — Implement the Scheduler [M, medium risk] — §4.13
 
@@ -445,7 +483,8 @@ A 4–6 week plan if one engineer is the target:
 | 2 | P0.2 sync-through-engine ✅; P0.3 persisted sequence ✅; P0.4 queue pruning + ADR-028 ✅. |
 | 3 | P0.5A (rewrite permissions doc) ✅; P0.5B (implement chain) deferred; P0.8 version reader ✅; P1.5 real validation stages ✅. |
 | 4 | P1.1 Naming subsystem ✅ (2026-04-23). |
-| 5–6 | P1.2 + P1.3 automation runtime + extension-point resolution. |
+| 5 | P1.3 Extension-point resolution ✅ (2026-04-24). |
+| 6 | P1.2 Automation runtime (fills the `ExtensionActionDispatcher` seam). |
 
 P1.4 Scheduler, P1.6 FieldValue expansion, and P1.7 row-level expressions slot in as individual PRs alongside the above.
 

--- a/Docs/IMPLEMENTATION-STATUS.md
+++ b/Docs/IMPLEMENTATION-STATUS.md
@@ -101,14 +101,14 @@ The goal is not to assign blame; it's to give future contributors an honest star
 
 ### 2.8 Notifications & Events — §4.8 / ADR-020
 
-- **Shipped** — `EventEmitter`, `MercantisEvent` marker protocol, concrete event types (`DocumentSavedEvent`, `DocumentDeletedEvent`, `DocumentSubmittedEvent`, `DocumentCancelledEvent`, `DocumentAmendedEvent`, `WorkflowTransitionEvent`, `AppInstalledEvent`).
-- **Partial** — `EventBus.swift` (ADR-012, superseded) **still exists and is still required by `DocumentEngine.init` and `WorkflowEngine.init`**. `EventEmitter` takes a `legacyBus:` in its initialiser to bridge. The migration is halfway done.
+- **Shipped** — `EventEmitter`, `MercantisEvent` marker protocol, concrete event types (`DocumentSavedEvent`, `DocumentDeletedEvent`, `DocumentSubmittedEvent`, `DocumentCancelledEvent`, `DocumentAmendedEvent`, `WorkflowTransitionEvent`, `AppInstalledEvent`). `EventBus.swift` / `EventEmitter(legacyBus:)` removed (P0.6).
 - **Missing** — In-app `NotificationLog` DocType, notification rules, email/SMS/webhook channels described in §4.16. §4.16 itself says "in progress".
 
 ### 2.9 App Runtime — §4.9 / §4.12
 
 - **Shipped** — `AppManifest` (Codable), `AppInstaller.install(_:)`, `AppInstaller.uninstall(appId:)`, `installApp` mutation flow.
-- **Missing** — §4.12's Layer-1 declarative resolution at install time: `documentEventSubscriptions`, `schedulerEvents`. `AppInstaller` does not read these keys from the manifest; `AppManifest` does not even declare them. ADR-015 / ADR-026 promise this; the runtime has no hook into it.
+- **Shipped (P1.3, 2026-04-24)** — `AppManifest.extensionPoints: ExtensionPoints`, `ExtensionPointResolver` binds `documentEventSubscription` declarations to the typed `EventEmitter` and forwards `schedulerEvent` declarations to an `ExtensionSchedulerRegistrar`. `AppInstaller.install` / `uninstall` now call the resolver; `AppInstaller.restoreExtensionPoints()` rebinds on launch. Action dispatch routes through the `ExtensionActionDispatcher` seam that P1.2's `AutomationActionRegistry` will conform to; the default `LoggingExtensionActionDispatcher` records dispatches for test assertions until then.
+- **Missing** — The main app (`mercantis_coreApp.swift`) does not yet construct an `AppInstaller` or call `restoreExtensionPoints()` at launch. P1.2 will plug in the real action dispatcher; P1.4 the real scheduler registrar.
 
 ### 2.10 Document Lifecycle — §4.10 / ADR-013
 
@@ -207,4 +207,4 @@ If you open the repo today expecting to find everything ARCHITECTURE.md §7 adve
 - Role-filtered `availableReports` — does not exist; returns all.
 - Any XCTest target — does not exist.
 
-Everything else in the doc is at least partially real. The _engine_ is in good shape; the _shell around the engine_ (naming, scheduling, automation runtime, automated events from manifests) is the gap.
+Everything else in the doc is at least partially real. The _engine_ is in good shape; the _shell around the engine_ (scheduling, automation runtime) is the remaining gap. Naming shipped in P1.1 (§2.11); extension-point resolution — the load-bearing wiring that binds manifest-declared events into `EventEmitter` — shipped in P1.3 (§2.9).

--- a/mercantis core/AppRuntime/AppInstaller.swift
+++ b/mercantis core/AppRuntime/AppInstaller.swift
@@ -16,11 +16,18 @@ public final class AppInstaller {
     private let database: MercantisDatabase
     private let schemaValidator: SchemaValidator
     private let registry: MetadataRegistry
+    private let extensionResolver: ExtensionPointResolver?
 
-    public init(database: MercantisDatabase, schemaValidator: SchemaValidator, registry: MetadataRegistry) {
+    public init(
+        database: MercantisDatabase,
+        schemaValidator: SchemaValidator,
+        registry: MetadataRegistry,
+        extensionResolver: ExtensionPointResolver? = nil
+    ) {
         self.database = database
         self.schemaValidator = schemaValidator
         self.registry = registry
+        self.extensionResolver = extensionResolver
     }
 
     // MARK: - Install
@@ -140,6 +147,11 @@ public final class AppInstaller {
         for docType in manifest.doctypes {
             try registry.register(docType)
         }
+
+        // 7. Bind declarative extension points (ADR-015, P1.3). Reinstall is
+        // idempotent — the resolver clears prior bindings for this app id
+        // before rebinding.
+        extensionResolver?.apply(manifest: manifest)
     }
 
     // MARK: - Uninstall
@@ -203,6 +215,53 @@ public final class AppInstaller {
                 try? registry.remove(docTypeId)
             }
         }
+
+        // 8. Release declarative extension-point bindings owned by this app
+        //    (ADR-015, P1.3). Safe when no resolver is wired or when the app
+        //    had no declarations.
+        extensionResolver?.clear(appId: appId)
+    }
+
+    // MARK: - Restore
+
+    /// Re-bind extension points for every already-installed app. Call once at
+    /// app launch after the resolver is wired — in-memory subscriptions do
+    /// not survive process restarts; the `apps` table does. (ADR-015, P1.3)
+    ///
+    /// Returns the set of app ids whose manifests were decoded and applied.
+    /// Apps whose payloads fail to decode are skipped and reported via
+    /// `onDecodeFailure` rather than aborting the whole restore.
+    @discardableResult
+    public func restoreExtensionPoints(
+        onDecodeFailure: ((_ appId: String, _ error: Error) -> Void)? = nil
+    ) throws -> [String] {
+        guard let extensionResolver else { return [] }
+
+        let rows: [(appId: String, payload: String)] = try database.read { db in
+            let fetched = try Row.fetchAll(db, sql: "SELECT id, payload FROM apps")
+            return fetched.compactMap { row in
+                guard let id: String = row["id"], let payload: String = row["payload"] else {
+                    return nil
+                }
+                return (appId: id, payload: payload)
+            }
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        var applied: [String] = []
+        for row in rows {
+            guard let data = row.payload.data(using: .utf8) else { continue }
+            do {
+                let manifest = try decoder.decode(AppManifest.self, from: data)
+                extensionResolver.apply(manifest: manifest)
+                applied.append(row.appId)
+            } catch {
+                onDecodeFailure?(row.appId, error)
+            }
+        }
+        return applied
     }
 
     // MARK: - Errors

--- a/mercantis core/AppRuntime/AppManifest.swift
+++ b/mercantis core/AppRuntime/AppManifest.swift
@@ -24,6 +24,7 @@ public struct AppManifest: Codable, Identifiable, Sendable {
     public var automationRules: [AutomationRule]
     public var dashboards: [DashboardDefinition]
     public var localizations: [LocalizationBundle]
+    public var extensionPoints: ExtensionPoints        // ADR-015, P1.3
     public var iconAsset: String?
 
     public init(
@@ -39,6 +40,7 @@ public struct AppManifest: Codable, Identifiable, Sendable {
         automationRules: [AutomationRule],
         dashboards: [DashboardDefinition],
         localizations: [LocalizationBundle],
+        extensionPoints: ExtensionPoints = .empty,
         iconAsset: String? = nil
     ) {
         self.id = id
@@ -53,6 +55,33 @@ public struct AppManifest: Codable, Identifiable, Sendable {
         self.automationRules = automationRules
         self.dashboards = dashboards
         self.localizations = localizations
+        self.extensionPoints = extensionPoints
         self.iconAsset = iconAsset
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, version, minimumCoreVersion, description
+        case doctypes, workflows, permissions, reports
+        case automationRules, dashboards, localizations
+        case extensionPoints, iconAsset
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        version = try c.decode(String.self, forKey: .version)
+        minimumCoreVersion = try c.decode(String.self, forKey: .minimumCoreVersion)
+        description = try c.decode(String.self, forKey: .description)
+        doctypes = try c.decode([DocType].self, forKey: .doctypes)
+        workflows = try c.decode([WorkflowDefinition].self, forKey: .workflows)
+        permissions = try c.decode([PermissionRule].self, forKey: .permissions)
+        reports = try c.decode([ReportDefinition].self, forKey: .reports)
+        automationRules = try c.decode([AutomationRule].self, forKey: .automationRules)
+        dashboards = try c.decode([DashboardDefinition].self, forKey: .dashboards)
+        localizations = try c.decode([LocalizationBundle].self, forKey: .localizations)
+        // Older manifests (pre-P1.3) don't carry `extensionPoints` — default to empty.
+        extensionPoints = try c.decodeIfPresent(ExtensionPoints.self, forKey: .extensionPoints) ?? .empty
+        iconAsset = try c.decodeIfPresent(String.self, forKey: .iconAsset)
     }
 }

--- a/mercantis core/AppRuntime/ExtensionPointResolver.swift
+++ b/mercantis core/AppRuntime/ExtensionPointResolver.swift
@@ -1,0 +1,386 @@
+//
+//  ExtensionPointResolver.swift
+//  mercantis core
+//
+//  Created by Kevin Busuttil on 24/04/2026.
+//
+
+import Foundation
+
+// MARK: - Collaborators
+
+/// Executes a single built-in action declared in a manifest. (ADR-025, P1.2)
+///
+/// `ExtensionPointResolver` delegates to this protocol so the automation action
+/// registry (P1.2) and the resolver can ship independently. Until P1.2 lands,
+/// `LoggingExtensionActionDispatcher` is the default — it logs each dispatch
+/// and records it in an inspectable trail so tests can assert wiring.
+public protocol ExtensionActionDispatcher: AnyObject, Sendable {
+    /// Dispatch one action declared in an app manifest.
+    ///
+    /// Implementations look up `action.actionType` against their registry and
+    /// invoke the matching handler. Throwing surfaces the error to the caller
+    /// (typically the event observer closure inside the resolver); resolver
+    /// callers decide whether to swallow or propagate.
+    func dispatch(
+        action: ExtensionActionDeclaration,
+        context: ExtensionActionContext
+    ) throws
+}
+
+/// Registers one scheduler declaration with the platform scheduler. (P1.4)
+///
+/// Until `SchedulerService` ships, `RecordingExtensionSchedulerRegistrar`
+/// records the declaration so tests can assert registrations without arming
+/// a timer. When P1.4 lands, `SchedulerService` will conform to this protocol.
+public protocol ExtensionSchedulerRegistrar: AnyObject, Sendable {
+    /// Returns a handle whose cancellation unregisters the scheduled task.
+    /// The resolver keeps the handle per-app and cancels it on uninstall.
+    func register(
+        declaration: SchedulerEventDeclaration,
+        appId: String,
+        dispatch: @escaping @Sendable () -> Void
+    ) -> ExtensionSchedulerHandle
+}
+
+/// Token returned by `ExtensionSchedulerRegistrar` that unregisters on cancel.
+public final class ExtensionSchedulerHandle: @unchecked Sendable {
+    private var cancellation: (@Sendable () -> Void)?
+    public init(cancellation: @escaping @Sendable () -> Void) {
+        self.cancellation = cancellation
+    }
+    public func cancel() {
+        cancellation?()
+        cancellation = nil
+    }
+    deinit { cancel() }
+}
+
+/// Context passed to each dispatched action. Today it only carries the
+/// manifest's subscription origin; P1.2 will extend this with the document
+/// reference when the dispatcher evolves into the automation runtime.
+public struct ExtensionActionContext: Sendable {
+    public let appId: String
+    public let origin: Origin
+
+    public enum Origin: Sendable {
+        case documentEvent(trigger: DocumentEventTrigger, documentId: String, docType: String)
+        case scheduler(declarationId: String, interval: ScheduleInterval)
+    }
+}
+
+// MARK: - Default implementations
+
+/// Default dispatcher that records each call without touching document state.
+/// Replaced by the real `AutomationActionRegistry` when P1.2 lands.
+public final class LoggingExtensionActionDispatcher: ExtensionActionDispatcher, @unchecked Sendable {
+    public struct Entry: Sendable, Equatable {
+        public let appId: String
+        public let actionType: String
+        public let parameters: [String: String]
+    }
+
+    private let lock = NSLock()
+    private var _entries: [Entry] = []
+
+    public init() {}
+
+    public var entries: [Entry] {
+        lock.lock(); defer { lock.unlock() }
+        return _entries
+    }
+
+    public func reset() {
+        lock.lock(); defer { lock.unlock() }
+        _entries.removeAll()
+    }
+
+    public func dispatch(
+        action: ExtensionActionDeclaration,
+        context: ExtensionActionContext
+    ) throws {
+        lock.lock()
+        _entries.append(Entry(
+            appId: context.appId,
+            actionType: action.actionType,
+            parameters: action.parameters
+        ))
+        lock.unlock()
+    }
+}
+
+/// Default registrar that records declarations without arming a timer.
+/// Replaced by `SchedulerService` when P1.4 lands.
+public final class RecordingExtensionSchedulerRegistrar: ExtensionSchedulerRegistrar, @unchecked Sendable {
+    public struct Entry: Sendable, Equatable {
+        public let appId: String
+        public let declarationId: String
+    }
+
+    private let lock = NSLock()
+    private var _entries: [Entry] = []
+
+    public init() {}
+
+    public var entries: [Entry] {
+        lock.lock(); defer { lock.unlock() }
+        return _entries
+    }
+
+    public func register(
+        declaration: SchedulerEventDeclaration,
+        appId: String,
+        dispatch: @escaping @Sendable () -> Void
+    ) -> ExtensionSchedulerHandle {
+        let entry = Entry(appId: appId, declarationId: declaration.id)
+        lock.lock()
+        _entries.append(entry)
+        lock.unlock()
+
+        return ExtensionSchedulerHandle { [weak self] in
+            guard let self else { return }
+            self.lock.lock()
+            self._entries.removeAll { $0 == entry }
+            self.lock.unlock()
+        }
+    }
+}
+
+// MARK: - Resolver
+
+/// Binds `AppManifest.extensionPoints` to the running `EventEmitter` and
+/// `SchedulerService` at install time, and tears bindings back down on
+/// uninstall. (ADR-015, ADR-026, P1.3)
+///
+/// The resolver keeps two per-app handle arrays:
+/// - `SubscriptionToken`s returned by `EventEmitter.subscribe`
+/// - `ExtensionSchedulerHandle`s returned by the scheduler registrar
+///
+/// `clear(appId:)` cancels every handle in both arrays and drops the entry.
+/// Both operations are idempotent.
+///
+/// ## Known follow-ups
+/// - `after_insert` is not in `DocumentEventTrigger`: `DocumentSavedEvent` does
+///   not yet carry an "isNew" flag, and silently binding to every save would
+///   surprise authors. Manifests using `"after_insert"` fail at decode time.
+/// - `documentEventSubscriptions` observe events published *after* commit, so
+///   they cannot block a save. When P1.2's automation runtime lands it will
+///   own pre-commit blocking actions; this resolver remains the post-commit
+///   pathway.
+public final class ExtensionPointResolver: @unchecked Sendable {
+
+    private let emitter: EventEmitter
+    private let dispatcher: ExtensionActionDispatcher
+    private let schedulerRegistrar: ExtensionSchedulerRegistrar
+    private let errorReporter: (@Sendable (ResolverError) -> Void)?
+
+    private let lock = NSLock()
+    private var tokensByApp: [String: [SubscriptionToken]] = [:]
+    private var scheduleHandlesByApp: [String: [ExtensionSchedulerHandle]] = [:]
+
+    public init(
+        emitter: EventEmitter,
+        dispatcher: ExtensionActionDispatcher = LoggingExtensionActionDispatcher(),
+        schedulerRegistrar: ExtensionSchedulerRegistrar = RecordingExtensionSchedulerRegistrar(),
+        errorReporter: (@Sendable (ResolverError) -> Void)? = nil
+    ) {
+        self.emitter = emitter
+        self.dispatcher = dispatcher
+        self.schedulerRegistrar = schedulerRegistrar
+        self.errorReporter = errorReporter
+    }
+
+    // MARK: - Apply / clear
+
+    /// Bind the manifest's declared extension points to the event emitter and
+    /// scheduler. Clears any prior bindings for the same app id first, so
+    /// reinstall/upgrade is idempotent.
+    ///
+    /// Unknown trigger strings fail earlier, at `AppManifest` decoding time —
+    /// `DocumentEventTrigger` is a closed enum and its `Codable` synthesis
+    /// rejects unlisted raw values (e.g. `"after_insert"`).
+    public func apply(manifest: AppManifest) {
+        let points = manifest.extensionPoints
+
+        clear(appId: manifest.id)
+
+        var newTokens: [SubscriptionToken] = []
+        newTokens.reserveCapacity(points.documentEventSubscriptions.count)
+
+        for sub in points.documentEventSubscriptions {
+            let token = bind(subscription: sub, appId: manifest.id)
+            newTokens.append(token)
+        }
+
+        var newHandles: [ExtensionSchedulerHandle] = []
+        newHandles.reserveCapacity(points.schedulerEvents.count)
+
+        for decl in points.schedulerEvents {
+            let handle = schedulerRegistrar.register(
+                declaration: decl,
+                appId: manifest.id,
+                dispatch: { [dispatcher, errorReporter] in
+                    let ctx = ExtensionActionContext(
+                        appId: manifest.id,
+                        origin: .scheduler(declarationId: decl.id, interval: decl.interval)
+                    )
+                    for action in decl.actions {
+                        do {
+                            try dispatcher.dispatch(action: action, context: ctx)
+                        } catch {
+                            errorReporter?(.dispatchFailed(
+                                appId: manifest.id,
+                                actionType: action.actionType,
+                                underlying: error
+                            ))
+                        }
+                    }
+                }
+            )
+            newHandles.append(handle)
+        }
+
+        lock.lock()
+        tokensByApp[manifest.id] = newTokens
+        scheduleHandlesByApp[manifest.id] = newHandles
+        lock.unlock()
+    }
+
+    /// Release every subscription and scheduler handle owned by `appId`.
+    /// Safe to call with an unknown app id.
+    public func clear(appId: String) {
+        lock.lock()
+        let tokens = tokensByApp.removeValue(forKey: appId) ?? []
+        let handles = scheduleHandlesByApp.removeValue(forKey: appId) ?? []
+        lock.unlock()
+
+        for token in tokens { token.cancel() }
+        for handle in handles { handle.cancel() }
+    }
+
+    /// Release every subscription and scheduler handle the resolver owns.
+    public func clearAll() {
+        lock.lock()
+        let apps = Array(tokensByApp.keys) + Array(scheduleHandlesByApp.keys)
+        lock.unlock()
+        for appId in Set(apps) {
+            clear(appId: appId)
+        }
+    }
+
+    // MARK: - Inspection (test / diagnostics)
+
+    public func boundAppIds() -> Set<String> {
+        lock.lock(); defer { lock.unlock() }
+        return Set(tokensByApp.keys).union(scheduleHandlesByApp.keys)
+    }
+
+    public func subscriptionCount(forAppId appId: String) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return tokensByApp[appId]?.count ?? 0
+    }
+
+    public func scheduleCount(forAppId appId: String) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return scheduleHandlesByApp[appId]?.count ?? 0
+    }
+
+    // MARK: - Binding
+
+    private func bind(subscription: DocumentEventSubscription, appId: String) -> SubscriptionToken {
+        // Each trigger binds to exactly one event type. The handler filters by
+        // `docTypeSelector` and dispatches each action in declared order.
+        switch subscription.trigger {
+        case .onSave, .onUpdate, .onChange:
+            return emitter.subscribe(DocumentSavedEvent.self) { [weak self] event in
+                guard let self, subscription.matches(docType: event.docType) else { return }
+                self.run(
+                    actions: subscription.actions,
+                    origin: .documentEvent(
+                        trigger: subscription.trigger,
+                        documentId: event.document.id,
+                        docType: event.docType
+                    ),
+                    appId: appId
+                )
+            }
+        case .onSubmit:
+            return emitter.subscribe(DocumentSubmittedEvent.self) { [weak self] event in
+                guard let self, subscription.matches(docType: event.docType) else { return }
+                self.run(
+                    actions: subscription.actions,
+                    origin: .documentEvent(
+                        trigger: .onSubmit,
+                        documentId: event.document.id,
+                        docType: event.docType
+                    ),
+                    appId: appId
+                )
+            }
+        case .onCancel:
+            return emitter.subscribe(DocumentCancelledEvent.self) { [weak self] event in
+                guard let self, subscription.matches(docType: event.docType) else { return }
+                self.run(
+                    actions: subscription.actions,
+                    origin: .documentEvent(
+                        trigger: .onCancel,
+                        documentId: event.document.id,
+                        docType: event.docType
+                    ),
+                    appId: appId
+                )
+            }
+        case .onAmend:
+            return emitter.subscribe(DocumentAmendedEvent.self) { [weak self] event in
+                guard let self, subscription.matches(docType: event.docType) else { return }
+                self.run(
+                    actions: subscription.actions,
+                    origin: .documentEvent(
+                        trigger: .onAmend,
+                        documentId: event.newDocumentId,
+                        docType: event.docType
+                    ),
+                    appId: appId
+                )
+            }
+        case .onTrash, .onDelete:
+            return emitter.subscribe(DocumentDeletedEvent.self) { [weak self] event in
+                guard let self, subscription.matches(docType: event.docType) else { return }
+                self.run(
+                    actions: subscription.actions,
+                    origin: .documentEvent(
+                        trigger: subscription.trigger,
+                        documentId: event.documentId,
+                        docType: event.docType
+                    ),
+                    appId: appId
+                )
+            }
+        }
+    }
+
+    private func run(
+        actions: [ExtensionActionDeclaration],
+        origin: ExtensionActionContext.Origin,
+        appId: String
+    ) {
+        let ctx = ExtensionActionContext(appId: appId, origin: origin)
+        for action in actions {
+            do {
+                try dispatcher.dispatch(action: action, context: ctx)
+            } catch {
+                errorReporter?(.dispatchFailed(
+                    appId: appId,
+                    actionType: action.actionType,
+                    underlying: error
+                ))
+            }
+        }
+    }
+
+    // MARK: - Errors
+
+    public enum ResolverError: Error, Sendable {
+        case dispatchFailed(appId: String, actionType: String, underlying: Error)
+    }
+}

--- a/mercantis core/AppRuntime/ExtensionPoints.swift
+++ b/mercantis core/AppRuntime/ExtensionPoints.swift
@@ -1,0 +1,177 @@
+//
+//  ExtensionPoints.swift
+//  mercantis core
+//
+//  Created by Kevin Busuttil on 24/04/2026.
+//
+
+import Foundation
+
+/// Declarative extension points carried by an `AppManifest`. (ADR-015, ADR-026)
+///
+/// Apps declare lifecycle-event subscriptions and scheduled task registrations
+/// here instead of shipping Python-style `hooks.py` code. `ExtensionPointResolver`
+/// binds these declarations to the `EventEmitter` / `SchedulerService` at install
+/// time.
+public struct ExtensionPoints: Codable, Sendable, Equatable {
+    public var documentEventSubscriptions: [DocumentEventSubscription]
+    public var schedulerEvents: [SchedulerEventDeclaration]
+
+    public init(
+        documentEventSubscriptions: [DocumentEventSubscription] = [],
+        schedulerEvents: [SchedulerEventDeclaration] = []
+    ) {
+        self.documentEventSubscriptions = documentEventSubscriptions
+        self.schedulerEvents = schedulerEvents
+    }
+
+    public static let empty = ExtensionPoints()
+
+    enum CodingKeys: String, CodingKey {
+        case documentEventSubscriptions
+        case schedulerEvents
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        documentEventSubscriptions = try container
+            .decodeIfPresent([DocumentEventSubscription].self, forKey: .documentEventSubscriptions) ?? []
+        schedulerEvents = try container
+            .decodeIfPresent([SchedulerEventDeclaration].self, forKey: .schedulerEvents) ?? []
+    }
+}
+
+// MARK: - Document Event Subscription
+
+/// One declarative subscription to a document lifecycle event. (ADR-015)
+///
+/// `docTypeSelector` is either a specific DocType id or `"*"` for all DocTypes.
+/// When the declared `trigger` fires for a matching document, each entry in
+/// `actions` is dispatched via `ExtensionActionDispatcher`.
+public struct DocumentEventSubscription: Codable, Sendable, Equatable {
+    public var id: String
+    public var docTypeSelector: String      // specific DocType id, or "*" for all
+    public var trigger: DocumentEventTrigger
+    public var actions: [ExtensionActionDeclaration]
+
+    public init(
+        id: String,
+        docTypeSelector: String,
+        trigger: DocumentEventTrigger,
+        actions: [ExtensionActionDeclaration]
+    ) {
+        self.id = id
+        self.docTypeSelector = docTypeSelector
+        self.trigger = trigger
+        self.actions = actions
+    }
+
+    /// True when this subscription applies to `docType`.
+    public func matches(docType: String) -> Bool {
+        docTypeSelector == "*" || docTypeSelector == docType
+    }
+}
+
+/// Document lifecycle triggers understood by the resolver. (ADR-015)
+///
+/// The Frappe-style aliases `on_update`, `on_change`, and `on_save` all bind to
+/// `DocumentSavedEvent`; Mercantis does not currently distinguish insert-vs-update
+/// at the event layer. `after_insert` is intentionally rejected until the event
+/// carries an "isNew" flag — see known follow-ups in `ExtensionPointResolver`.
+public enum DocumentEventTrigger: String, Codable, Sendable, CaseIterable {
+    case onSave      = "on_save"
+    case onUpdate    = "on_update"
+    case onChange    = "on_change"
+    case onSubmit    = "on_submit"
+    case onCancel    = "on_cancel"
+    case onAmend     = "on_amend"
+    case onTrash     = "on_trash"
+    case onDelete    = "on_delete"
+}
+
+// MARK: - Scheduler Event Declaration
+
+/// One declarative scheduled task registration. (ADR-015)
+///
+/// The resolver forwards this to `ExtensionSchedulerRegistrar`. Until the
+/// `SchedulerService` (P1.4) ships, the default registrar records the
+/// declaration without arming a timer.
+public struct SchedulerEventDeclaration: Codable, Sendable, Equatable {
+    public var id: String
+    public var interval: ScheduleInterval
+    public var actions: [ExtensionActionDeclaration]
+
+    public init(
+        id: String,
+        interval: ScheduleInterval,
+        actions: [ExtensionActionDeclaration]
+    ) {
+        self.id = id
+        self.interval = interval
+        self.actions = actions
+    }
+}
+
+/// Scheduler cadences understood by the resolver. (ADR-015)
+public enum ScheduleInterval: Codable, Sendable, Equatable {
+    case all            // every tick
+    case hourly
+    case daily
+    case weekly
+    case monthly
+    case cron(String)   // cron expression (see P1.4 for supported subset)
+
+    private enum Kind: String, Codable {
+        case all, hourly, daily, weekly, monthly, cron
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, expression
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .all:              try c.encode(Kind.all, forKey: .kind)
+        case .hourly:           try c.encode(Kind.hourly, forKey: .kind)
+        case .daily:            try c.encode(Kind.daily, forKey: .kind)
+        case .weekly:           try c.encode(Kind.weekly, forKey: .kind)
+        case .monthly:          try c.encode(Kind.monthly, forKey: .kind)
+        case .cron(let expr):
+            try c.encode(Kind.cron, forKey: .kind)
+            try c.encode(expr, forKey: .expression)
+        }
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try c.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .all:     self = .all
+        case .hourly:  self = .hourly
+        case .daily:   self = .daily
+        case .weekly:  self = .weekly
+        case .monthly: self = .monthly
+        case .cron:
+            let expr = try c.decode(String.self, forKey: .expression)
+            self = .cron(expr)
+        }
+    }
+}
+
+// MARK: - Action Declaration
+
+/// One built-in action to execute when a subscription fires. (ADR-015, ADR-025)
+///
+/// `actionType` is resolved by `ExtensionActionDispatcher` — typically against
+/// the `AutomationActionRegistry` once P1.2 lands. `parameters` is the raw
+/// map from the manifest; handlers interpret it per-action-type.
+public struct ExtensionActionDeclaration: Codable, Sendable, Equatable {
+    public var actionType: String
+    public var parameters: [String: String]
+
+    public init(actionType: String, parameters: [String: String] = [:]) {
+        self.actionType = actionType
+        self.parameters = parameters
+    }
+}

--- a/mercantis coreTests/ExtensionPointsTests.swift
+++ b/mercantis coreTests/ExtensionPointsTests.swift
@@ -1,0 +1,390 @@
+//
+//  ExtensionPointsTests.swift
+//  mercantis coreTests
+//
+//  Covers declarative extension-point resolution at install time. (ADR-015,
+//  ADR-026, P1.3)
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class ExtensionPointsTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+    private var dispatcher: LoggingExtensionActionDispatcher!
+    private var schedulerRegistrar: RecordingExtensionSchedulerRegistrar!
+    private var resolver: ExtensionPointResolver!
+    private var installer: AppInstaller!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness()
+        dispatcher = LoggingExtensionActionDispatcher()
+        schedulerRegistrar = RecordingExtensionSchedulerRegistrar()
+        resolver = ExtensionPointResolver(
+            emitter: harness.emitter,
+            dispatcher: dispatcher,
+            schedulerRegistrar: schedulerRegistrar
+        )
+        installer = AppInstaller(
+            database: harness.database,
+            schemaValidator: SchemaValidator(),
+            registry: harness.registry,
+            extensionResolver: resolver
+        )
+    }
+
+    override func tearDown() {
+        resolver?.clearAll()
+        TestSupport.cleanUp(databaseURL: harness.url)
+        harness = nil
+        dispatcher = nil
+        schedulerRegistrar = nil
+        resolver = nil
+        installer = nil
+    }
+
+    // MARK: - Manifest decoding
+
+    func testManifestDecodesWithoutExtensionPointsField() throws {
+        // Pre-P1.3 manifests omit the `extensionPoints` key entirely.
+        let json = """
+        {
+            "id": "app.mercantis.legacy",
+            "name": "Legacy",
+            "version": "0.1.0",
+            "minimumCoreVersion": "1.0.0",
+            "description": "",
+            "doctypes": [],
+            "workflows": [],
+            "permissions": [],
+            "reports": [],
+            "automationRules": [],
+            "dashboards": [],
+            "localizations": []
+        }
+        """.data(using: .utf8)!
+
+        let manifest = try JSONDecoder().decode(AppManifest.self, from: json)
+        XCTAssertEqual(manifest.extensionPoints, .empty)
+    }
+
+    func testManifestRejectsUnsupportedTrigger() {
+        let json = """
+        {
+            "id": "app.mercantis.invalid",
+            "name": "Invalid",
+            "version": "0.1.0",
+            "minimumCoreVersion": "1.0.0",
+            "description": "",
+            "doctypes": [],
+            "workflows": [],
+            "permissions": [],
+            "reports": [],
+            "automationRules": [],
+            "dashboards": [],
+            "localizations": [],
+            "extensionPoints": {
+                "documentEventSubscriptions": [{
+                    "id": "s1",
+                    "docTypeSelector": "*",
+                    "trigger": "after_insert",
+                    "actions": []
+                }],
+                "schedulerEvents": []
+            }
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertThrowsError(try JSONDecoder().decode(AppManifest.self, from: json))
+    }
+
+    // MARK: - Installer wiring
+
+    func testInstallAppliesExtensionPointsAndUninstallReleasesThem() throws {
+        let manifest = Self.makeManifest(
+            id: "app.test.wiring",
+            docType: Self.invoiceDocType(appId: "app.test.wiring"),
+            subscription: DocumentEventSubscription(
+                id: "sub-1",
+                docTypeSelector: "SalesInvoice",
+                trigger: .onSubmit,
+                actions: [ExtensionActionDeclaration(actionType: "send_notification")]
+            )
+        )
+
+        try installer.install(manifest)
+
+        XCTAssertEqual(resolver.subscriptionCount(forAppId: manifest.id), 1)
+        XCTAssertTrue(resolver.boundAppIds().contains(manifest.id))
+
+        try installer.uninstall(appId: manifest.id)
+
+        XCTAssertEqual(resolver.subscriptionCount(forAppId: manifest.id), 0)
+        XCTAssertFalse(resolver.boundAppIds().contains(manifest.id))
+    }
+
+    func testReinstallIsIdempotent() throws {
+        let manifest = Self.makeManifest(
+            id: "app.test.reinstall",
+            docType: Self.invoiceDocType(appId: "app.test.reinstall"),
+            subscription: DocumentEventSubscription(
+                id: "sub-1",
+                docTypeSelector: "*",
+                trigger: .onSave,
+                actions: [ExtensionActionDeclaration(actionType: "set_value")]
+            )
+        )
+
+        try installer.install(manifest)
+        try installer.install(manifest)
+
+        XCTAssertEqual(
+            resolver.subscriptionCount(forAppId: manifest.id), 1,
+            "reinstall must clear prior bindings rather than accumulate"
+        )
+    }
+
+    func testSchedulerDeclarationsRegisterAndReleaseWithApp() throws {
+        let manifest = Self.makeManifest(
+            id: "app.test.sched",
+            docType: Self.invoiceDocType(appId: "app.test.sched"),
+            subscription: nil,
+            schedulerEvents: [
+                SchedulerEventDeclaration(
+                    id: "daily-reminder",
+                    interval: .daily,
+                    actions: [ExtensionActionDeclaration(actionType: "send_notification")]
+                )
+            ]
+        )
+
+        try installer.install(manifest)
+
+        XCTAssertEqual(resolver.scheduleCount(forAppId: manifest.id), 1)
+        XCTAssertEqual(
+            schedulerRegistrar.entries,
+            [RecordingExtensionSchedulerRegistrar.Entry(
+                appId: "app.test.sched",
+                declarationId: "daily-reminder"
+            )]
+        )
+
+        try installer.uninstall(appId: manifest.id)
+
+        XCTAssertEqual(resolver.scheduleCount(forAppId: manifest.id), 0)
+        XCTAssertTrue(schedulerRegistrar.entries.isEmpty)
+    }
+
+    // MARK: - Event dispatch
+
+    func testOnSubmitSubscriptionFiresOnMatchingDocType() throws {
+        let docType = Self.invoiceDocType(appId: "app.test.dispatch", isSubmittable: true)
+        let manifest = Self.makeManifest(
+            id: "app.test.dispatch",
+            docType: docType,
+            subscription: DocumentEventSubscription(
+                id: "sub-submit",
+                docTypeSelector: "SalesInvoice",
+                trigger: .onSubmit,
+                actions: [
+                    ExtensionActionDeclaration(
+                        actionType: "send_notification",
+                        parameters: ["channel": "ops"]
+                    )
+                ]
+            )
+        )
+
+        try installer.install(manifest)
+
+        var saved = try harness.engine.save(
+            TestSupport.makeDocument(
+                id: "SI-001",
+                docType: "SalesInvoice",
+                fields: ["grandTotal": .double(100)]
+            )
+        )
+        try harness.engine.submit(&saved)
+
+        let entries = dispatcher.entries
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.actionType, "send_notification")
+        XCTAssertEqual(entries.first?.appId, "app.test.dispatch")
+        XCTAssertEqual(entries.first?.parameters["channel"], "ops")
+    }
+
+    func testDocTypeSelectorSkipsNonMatchingDocTypes() throws {
+        try harness.registry.register(
+            TestSupport.makeDocType(
+                id: "Note",
+                appId: "app.test.selector",
+                fields: [TestSupport.textField("title", required: true)]
+            )
+        )
+
+        let invoice = Self.invoiceDocType(appId: "app.test.selector")
+        let manifest = Self.makeManifest(
+            id: "app.test.selector",
+            docType: invoice,
+            subscription: DocumentEventSubscription(
+                id: "sub-invoice-only",
+                docTypeSelector: "SalesInvoice",
+                trigger: .onSave,
+                actions: [ExtensionActionDeclaration(actionType: "log")]
+            )
+        )
+
+        try installer.install(manifest)
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "note-1",
+            docType: "Note",
+            fields: ["title": .string("ignored")]
+        ))
+        XCTAssertTrue(
+            dispatcher.entries.isEmpty,
+            "docTypeSelector == SalesInvoice must skip Note save"
+        )
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-002",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(25)]
+        ))
+        XCTAssertEqual(dispatcher.entries.count, 1)
+    }
+
+    func testWildcardSelectorMatchesEveryDocType() throws {
+        try harness.registry.register(
+            TestSupport.makeDocType(
+                id: "Note",
+                appId: "app.test.wild",
+                fields: [TestSupport.textField("title", required: true)]
+            )
+        )
+        let manifest = Self.makeManifest(
+            id: "app.test.wild",
+            docType: Self.invoiceDocType(appId: "app.test.wild"),
+            subscription: DocumentEventSubscription(
+                id: "sub-*",
+                docTypeSelector: "*",
+                trigger: .onSave,
+                actions: [ExtensionActionDeclaration(actionType: "log")]
+            )
+        )
+        try installer.install(manifest)
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "note-1", docType: "Note", fields: ["title": .string("x")]
+        ))
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-003", docType: "SalesInvoice", fields: ["grandTotal": .double(1)]
+        ))
+
+        XCTAssertEqual(dispatcher.entries.count, 2)
+    }
+
+    func testUninstallStopsDispatchingEventsForThatApp() throws {
+        let manifest = Self.makeManifest(
+            id: "app.test.teardown",
+            docType: Self.invoiceDocType(appId: "app.test.teardown"),
+            subscription: DocumentEventSubscription(
+                id: "sub-save",
+                docTypeSelector: "*",
+                trigger: .onSave,
+                actions: [ExtensionActionDeclaration(actionType: "log")]
+            )
+        )
+        try installer.install(manifest)
+        try installer.uninstall(appId: manifest.id)
+
+        // DocType is gone from the registry after uninstall; re-register so
+        // the save goes through with full validation.
+        try harness.registry.register(Self.invoiceDocType(appId: "app.test.teardown"))
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-004", docType: "SalesInvoice", fields: ["grandTotal": .double(5)]
+        ))
+
+        XCTAssertTrue(
+            dispatcher.entries.isEmpty,
+            "uninstall must release the subscription before the save fires"
+        )
+    }
+
+    // MARK: - Restore
+
+    func testRestoreReappliesBindingsForAlreadyInstalledApps() throws {
+        let manifest = Self.makeManifest(
+            id: "app.test.restore",
+            docType: Self.invoiceDocType(appId: "app.test.restore"),
+            subscription: DocumentEventSubscription(
+                id: "sub-save",
+                docTypeSelector: "*",
+                trigger: .onSave,
+                actions: [ExtensionActionDeclaration(actionType: "log")]
+            )
+        )
+        try installer.install(manifest)
+
+        // Simulate a process restart: discard every in-memory binding.
+        resolver.clearAll()
+        XCTAssertEqual(resolver.subscriptionCount(forAppId: manifest.id), 0)
+
+        let applied = try installer.restoreExtensionPoints()
+        XCTAssertEqual(applied, [manifest.id])
+        XCTAssertEqual(resolver.subscriptionCount(forAppId: manifest.id), 1)
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-restore", docType: "SalesInvoice", fields: ["grandTotal": .double(1)]
+        ))
+        XCTAssertEqual(dispatcher.entries.count, 1)
+    }
+
+    // MARK: - Fixtures
+
+    private static func invoiceDocType(
+        appId: String,
+        isSubmittable: Bool = false
+    ) -> DocType {
+        TestSupport.makeDocType(
+            id: "SalesInvoice",
+            appId: appId,
+            fields: [
+                TestSupport.numberField("grandTotal")
+            ],
+            isSubmittable: isSubmittable,
+            syncPolicy: isSubmittable
+                ? TestSupport.submittableSyncPolicy()
+                : TestSupport.defaultSyncPolicy(),
+            titleField: "grandTotal"
+        )
+    }
+
+    private static func makeManifest(
+        id: String,
+        docType: DocType,
+        subscription: DocumentEventSubscription?,
+        schedulerEvents: [SchedulerEventDeclaration] = []
+    ) -> AppManifest {
+        AppManifest(
+            id: id,
+            name: id,
+            version: "0.1.0",
+            minimumCoreVersion: "1.0.0",
+            description: "",
+            doctypes: [docType],
+            workflows: [],
+            permissions: [],
+            reports: [],
+            automationRules: [],
+            dashboards: [],
+            localizations: [],
+            extensionPoints: ExtensionPoints(
+                documentEventSubscriptions: subscription.map { [$0] } ?? [],
+                schedulerEvents: schedulerEvents
+            )
+        )
+    }
+}


### PR DESCRIPTION
Adds `AppManifest.extensionPoints` and `ExtensionPointResolver`: installing a manifest now binds declared document-lifecycle subscriptions to the typed `EventEmitter` and forwards scheduled-task declarations to an `ExtensionSchedulerRegistrar`. Per-app tokens and handles are released on uninstall; `AppInstaller.restoreExtensionPoints()` re-binds on launch.

Action dispatch routes through `ExtensionActionDispatcher` so P1.2's `AutomationActionRegistry` can plug in without further resolver changes; a logging dispatcher ships as the default to keep tests wiring-verifiable.

https://claude.ai/code/session_01TDM7UfpZeyajZbochpLUnA