### PR TITLE
Implement P1.2 automation runtime with action registry and handlers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -541,9 +541,18 @@ The tree below reflects what is actually on disk today. Subsystems described in 
 mercantis core/
 ├── mercantis_coreApp.swift       # @main SwiftUI entry point
 ├── AppRuntime/
-│   ├── AppInstaller.swift        # Installs/uninstalls app manifests
+│   ├── AppInstaller.swift        # Installs/uninstalls app manifests; wires ExtensionPointResolver + AutomationRunner
 │   ├── AppManifest.swift         # Codable manifest struct
-│   └── AppRuntimeTypes.swift     # WorkflowDefinition, ReportDefinition, AutomationRule, DashboardDefinition, LocalizationBundle, …
+│   ├── AppRuntimeTypes.swift     # WorkflowDefinition, ReportDefinition, AutomationRule, DashboardDefinition, LocalizationBundle, …
+│   ├── ExtensionPoints.swift     # DocumentEventSubscription, SchedulerEventDeclaration, ExtensionActionDeclaration
+│   └── ExtensionPointResolver.swift # Binds manifest extension points to EventEmitter + scheduler
+├── Automation/
+│   ├── AutomationActionHandler.swift       # AutomationActionHandler protocol + AutomationContext + AutomationActionError
+│   ├── AutomationActionRegistry.swift      # Registry keyed by actionType (ADR-025)
+│   ├── BuiltInActionHandlers.swift         # set_value / set_status / send_notification / validate / assign
+│   ├── AutomationSinks.swift               # NotificationLogWriter / AssignmentLogWriter + in-memory defaults
+│   ├── AutomationRunner.swift              # Subscribes to document events, matches AppManifest.automationRules
+│   └── AutomationActionDispatcher.swift    # Bridges registry → ExtensionActionDispatcher seam for P1.3
 ├── Customization/
 │   ├── CustomField.swift         # Runtime field additions to existing DocTypes
 │   └── PropertySetter.swift      # Per-field property overrides
@@ -603,7 +612,6 @@ mercantis core/
 
 | Subsystem | §s | ADRs | Proposal |
 |---|---|---|---|
-| `Automation/` — action registry + built-in handlers | §4.13 | ADR-019, ADR-025 | P1.2 |
 | `Cache/` — cross-subsystem `CacheManager` | §4.14 | — | P3.4 |
 | `Files/` — attachments + sandboxed storage | §4.18 | — | P3.1 |
 | `ImportExport/` — CSV/JSON importer + exporter + fixtures | §4.20 | — | P3.3 |

--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -1,6 +1,6 @@
 # Enhancement Proposal
 
-_Last updated: 2026-04-24 (P1.3 — Extension-point resolution shipped)_
+_Last updated: 2026-04-24 (P1.2 — Automation runtime shipped)_
 
 Companion document to [`IMPLEMENTATION-STATUS.md`](./IMPLEMENTATION-STATUS.md). The status doc catalogues _what is_; this doc proposes _what to do next_. Each item is labelled with effort (S/M/L), risk, and the ADR or architecture section it closes.
 
@@ -159,19 +159,64 @@ mercantis core/Naming/
 - Offline multi-device counter reconciliation via the sync queue is not implemented — ADR-014 calls out per-device range reservation; today two devices saving offline will both start at `SINV-2026-0001`.
 - `amend` still allocates a raw UUID for the new draft rather than routing through `NamingService`. Reasonable for now; worth revisiting if amended copies need series IDs.
 
-### P1.2 — Implement the Automation runtime [L, medium risk] — ADR-019 / ADR-025
+### P1.2 — Implement the Automation runtime [L, medium risk] — ADR-019 / ADR-025 *(done — 2026-04-24)*
 
-`AppManifest.automationRules` decodes but nothing executes them. Minimum viable:
+`mercantis core/Automation/` ships the P1.2 runtime described below. Handlers
+use the registry-based dispatch required by ADR-025; new action types are
+added by registering an `AutomationActionHandler` conformance compiled into
+Core (downloaded apps cannot).
 
 ```
 mercantis core/Automation/
-├── AutomationActionHandler.swift    // protocol: actionType, execute(document:parameters:context:)
-├── AutomationActionRegistry.swift   // register / lookup / execute
-├── BuiltInActionHandlers.swift      // SetValueHandler, SetStatusHandler, SendNotificationHandler (log-only for now), ValidateHandler, AssignHandler
-└── AutomationRunner.swift           // subscribes to DocumentSavedEvent / DocumentSubmittedEvent, matches rules, dispatches handlers
+├── AutomationActionHandler.swift       // protocol: actionType + execute(document:parameters:context:), AutomationContext, AutomationActionError
+├── AutomationActionRegistry.swift      // register / unregister / handler(for:) / execute(...); replaces earlier entries on duplicate register
+├── BuiltInActionHandlers.swift         // SetValueHandler, SetStatusHandler, SendNotificationHandler, ValidateHandler, AssignHandler; FieldValueDecoder + ParameterInterpolator helpers
+├── AutomationSinks.swift               // NotificationLogWriter / AssignmentLogWriter protocols + in-memory defaults (log-only, no migration)
+├── AutomationRunner.swift              // subscribes to DocumentSavedEvent / DocumentSubmittedEvent / DocumentCancelledEvent; matches AppManifest.automationRules; re-entrancy guard on document id
+└── AutomationActionDispatcher.swift    // fills the P1.3 ExtensionActionDispatcher seam so manifest-declared documentEventSubscriptions route through the same registry
 ```
 
-Depends on P1.3 (extension-point resolution) to actually bind a manifest's rule set to the event bus at install time.
+`AppInstaller` now takes an optional `automationRunner:` parameter and, on
+`install` / `uninstall` / `restoreExtensionPoints`, registers or releases the
+manifest's `automationRules` alongside the P1.3 extension-point bindings.
+`DocumentEngine` gains an `AutomationDocumentGateway` conformance (via a thin
+extension) so the runner and dispatcher can reload the canonical document
+before running handlers and write the mutation back post-commit.
+
+The built-ins map to ADR-025's action-type table:
+
+- `set_value` — writes one field; `FieldValueDecoder` infers the `FieldValue` case from the string literal (or honours an explicit `type` parameter: `string | int | double | bool | null`).
+- `set_status` — writes `document.status`. Does not touch ADR-013's `docStatus`; that remains the job of `DocumentEngine.submit` / `cancel` / `amend`.
+- `send_notification` — writes one `NotificationLogEntry` to the injected `NotificationLogWriter`. `subject` / `body` support `{field}` placeholders expanded from the document's field map.
+- `validate` — evaluates a boolean expression via `ExpressionEvaluator` and throws `AutomationActionError.validationFailed` when the condition is false. Intended to block saves when run inside the save transaction; post-commit it surfaces the failure to the runner / dispatcher's error reporter.
+- `assign` — writes one `AssignmentLogEntry` (user or role target) to the injected `AssignmentLogWriter`.
+
+Coverage in `AutomationTests.swift` (25 tests): each handler's happy-path and
+missing-parameter branches, the registry's unknown-action-type guard and
+handler-replacement semantics, `FieldValueDecoder`'s inference table,
+`ParameterInterpolator`'s placeholder handling, the runner's condition
+evaluation and Frappe-style `on_update` / `on_change` / `onSave` alias
+matching, the re-entrancy guard that breaks `set_value`-rewrites-save loops,
+the on-submit-only dispatch path, `AppInstaller` → runner register/unregister
+wiring, end-to-end dispatch through `ExtensionPointResolver` via
+`AutomationActionDispatcher`, and scheduler-origin placeholder dispatch.
+
+**Known follow-ups (not scoped to P1.2):**
+- Pre-commit blocking `validate` — ADR-019 calls for the automation runtime
+  to execute inside the save transaction so a failing action rolls back the
+  write. That requires threading the runner through
+  `DocumentEngine.save(_:)` (new parameter + new coverage), which is deferred
+  beyond P1.2. Post-commit `validate` still runs; it reports the failure via
+  `RunnerError.ruleFailed` but the commit is not rolled back.
+- Persistent `notification_log` / `assignment_log` tables — handlers write to
+  in-memory sinks today. Adding migrations before P1.4 (Scheduler) can drive
+  real notification delivery would be premature.
+- Scheduler-triggered rules — `AppManifest.automationRules` with
+  `triggerEvent == "onSchedule"` are registered but never fire. P1.4's
+  `SchedulerService` will drive them.
+- `AutomationActionDispatcher` running scheduler-origin actions against a
+  placeholder `Document` is a minimal path; when a real schedule runs, the
+  handler set needs a context shape that doesn't pretend there's a document.
 
 ### P1.3 — Implement extension-point resolution at install time [M, medium risk] — ADR-015 / ADR-026 *(done — 2026-04-24)*
 
@@ -405,7 +450,7 @@ The subsystems explicitly recorded as missing in `IMPLEMENTATION-STATUS.md` are 
 | Missing subsystem | Why it matters for Hub |
 |---|---|
 | ~~Naming (ADR-014, P1.1)~~ ✅ shipped 2026-04-23 | Hub documents can now declare `autoname: "naming_series:SINV-.YYYY.-.####"` and get ERP-shaped IDs. Offline multi-device counter reconciliation is the remaining gap. |
-| Automation runtime (ADR-019/025, P1.2/P1.3) | "On submit, deduct stock" is a basic ERP rule. Without the automation runtime, every such rule must be hard-coded in Hub's own Swift — which is exactly what ADR-007 prohibits. |
+| ~~Automation runtime (ADR-019/025, P1.2/P1.3)~~ ✅ shipped 2026-04-24 | Declarative `AutomationRule`s and `documentEventSubscription`s now route through `AutomationActionRegistry`. "On submit, deduct stock" is expressible as a `set_value` / `validate` pair on the manifest side. Remaining gaps: pre-commit blocking inside the save transaction, scheduler-driven rules (P1.4), and persistent notification / assignment storage. |
 | Files / Attachments (§4.18, P3.1) | Attaching PDFs, images, and supplier documents to records is table-stakes for back-office ERP. |
 | Import / Export (§4.20, P3.3) | Opening-balance imports and data migration are day-one practical needs for any real deployment. |
 | Printing / PDF (§4.17, P3.2) | Invoices, purchase orders, and delivery notes must be printable. |
@@ -484,7 +529,7 @@ A 4–6 week plan if one engineer is the target:
 | 3 | P0.5A (rewrite permissions doc) ✅; P0.5B (implement chain) deferred; P0.8 version reader ✅; P1.5 real validation stages ✅. |
 | 4 | P1.1 Naming subsystem ✅ (2026-04-23). |
 | 5 | P1.3 Extension-point resolution ✅ (2026-04-24). |
-| 6 | P1.2 Automation runtime (fills the `ExtensionActionDispatcher` seam). |
+| 6 | P1.2 Automation runtime ✅ (2026-04-24) (fills the `ExtensionActionDispatcher` seam). |
 
 P1.4 Scheduler, P1.6 FieldValue expansion, and P1.7 row-level expressions slot in as individual PRs alongside the above.
 

--- a/mercantis core/AppRuntime/AppInstaller.swift
+++ b/mercantis core/AppRuntime/AppInstaller.swift
@@ -17,17 +17,20 @@ public final class AppInstaller {
     private let schemaValidator: SchemaValidator
     private let registry: MetadataRegistry
     private let extensionResolver: ExtensionPointResolver?
+    private let automationRunner: AutomationRunner?
 
     public init(
         database: MercantisDatabase,
         schemaValidator: SchemaValidator,
         registry: MetadataRegistry,
-        extensionResolver: ExtensionPointResolver? = nil
+        extensionResolver: ExtensionPointResolver? = nil,
+        automationRunner: AutomationRunner? = nil
     ) {
         self.database = database
         self.schemaValidator = schemaValidator
         self.registry = registry
         self.extensionResolver = extensionResolver
+        self.automationRunner = automationRunner
     }
 
     // MARK: - Install
@@ -152,6 +155,11 @@ public final class AppInstaller {
         // idempotent — the resolver clears prior bindings for this app id
         // before rebinding.
         extensionResolver?.apply(manifest: manifest)
+
+        // 8. Register `AutomationRule`s with the runner (ADR-019, P1.2).
+        // `register(rules:appId:)` replaces any prior rule set for this app,
+        // matching reinstall semantics above.
+        automationRunner?.register(rules: manifest.automationRules, appId: manifest.id)
     }
 
     // MARK: - Uninstall
@@ -220,6 +228,10 @@ public final class AppInstaller {
         //    (ADR-015, P1.3). Safe when no resolver is wired or when the app
         //    had no declarations.
         extensionResolver?.clear(appId: appId)
+
+        // 9. Release the app's `AutomationRule`s from the runner
+        //    (ADR-019, P1.2). Safe when no runner is wired.
+        automationRunner?.unregister(appId: appId)
     }
 
     // MARK: - Restore
@@ -235,7 +247,7 @@ public final class AppInstaller {
     public func restoreExtensionPoints(
         onDecodeFailure: ((_ appId: String, _ error: Error) -> Void)? = nil
     ) throws -> [String] {
-        guard let extensionResolver else { return [] }
+        guard extensionResolver != nil || automationRunner != nil else { return [] }
 
         let rows: [(appId: String, payload: String)] = try database.read { db in
             let fetched = try Row.fetchAll(db, sql: "SELECT id, payload FROM apps")
@@ -255,7 +267,11 @@ public final class AppInstaller {
             guard let data = row.payload.data(using: .utf8) else { continue }
             do {
                 let manifest = try decoder.decode(AppManifest.self, from: data)
-                extensionResolver.apply(manifest: manifest)
+                extensionResolver?.apply(manifest: manifest)
+                automationRunner?.register(
+                    rules: manifest.automationRules,
+                    appId: manifest.id
+                )
                 applied.append(row.appId)
             } catch {
                 onDecodeFailure?(row.appId, error)

--- a/mercantis core/AppRuntime/ExtensionPointResolver.swift
+++ b/mercantis core/AppRuntime/ExtensionPointResolver.swift
@@ -12,9 +12,11 @@ import Foundation
 /// Executes a single built-in action declared in a manifest. (ADR-025, P1.2)
 ///
 /// `ExtensionPointResolver` delegates to this protocol so the automation action
-/// registry (P1.2) and the resolver can ship independently. Until P1.2 lands,
-/// `LoggingExtensionActionDispatcher` is the default — it logs each dispatch
-/// and records it in an inspectable trail so tests can assert wiring.
+/// registry (P1.2) and the resolver stay decoupled. P1.2 ships
+/// `AutomationActionDispatcher` as the production conformance; the resolver
+/// keeps `LoggingExtensionActionDispatcher` as its default so tests and
+/// headless diagnostics can assert wiring without pulling in the automation
+/// runtime.
 public protocol ExtensionActionDispatcher: AnyObject, Sendable {
     /// Dispatch one action declared in an app manifest.
     ///
@@ -72,7 +74,8 @@ public struct ExtensionActionContext: Sendable {
 // MARK: - Default implementations
 
 /// Default dispatcher that records each call without touching document state.
-/// Replaced by the real `AutomationActionRegistry` when P1.2 lands.
+/// Replaced by `AutomationActionDispatcher` (P1.2) when the host wires the
+/// automation runtime into the resolver.
 public final class LoggingExtensionActionDispatcher: ExtensionActionDispatcher, @unchecked Sendable {
     public struct Entry: Sendable, Equatable {
         public let appId: String

--- a/mercantis core/AppRuntime/ExtensionPoints.swift
+++ b/mercantis core/AppRuntime/ExtensionPoints.swift
@@ -164,7 +164,7 @@ public enum ScheduleInterval: Codable, Sendable, Equatable {
 /// One built-in action to execute when a subscription fires. (ADR-015, ADR-025)
 ///
 /// `actionType` is resolved by `ExtensionActionDispatcher` — typically against
-/// the `AutomationActionRegistry` once P1.2 lands. `parameters` is the raw
+/// the `AutomationActionRegistry` (P1.2 / ADR-025). `parameters` is the raw
 /// map from the manifest; handlers interpret it per-action-type.
 public struct ExtensionActionDeclaration: Codable, Sendable, Equatable {
     public var actionType: String

--- a/mercantis core/Automation/AutomationActionDispatcher.swift
+++ b/mercantis core/Automation/AutomationActionDispatcher.swift
@@ -1,0 +1,191 @@
+//
+//  AutomationActionDispatcher.swift
+//  mercantis core
+//
+//  P1.2 — Bridges `AutomationActionRegistry` to the
+//  `ExtensionActionDispatcher` seam exposed by P1.3's
+//  `ExtensionPointResolver`. Satisfies the "P1.2 fills the
+//  ExtensionActionDispatcher seam" item in the sequencing plan.
+//
+
+import Foundation
+
+/// `ExtensionActionDispatcher` conformance that routes declarative
+/// `ExtensionActionDeclaration`s through the shared
+/// `AutomationActionRegistry`.
+///
+/// ### Responsibilities
+///
+/// 1. Translate `ExtensionActionContext.Origin` into the corresponding
+///    `AutomationContext` (appId, trigger, docType, documentId).
+/// 2. For document-origin invocations: load the document via the injected
+///    `AutomationDocumentGateway`, run the handler in-place, and persist
+///    mutations. When no gateway is configured the handler runs against a
+///    placeholder document — fine for `send_notification` / `assign`, a
+///    no-op for `set_value` / `set_status` because the mutated value has
+///    nowhere to go.
+/// 3. For scheduler-origin invocations: run the handler against an empty
+///    placeholder document. Scheduler triggers are document-less by design;
+///    a handler that needs fields should not be wired to a scheduler rule.
+///
+/// ### Re-entrancy
+///
+/// The dispatcher tracks the document ids currently being processed in the
+/// same way as `AutomationRunner`. A handler that writes the document back
+/// re-fires `DocumentSavedEvent`, which could hit another manifest
+/// subscription and loop — the per-document guard breaks the cycle.
+public final class AutomationActionDispatcher: ExtensionActionDispatcher, @unchecked Sendable {
+
+    private let registry: AutomationActionRegistry
+    private let gateway: AutomationDocumentGateway?
+    private let notificationSink: NotificationLogWriter
+    private let assignmentSink: AssignmentLogWriter
+    private let expressionEvaluator: ExpressionEvaluator
+    private let userId: String
+    private let clock: @Sendable () -> Date
+
+    private let lock = NSLock()
+    private var inFlightDocIds: Set<String> = []
+
+    public init(
+        registry: AutomationActionRegistry = AutomationActionRegistry(),
+        gateway: AutomationDocumentGateway? = nil,
+        notificationSink: NotificationLogWriter = InMemoryNotificationLog(),
+        assignmentSink: AssignmentLogWriter = InMemoryAssignmentLog(),
+        expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator(),
+        userId: String = "",
+        clock: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.registry = registry
+        self.gateway = gateway
+        self.notificationSink = notificationSink
+        self.assignmentSink = assignmentSink
+        self.expressionEvaluator = expressionEvaluator
+        self.userId = userId
+        self.clock = clock
+    }
+
+    // MARK: - ExtensionActionDispatcher
+
+    public func dispatch(
+        action: ExtensionActionDeclaration,
+        context: ExtensionActionContext
+    ) throws {
+        switch context.origin {
+        case let .documentEvent(trigger, documentId, docType):
+            try dispatchDocumentAction(
+                action: action,
+                appId: context.appId,
+                trigger: trigger.rawValue,
+                documentId: documentId,
+                docType: docType
+            )
+        case let .scheduler(declarationId, _):
+            try dispatchSchedulerAction(
+                action: action,
+                appId: context.appId,
+                declarationId: declarationId
+            )
+        }
+    }
+
+    // MARK: - Private
+
+    private func dispatchDocumentAction(
+        action: ExtensionActionDeclaration,
+        appId: String,
+        trigger: String,
+        documentId: String,
+        docType: String
+    ) throws {
+        // Re-entrancy guard. Handlers that mutate the document and write it
+        // back will fire DocumentSavedEvent, which could route through the
+        // resolver and land here again for the same doc id.
+        lock.lock()
+        if inFlightDocIds.contains(documentId) {
+            lock.unlock()
+            return
+        }
+        inFlightDocIds.insert(documentId)
+        lock.unlock()
+        defer {
+            lock.lock()
+            inFlightDocIds.remove(documentId)
+            lock.unlock()
+        }
+
+        var document = (try gateway?.loadDocument(docType: docType, id: documentId))
+            ?? Self.placeholder(documentId: documentId, docType: docType)
+        let originalFields = document.fields
+        let originalStatus = document.status
+
+        let autoCtx = AutomationContext(
+            appId: appId,
+            trigger: trigger,
+            docType: docType,
+            documentId: documentId,
+            userId: userId,
+            now: clock(),
+            notificationSink: notificationSink,
+            assignmentSink: assignmentSink,
+            expressionEvaluator: expressionEvaluator
+        )
+
+        try registry.execute(
+            actionType: action.actionType,
+            parameters: action.parameters,
+            on: &document,
+            context: autoCtx
+        )
+
+        let mutated = document.fields != originalFields || document.status != originalStatus
+        if mutated, let gateway {
+            _ = try gateway.saveDocument(document)
+        }
+    }
+
+    private func dispatchSchedulerAction(
+        action: ExtensionActionDeclaration,
+        appId: String,
+        declarationId: String
+    ) throws {
+        var placeholder = Self.placeholder(
+            documentId: "scheduler:\(declarationId)",
+            docType: ""
+        )
+        let autoCtx = AutomationContext(
+            appId: appId,
+            trigger: "onSchedule",
+            docType: "",
+            documentId: "",
+            userId: userId,
+            now: clock(),
+            notificationSink: notificationSink,
+            assignmentSink: assignmentSink,
+            expressionEvaluator: expressionEvaluator
+        )
+        try registry.execute(
+            actionType: action.actionType,
+            parameters: action.parameters,
+            on: &placeholder,
+            context: autoCtx
+        )
+    }
+
+    private static func placeholder(documentId: String, docType: String) -> Document {
+        Document(
+            id: documentId,
+            docType: docType,
+            company: "",
+            status: "",
+            createdAt: Date(),
+            updatedAt: Date(),
+            syncVersion: 0,
+            syncState: .local,
+            docStatus: 0,
+            amendedFrom: nil,
+            fields: [:],
+            children: [:]
+        )
+    }
+}

--- a/mercantis core/Automation/AutomationActionHandler.swift
+++ b/mercantis core/Automation/AutomationActionHandler.swift
@@ -1,0 +1,129 @@
+//
+//  AutomationActionHandler.swift
+//  mercantis core
+//
+//  P1.2 — Automation runtime. See ADR-019, ADR-025.
+//
+
+import Foundation
+
+// MARK: - Automation Context
+
+/// Context passed to every `AutomationActionHandler.execute(...)` call. (ADR-019)
+///
+/// Carries the event origin, the acting user, and the injectable side-effect
+/// sinks that handlers like `send_notification` and `assign` write to. The
+/// context is intentionally plain data — handlers do not receive a reference
+/// to the `DocumentEngine` or the `EventEmitter`; orchestration is the
+/// runner's / dispatcher's responsibility.
+public struct AutomationContext: Sendable {
+    /// Installed app id that owns the rule or extension-point subscription.
+    /// Empty when the registry is invoked outside an app scope (e.g. a test
+    /// that dispatches a handler directly).
+    public let appId: String
+
+    /// Raw trigger identifier. For document events this matches the
+    /// `DocumentEventTrigger` raw value (e.g. `"on_save"`, `"on_submit"`).
+    /// For legacy `AppManifest.automationRules`, this is the declared
+    /// `triggerEvent` string.
+    public let trigger: String
+
+    /// The DocType id of the document the event fired for. Empty for
+    /// scheduler-origin invocations that are not bound to a DocType.
+    public let docType: String
+
+    /// The id of the document the event fired for. Empty for scheduler-origin
+    /// invocations.
+    public let documentId: String
+
+    /// The user on whose behalf the event was produced. `DocumentEngine`
+    /// populates this from its own `userId`; scheduler-origin invocations
+    /// use `""` unless the caller injects one.
+    public let userId: String
+
+    /// Wall-clock timestamp at handler-dispatch time.
+    public let now: Date
+
+    /// Sink that `SendNotificationHandler` writes to.
+    public let notificationSink: NotificationLogWriter
+
+    /// Sink that `AssignHandler` writes to.
+    public let assignmentSink: AssignmentLogWriter
+
+    /// Expression evaluator used by condition-aware handlers (currently
+    /// `ValidateHandler`). Handlers that don't need it can ignore it.
+    public let expressionEvaluator: ExpressionEvaluator
+
+    public init(
+        appId: String = "",
+        trigger: String,
+        docType: String = "",
+        documentId: String = "",
+        userId: String = "",
+        now: Date = Date(),
+        notificationSink: NotificationLogWriter = InMemoryNotificationLog(),
+        assignmentSink: AssignmentLogWriter = InMemoryAssignmentLog(),
+        expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator()
+    ) {
+        self.appId = appId
+        self.trigger = trigger
+        self.docType = docType
+        self.documentId = documentId
+        self.userId = userId
+        self.now = now
+        self.notificationSink = notificationSink
+        self.assignmentSink = assignmentSink
+        self.expressionEvaluator = expressionEvaluator
+    }
+}
+
+// MARK: - Handler Protocol
+
+/// A handler for one built-in automation action type. (ADR-025)
+///
+/// Handlers mutate the document in place; it is the caller's responsibility
+/// (runner or dispatcher) to persist the mutation. Handlers that produce
+/// side effects — notifications, assignments — use the sinks on
+/// `AutomationContext` rather than touching global state.
+///
+/// Throwing from `execute(...)` signals failure to the caller. When the
+/// caller is `DocumentEngine` running inside the save transaction, a thrown
+/// error rolls back the save (ADR-019). Post-commit callers (the runner
+/// subscribed to `DocumentSavedEvent`) report the error and move on.
+public protocol AutomationActionHandler: Sendable {
+    /// The `actionType` string this handler is registered under
+    /// (e.g. `"set_value"`, `"send_notification"`). Matching is
+    /// case-sensitive.
+    static var actionType: String { get }
+
+    func execute(
+        document: inout Document,
+        parameters: [String: String],
+        context: AutomationContext
+    ) throws
+}
+
+// MARK: - Errors
+
+/// Errors thrown by `AutomationActionRegistry` and the built-in handlers.
+public enum AutomationActionError: Error, Sendable, Equatable {
+    /// No handler is registered for the given `actionType`. `SendNotificationHandler`
+    /// et al. are registered by `BuiltInAutomationActions.registerAll(into:)`; custom
+    /// actions must be registered explicitly.
+    case unknownActionType(String)
+
+    /// A required parameter was missing from the declaration.
+    case missingParameter(actionType: String, name: String)
+
+    /// A parameter was present but could not be interpreted.
+    case invalidParameter(actionType: String, name: String, reason: String)
+
+    /// `ValidateHandler` evaluated its condition and the condition returned false.
+    case validationFailed(message: String)
+
+    /// An expression handler could not evaluate its expression (e.g. syntax error
+    /// or an undefined field reference). The underlying evaluator error is
+    /// preserved as a string — `ExpressionEvaluator.EvaluatorError` is not
+    /// `Equatable`, so we stringify to keep this enum `Equatable`.
+    case expressionFailed(actionType: String, expression: String, underlying: String)
+}

--- a/mercantis core/Automation/AutomationActionRegistry.swift
+++ b/mercantis core/Automation/AutomationActionRegistry.swift
@@ -1,0 +1,82 @@
+//
+//  AutomationActionRegistry.swift
+//  mercantis core
+//
+//  P1.2 — Registry that maps `actionType` strings to `AutomationActionHandler`
+//  conformances. Registry-based dispatch instead of string-switch. (ADR-025)
+//
+
+import Foundation
+
+/// Thread-safe registry of `AutomationActionHandler`s, keyed by `actionType`.
+///
+/// - Built-in handlers are registered via `BuiltInAutomationActions.registerAll(into:)`.
+/// - Additional handlers can be added at runtime; downloaded apps cannot
+///   register handlers (ADR-008).
+/// - Later registrations with the same `actionType` overwrite earlier ones.
+///   This is intentional so a host process can swap a built-in (e.g. replace
+///   the in-memory `send_notification` handler with one that delivers email)
+///   without subclassing the registry.
+public final class AutomationActionRegistry: @unchecked Sendable {
+
+    private var handlers: [String: AutomationActionHandler] = [:]
+    private let lock = NSLock()
+
+    public init(registerBuiltIns: Bool = true) {
+        if registerBuiltIns {
+            BuiltInAutomationActions.registerAll(into: self)
+        }
+    }
+
+    // MARK: - Registration
+
+    /// Register a handler. Replaces any previous handler with the same `actionType`.
+    public func register<H: AutomationActionHandler>(_ handler: H) {
+        lock.lock()
+        handlers[type(of: handler).actionType] = handler
+        lock.unlock()
+    }
+
+    /// Remove the handler registered for `actionType`, if any.
+    public func unregister(actionType: String) {
+        lock.lock()
+        handlers.removeValue(forKey: actionType)
+        lock.unlock()
+    }
+
+    /// The set of `actionType` strings currently registered. Inspectable at
+    /// runtime (ADR-025 consequence).
+    public func registeredActionTypes() -> Set<String> {
+        lock.lock(); defer { lock.unlock() }
+        return Set(handlers.keys)
+    }
+
+    /// Return the handler registered for `actionType`, if any.
+    public func handler(for actionType: String) -> AutomationActionHandler? {
+        lock.lock(); defer { lock.unlock() }
+        return handlers[actionType]
+    }
+
+    // MARK: - Execution
+
+    /// Execute one action against a document using the registered handler.
+    ///
+    /// Throws `AutomationActionError.unknownActionType` if no handler is
+    /// registered for `actionType` — silent no-op dispatch is forbidden
+    /// (ADR-025).
+    ///
+    /// The caller owns persistence: if the handler mutates `document`, the
+    /// caller is responsible for saving the resulting value back to the
+    /// document store.
+    public func execute(
+        actionType: String,
+        parameters: [String: String],
+        on document: inout Document,
+        context: AutomationContext
+    ) throws {
+        guard let handler = handler(for: actionType) else {
+            throw AutomationActionError.unknownActionType(actionType)
+        }
+        try handler.execute(document: &document, parameters: parameters, context: context)
+    }
+}

--- a/mercantis core/Automation/AutomationRunner.swift
+++ b/mercantis core/Automation/AutomationRunner.swift
@@ -1,0 +1,314 @@
+//
+//  AutomationRunner.swift
+//  mercantis core
+//
+//  P1.2 — Subscribes to document lifecycle events, matches rules against
+//  `AutomationRule` declarations, evaluates each rule's
+//  `conditionExpression`, and dispatches each action through the
+//  `AutomationActionRegistry`.
+//
+//  See ADR-019 for the execution model and ADR-025 for the registry.
+//
+
+import Foundation
+
+/// Document persistence gateway used by the runner to load the most recent
+/// persisted document before running handlers (which may mutate it) and to
+/// write the mutated document back.
+///
+/// `DocumentEngine` conforms to this via a thin extension below. Tests pass
+/// their own conformance to assert wiring in isolation.
+public protocol AutomationDocumentGateway: AnyObject {
+    func loadDocument(docType: String, id: String) throws -> Document?
+    func saveDocument(_ document: Document) throws -> Document
+}
+
+extension DocumentEngine: AutomationDocumentGateway {
+    public func loadDocument(docType: String, id: String) throws -> Document? {
+        try fetch(docType: docType, id: id)
+    }
+
+    public func saveDocument(_ document: Document) throws -> Document {
+        try save(document)
+    }
+}
+
+// MARK: - Runner
+
+/// Event-driven automation runner. (ADR-019)
+///
+/// The runner observes post-commit `MercantisEvent`s (save / submit / cancel /
+/// amend) and fires every `AutomationRule` whose `docType` and `triggerEvent`
+/// match. Actions are dispatched through the shared `AutomationActionRegistry`.
+/// When handlers mutate the document, the mutation is written back via
+/// `AutomationDocumentGateway.saveDocument(_:)`.
+///
+/// ### Scope
+///
+/// - Post-commit only. ADR-019 calls for automation to run *inside* the save
+///   transaction so a failing `validate` action rolls back the write. That
+///   requires threading the runner through `DocumentEngine.save(_:)` —
+///   deferred beyond P1.2 because it changes the save signature and requires
+///   new coverage in `DocumentEngineTests`. Post-commit `validate` is still
+///   useful: it surfaces an error to `errorReporter` and sinks an
+///   `AutomationActionError.validationFailed`, so the UI layer or host
+///   app can react.
+/// - The runner does not interpret `triggerEvent == "onSchedule"` — that
+///   belongs to P1.4's `SchedulerService`.
+///
+/// ### Re-entrancy
+///
+/// A handler that writes the document back (e.g. `set_value`) re-fires
+/// `DocumentSavedEvent`, which could feed the runner into an infinite loop
+/// if a rule fires on its own side effect. The runner tracks the document
+/// ids currently under processing and skips nested dispatches.
+public final class AutomationRunner: @unchecked Sendable {
+
+    private let emitter: EventEmitter
+    private let registry: AutomationActionRegistry
+    private let gateway: AutomationDocumentGateway?
+    private let notificationSink: NotificationLogWriter
+    private let assignmentSink: AssignmentLogWriter
+    private let expressionEvaluator: ExpressionEvaluator
+    private let userId: String
+    private let clock: @Sendable () -> Date
+    private let errorReporter: (@Sendable (RunnerError) -> Void)?
+
+    private let lock = NSLock()
+    private var rulesByApp: [String: [AutomationRule]] = [:]
+    private var tokens: [SubscriptionToken] = []
+    private var inFlightDocIds: Set<String> = []
+
+    public init(
+        emitter: EventEmitter,
+        registry: AutomationActionRegistry = AutomationActionRegistry(),
+        gateway: AutomationDocumentGateway? = nil,
+        notificationSink: NotificationLogWriter = InMemoryNotificationLog(),
+        assignmentSink: AssignmentLogWriter = InMemoryAssignmentLog(),
+        expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator(),
+        userId: String = "",
+        clock: @escaping @Sendable () -> Date = { Date() },
+        errorReporter: (@Sendable (RunnerError) -> Void)? = nil
+    ) {
+        self.emitter = emitter
+        self.registry = registry
+        self.gateway = gateway
+        self.notificationSink = notificationSink
+        self.assignmentSink = assignmentSink
+        self.expressionEvaluator = expressionEvaluator
+        self.userId = userId
+        self.clock = clock
+        self.errorReporter = errorReporter
+        wireSubscriptions()
+    }
+
+    deinit {
+        for token in tokens { token.cancel() }
+    }
+
+    // MARK: - Rule registration
+
+    /// Install every rule declared by a manifest. Replaces any prior rule
+    /// set registered for the same `appId`. Safe to call repeatedly.
+    public func register(rules: [AutomationRule], appId: String) {
+        lock.lock()
+        rulesByApp[appId] = rules
+        lock.unlock()
+    }
+
+    /// Remove every rule registered for `appId`. Matches `AppInstaller.uninstall`.
+    public func unregister(appId: String) {
+        lock.lock()
+        rulesByApp.removeValue(forKey: appId)
+        lock.unlock()
+    }
+
+    /// Install every rule from every manifest. Used by `restore`-style paths
+    /// at launch: replaces the full rule set in one call.
+    public func applyManifests(_ manifests: [AppManifest]) {
+        lock.lock()
+        rulesByApp.removeAll(keepingCapacity: true)
+        for manifest in manifests {
+            rulesByApp[manifest.id] = manifest.automationRules
+        }
+        lock.unlock()
+    }
+
+    /// The number of rules currently registered for `appId`. For tests and
+    /// diagnostics.
+    public func ruleCount(forAppId appId: String) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return rulesByApp[appId]?.count ?? 0
+    }
+
+    // MARK: - Event wiring
+
+    private func wireSubscriptions() {
+        let saved = emitter.subscribe(DocumentSavedEvent.self) { [weak self] event in
+            self?.handle(trigger: "onSave", document: event.document, docType: event.docType)
+        }
+        let submitted = emitter.subscribe(DocumentSubmittedEvent.self) { [weak self] event in
+            self?.handle(trigger: "onSubmit", document: event.document, docType: event.docType)
+        }
+        let cancelled = emitter.subscribe(DocumentCancelledEvent.self) { [weak self] event in
+            self?.handle(trigger: "onCancel", document: event.document, docType: event.docType)
+        }
+
+        lock.lock()
+        tokens.append(saved)
+        tokens.append(submitted)
+        tokens.append(cancelled)
+        lock.unlock()
+    }
+
+    // MARK: - Dispatch
+
+    private func handle(trigger: String, document: Document, docType: String) {
+        // Snapshot the matching rules under the lock; release before dispatch
+        // so handlers can re-enter without deadlocking.
+        let matches: [(appId: String, rule: AutomationRule)] = {
+            lock.lock(); defer { lock.unlock() }
+            var out: [(String, AutomationRule)] = []
+            for (appId, rules) in rulesByApp {
+                for rule in rules where rule.docType == docType
+                    && triggerMatches(declaredTrigger: rule.triggerEvent, eventTrigger: trigger) {
+                    out.append((appId, rule))
+                }
+            }
+            return out
+        }()
+        guard !matches.isEmpty else { return }
+
+        // Re-entrancy guard.
+        lock.lock()
+        if inFlightDocIds.contains(document.id) {
+            lock.unlock()
+            return
+        }
+        inFlightDocIds.insert(document.id)
+        lock.unlock()
+
+        defer {
+            lock.lock()
+            inFlightDocIds.remove(document.id)
+            lock.unlock()
+        }
+
+        for (appId, rule) in matches {
+            do {
+                try runRule(rule, appId: appId, trigger: trigger, initialDocument: document)
+            } catch {
+                errorReporter?(.ruleFailed(
+                    appId: appId,
+                    ruleId: rule.id,
+                    underlying: error
+                ))
+            }
+        }
+    }
+
+    private func runRule(
+        _ rule: AutomationRule,
+        appId: String,
+        trigger: String,
+        initialDocument: Document
+    ) throws {
+        // Load the latest persisted state if a gateway is available. This
+        // protects against stale payloads when multiple saves fire in quick
+        // succession. Without a gateway the event-delivered document is
+        // treated as authoritative.
+        var document: Document = {
+            guard let gateway,
+                  let loaded = try? gateway.loadDocument(
+                    docType: initialDocument.docType,
+                    id: initialDocument.id
+                  ) else {
+                return initialDocument
+            }
+            return loaded
+        }()
+        let originalFields = document.fields
+        let originalStatus = document.status
+
+        // Evaluate the rule's condition against the current document state.
+        // A missing / empty condition is treated as `true`. Evaluation errors
+        // are reported and the rule is skipped — a broken condition is not
+        // the same as a false one, so we don't silently run actions.
+        if !rule.conditionExpression.isEmpty {
+            let passes: Bool
+            do {
+                passes = try expressionEvaluator.evaluateBool(
+                    expression: rule.conditionExpression,
+                    context: document.fields
+                )
+            } catch {
+                throw RunnerError.conditionFailed(
+                    appId: appId,
+                    ruleId: rule.id,
+                    expression: rule.conditionExpression,
+                    underlying: error
+                )
+            }
+            guard passes else { return }
+        }
+
+        let context = AutomationContext(
+            appId: appId,
+            trigger: trigger,
+            docType: document.docType,
+            documentId: document.id,
+            userId: userId,
+            now: clock(),
+            notificationSink: notificationSink,
+            assignmentSink: assignmentSink,
+            expressionEvaluator: expressionEvaluator
+        )
+
+        for action in rule.actions {
+            try registry.execute(
+                actionType: action.type,
+                parameters: action.parameters,
+                on: &document,
+                context: context
+            )
+        }
+
+        let mutated = document.fields != originalFields || document.status != originalStatus
+        if mutated, let gateway {
+            _ = try gateway.saveDocument(document)
+        }
+    }
+
+    // MARK: - Trigger matching
+
+    /// Match the manifest-declared `triggerEvent` against the runner's event trigger.
+    ///
+    /// Accepts the Mercantis camelCase form (`onSave`, `onSubmit`, `onCancel`)
+    /// and the Frappe-style snake_case aliases (`on_save`, `on_submit`,
+    /// `on_update`, `on_change`, `on_cancel`). Case-insensitive.
+    private func triggerMatches(declaredTrigger declared: String, eventTrigger event: String) -> Bool {
+        let d = declared.lowercased()
+        let e = event.lowercased()
+        if d == e { return true }
+        switch e {
+        case "onsave":
+            return ["on_save", "on_update", "on_change", "onupdate", "onchange"].contains(d)
+        case "onsubmit":
+            return d == "on_submit"
+        case "oncancel":
+            return d == "on_cancel"
+        default:
+            return false
+        }
+    }
+
+    // MARK: - Errors
+
+    public enum RunnerError: Error, Sendable {
+        /// The condition expression couldn't be evaluated. The rule was not run.
+        case conditionFailed(appId: String, ruleId: String, expression: String, underlying: Error)
+
+        /// A registered handler threw during execution.
+        case ruleFailed(appId: String, ruleId: String, underlying: Error)
+    }
+}

--- a/mercantis core/Automation/AutomationSinks.swift
+++ b/mercantis core/Automation/AutomationSinks.swift
@@ -1,0 +1,153 @@
+//
+//  AutomationSinks.swift
+//  mercantis core
+//
+//  P1.2 — Side-effect sinks for `SendNotificationHandler` and `AssignHandler`.
+//
+//  Notifications and assignments are not yet persisted in Core. ADR-019 calls
+//  for `NotificationLog` rows, but there is no `notification_log` /
+//  `assignment_log` table today, and adding one before the consumers exist is
+//  premature. For P1.2 the handlers write to an in-memory sink so the runtime
+//  is observable in tests and at runtime, and a future migration can swap the
+//  default for a persistent writer without changing the handler protocol.
+//
+
+import Foundation
+
+// MARK: - Notification Log
+
+/// One log entry produced by `SendNotificationHandler`.
+public struct NotificationLogEntry: Sendable, Equatable {
+    public let id: UUID
+    public let appId: String
+    public let docType: String
+    public let documentId: String
+    public let channel: String
+    public let recipient: String?
+    public let subject: String
+    public let body: String
+    public let emittedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        appId: String,
+        docType: String,
+        documentId: String,
+        channel: String,
+        recipient: String?,
+        subject: String,
+        body: String,
+        emittedAt: Date
+    ) {
+        self.id = id
+        self.appId = appId
+        self.docType = docType
+        self.documentId = documentId
+        self.channel = channel
+        self.recipient = recipient
+        self.subject = subject
+        self.body = body
+        self.emittedAt = emittedAt
+    }
+}
+
+/// Sink for `SendNotificationHandler`. Implementations may log, persist,
+/// or fan out to transports. The default (`InMemoryNotificationLog`) records
+/// entries for inspection and is safe to use in tests.
+public protocol NotificationLogWriter: AnyObject, Sendable {
+    func write(_ entry: NotificationLogEntry)
+}
+
+/// Thread-safe in-memory notification sink. Records every entry in the
+/// order `write(...)` was called.
+public final class InMemoryNotificationLog: NotificationLogWriter, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _entries: [NotificationLogEntry] = []
+
+    public init() {}
+
+    public var entries: [NotificationLogEntry] {
+        lock.lock(); defer { lock.unlock() }
+        return _entries
+    }
+
+    public func reset() {
+        lock.lock(); defer { lock.unlock() }
+        _entries.removeAll()
+    }
+
+    public func write(_ entry: NotificationLogEntry) {
+        lock.lock()
+        _entries.append(entry)
+        lock.unlock()
+    }
+}
+
+// MARK: - Assignment Log
+
+/// One log entry produced by `AssignHandler`.
+public struct AssignmentLogEntry: Sendable, Equatable {
+    public enum Target: Sendable, Equatable {
+        case user(String)
+        case role(String)
+    }
+
+    public let id: UUID
+    public let appId: String
+    public let docType: String
+    public let documentId: String
+    public let target: Target
+    public let note: String?
+    public let assignedBy: String
+    public let assignedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        appId: String,
+        docType: String,
+        documentId: String,
+        target: Target,
+        note: String?,
+        assignedBy: String,
+        assignedAt: Date
+    ) {
+        self.id = id
+        self.appId = appId
+        self.docType = docType
+        self.documentId = documentId
+        self.target = target
+        self.note = note
+        self.assignedBy = assignedBy
+        self.assignedAt = assignedAt
+    }
+}
+
+/// Sink for `AssignHandler`. Implementations may persist, notify, or ignore.
+public protocol AssignmentLogWriter: AnyObject, Sendable {
+    func write(_ entry: AssignmentLogEntry)
+}
+
+/// Thread-safe in-memory assignment sink. Default for tests and for runtime
+/// use until a persistent assignment store is introduced.
+public final class InMemoryAssignmentLog: AssignmentLogWriter, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _entries: [AssignmentLogEntry] = []
+
+    public init() {}
+
+    public var entries: [AssignmentLogEntry] {
+        lock.lock(); defer { lock.unlock() }
+        return _entries
+    }
+
+    public func reset() {
+        lock.lock(); defer { lock.unlock() }
+        _entries.removeAll()
+    }
+
+    public func write(_ entry: AssignmentLogEntry) {
+        lock.lock()
+        _entries.append(entry)
+        lock.unlock()
+    }
+}

--- a/mercantis core/Automation/BuiltInActionHandlers.swift
+++ b/mercantis core/Automation/BuiltInActionHandlers.swift
@@ -1,0 +1,347 @@
+//
+//  BuiltInActionHandlers.swift
+//  mercantis core
+//
+//  P1.2 — Built-in `AutomationActionHandler` conformances. (ADR-019, ADR-025)
+//
+//  The five built-ins map to the action type table in ADR-025:
+//
+//      | actionType         | Handler                    |
+//      |--------------------|----------------------------|
+//      | set_value          | SetValueHandler            |
+//      | set_status         | SetStatusHandler           |
+//      | send_notification  | SendNotificationHandler    |
+//      | validate           | ValidateHandler            |
+//      | assign             | AssignHandler              |
+//
+
+import Foundation
+
+// MARK: - Bulk registration
+
+/// Convenience registrar for all built-in handlers. Called by the
+/// `AutomationActionRegistry` initialiser unless the caller opts out.
+public enum BuiltInAutomationActions {
+    public static func registerAll(into registry: AutomationActionRegistry) {
+        registry.register(SetValueHandler())
+        registry.register(SetStatusHandler())
+        registry.register(SendNotificationHandler())
+        registry.register(ValidateHandler())
+        registry.register(AssignHandler())
+    }
+}
+
+// MARK: - set_value
+
+/// Set a single field on the document to a literal value.
+///
+/// Parameters:
+/// - `field` (required) — the field key to write.
+/// - `value` (required) — the literal value. Interpreted via
+///   `FieldValueDecoder.decode(_:)` so `"42"` becomes `.int(42)`,
+///   `"true"` becomes `.bool(true)`, etc.
+/// - `type` (optional) — force a specific `FieldValue` case:
+///   `"string" | "int" | "double" | "bool" | "null"`. When present,
+///   overrides the automatic inference.
+public struct SetValueHandler: AutomationActionHandler {
+    public static let actionType = "set_value"
+    public init() {}
+
+    public func execute(
+        document: inout Document,
+        parameters: [String: String],
+        context: AutomationContext
+    ) throws {
+        guard let field = parameters["field"], !field.isEmpty else {
+            throw AutomationActionError.missingParameter(
+                actionType: Self.actionType, name: "field"
+            )
+        }
+        guard let raw = parameters["value"] else {
+            throw AutomationActionError.missingParameter(
+                actionType: Self.actionType, name: "value"
+            )
+        }
+        let value = try FieldValueDecoder.decode(raw, forcedType: parameters["type"])
+        document.fields[field] = value
+    }
+}
+
+// MARK: - set_status
+
+/// Change the document's workflow `status`.
+///
+/// This only writes to `document.status`. ADR-013's `docStatus` lifecycle
+/// (Draft/Submitted/Cancelled) is controlled by `DocumentEngine.submit/cancel/amend`
+/// and is deliberately not a target of this handler — automation must go
+/// through those paths to preserve the submit immutability guard.
+///
+/// Parameters:
+/// - `status` (required) — the target workflow state name.
+public struct SetStatusHandler: AutomationActionHandler {
+    public static let actionType = "set_status"
+    public init() {}
+
+    public func execute(
+        document: inout Document,
+        parameters: [String: String],
+        context: AutomationContext
+    ) throws {
+        guard let status = parameters["status"], !status.isEmpty else {
+            throw AutomationActionError.missingParameter(
+                actionType: Self.actionType, name: "status"
+            )
+        }
+        document.status = status
+    }
+}
+
+// MARK: - send_notification
+
+/// Emit a notification-log entry. The handler never sends email or push
+/// itself — delivery is the sink's responsibility. The default sink
+/// (`InMemoryNotificationLog`) just records the entry.
+///
+/// Parameters:
+/// - `channel` (optional, default `"default"`) — logical transport, e.g.
+///   `"email"`, `"push"`, `"ops"`.
+/// - `recipient` (optional) — user id, email address, or role name, depending
+///   on the channel.
+/// - `subject` (optional, default `""`).
+/// - `body` (optional, default `""`). Placeholders of the form `{field}` are
+///   substituted from `document.fields`; unknown placeholders are left as-is.
+public struct SendNotificationHandler: AutomationActionHandler {
+    public static let actionType = "send_notification"
+    public init() {}
+
+    public func execute(
+        document: inout Document,
+        parameters: [String: String],
+        context: AutomationContext
+    ) throws {
+        let channel = parameters["channel"] ?? "default"
+        let recipient = parameters["recipient"]
+        let subject = ParameterInterpolator.interpolate(
+            parameters["subject"] ?? "", in: document
+        )
+        let body = ParameterInterpolator.interpolate(
+            parameters["body"] ?? "", in: document
+        )
+        let entry = NotificationLogEntry(
+            appId: context.appId,
+            docType: context.docType.isEmpty ? document.docType : context.docType,
+            documentId: context.documentId.isEmpty ? document.id : context.documentId,
+            channel: channel,
+            recipient: recipient,
+            subject: subject,
+            body: body,
+            emittedAt: context.now
+        )
+        context.notificationSink.write(entry)
+    }
+}
+
+// MARK: - validate
+
+/// Throw a `validationFailed` error when the condition expression evaluates
+/// to `false`. Intended to block a save when run inside the save transaction
+/// — ADR-019 calls this the "blocking save" path. When run post-commit
+/// (which is what the P1.3 extension-point resolver currently does), a
+/// thrown error is surfaced to the dispatcher's error reporter; the commit
+/// is not rolled back.
+///
+/// Parameters:
+/// - `expression` (required) — a boolean `ExpressionEvaluator` expression.
+/// - `message` (optional, default `"Validation failed."`) — error text.
+public struct ValidateHandler: AutomationActionHandler {
+    public static let actionType = "validate"
+    public init() {}
+
+    public func execute(
+        document: inout Document,
+        parameters: [String: String],
+        context: AutomationContext
+    ) throws {
+        guard let expression = parameters["expression"], !expression.isEmpty else {
+            throw AutomationActionError.missingParameter(
+                actionType: Self.actionType, name: "expression"
+            )
+        }
+        let message = parameters["message"] ?? "Validation failed."
+
+        let passes: Bool
+        do {
+            passes = try context.expressionEvaluator.evaluateBool(
+                expression: expression,
+                context: document.fields
+            )
+        } catch {
+            throw AutomationActionError.expressionFailed(
+                actionType: Self.actionType,
+                expression: expression,
+                underlying: "\(error)"
+            )
+        }
+        if !passes {
+            throw AutomationActionError.validationFailed(message: message)
+        }
+    }
+}
+
+// MARK: - assign
+
+/// Record an assignment of the document to a user or role.
+///
+/// Parameters:
+/// - `user` or `role` (one of, required).
+/// - `note` (optional).
+public struct AssignHandler: AutomationActionHandler {
+    public static let actionType = "assign"
+    public init() {}
+
+    public func execute(
+        document: inout Document,
+        parameters: [String: String],
+        context: AutomationContext
+    ) throws {
+        let target: AssignmentLogEntry.Target
+        if let user = parameters["user"], !user.isEmpty {
+            target = .user(user)
+        } else if let role = parameters["role"], !role.isEmpty {
+            target = .role(role)
+        } else {
+            throw AutomationActionError.missingParameter(
+                actionType: Self.actionType, name: "user|role"
+            )
+        }
+
+        let entry = AssignmentLogEntry(
+            appId: context.appId,
+            docType: context.docType.isEmpty ? document.docType : context.docType,
+            documentId: context.documentId.isEmpty ? document.id : context.documentId,
+            target: target,
+            note: parameters["note"],
+            assignedBy: context.userId,
+            assignedAt: context.now
+        )
+        context.assignmentSink.write(entry)
+    }
+}
+
+// MARK: - Helpers
+
+/// Converts a string literal from a manifest declaration into a `FieldValue`.
+///
+/// Disambiguation: a manifest only carries strings, so `"42"` could mean the
+/// number 42 or the string `"42"`. Callers can force the interpretation
+/// via an explicit `type` parameter; otherwise the decoder infers from the
+/// literal shape (bool → int → double → string, in that order).
+enum FieldValueDecoder {
+    static func decode(_ raw: String, forcedType: String?) throws -> FieldValue {
+        if let forced = forcedType?.lowercased(), !forced.isEmpty {
+            switch forced {
+            case "string":
+                return .string(raw)
+            case "int", "integer":
+                guard let n = Int(raw) else {
+                    throw AutomationActionError.invalidParameter(
+                        actionType: "set_value",
+                        name: "value",
+                        reason: "expected Int, got '\(raw)'"
+                    )
+                }
+                return .int(n)
+            case "double", "decimal", "number":
+                guard let d = Double(raw) else {
+                    throw AutomationActionError.invalidParameter(
+                        actionType: "set_value",
+                        name: "value",
+                        reason: "expected Double, got '\(raw)'"
+                    )
+                }
+                return .double(d)
+            case "bool", "boolean":
+                switch raw.lowercased() {
+                case "true", "yes", "1":  return .bool(true)
+                case "false", "no", "0":  return .bool(false)
+                default:
+                    throw AutomationActionError.invalidParameter(
+                        actionType: "set_value",
+                        name: "value",
+                        reason: "expected Bool, got '\(raw)'"
+                    )
+                }
+            case "null":
+                return .null
+            default:
+                throw AutomationActionError.invalidParameter(
+                    actionType: "set_value",
+                    name: "type",
+                    reason: "unknown type '\(forced)'"
+                )
+            }
+        }
+        // Inference path. Preserve this order: a bare `"1"` should decode as
+        // an Int, not a Bool, so the explicit literals come first.
+        switch raw.lowercased() {
+        case "true":  return .bool(true)
+        case "false": return .bool(false)
+        case "null":  return .null
+        default: break
+        }
+        if let n = Int(raw) { return .int(n) }
+        if let d = Double(raw) { return .double(d) }
+        return .string(raw)
+    }
+}
+
+/// Very small `{field}` placeholder expander used by
+/// `SendNotificationHandler`. Unknown placeholders are left as `{name}` so
+/// tests can detect them and callers can iterate.
+enum ParameterInterpolator {
+    static func interpolate(_ template: String, in document: Document) -> String {
+        guard template.contains("{") else { return template }
+        var result = ""
+        var buffer = ""
+        var inPlaceholder = false
+        for ch in template {
+            if ch == "{" {
+                result.append(buffer)
+                buffer = ""
+                inPlaceholder = true
+                continue
+            }
+            if ch == "}" && inPlaceholder {
+                if let value = document.fields[buffer] {
+                    result.append(stringify(value))
+                } else {
+                    result.append("{")
+                    result.append(buffer)
+                    result.append("}")
+                }
+                buffer = ""
+                inPlaceholder = false
+                continue
+            }
+            buffer.append(ch)
+        }
+        // Trailing open brace: restore literally.
+        if inPlaceholder {
+            result.append("{")
+            result.append(buffer)
+        } else {
+            result.append(buffer)
+        }
+        return result
+    }
+
+    private static func stringify(_ value: FieldValue) -> String {
+        switch value {
+        case .string(let s): return s
+        case .int(let i):    return String(i)
+        case .double(let d): return String(d)
+        case .bool(let b):   return b ? "true" : "false"
+        case .null:          return ""
+        }
+    }
+}

--- a/mercantis coreTests/AutomationTests.swift
+++ b/mercantis coreTests/AutomationTests.swift
@@ -1,0 +1,867 @@
+//
+//  AutomationTests.swift
+//  mercantis coreTests
+//
+//  Covers the P1.2 automation runtime: action registry, built-in handlers,
+//  runner that listens to document events, and the
+//  `ExtensionActionDispatcher` bridge.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class AutomationTests: XCTestCase {
+
+    private var notifications: InMemoryNotificationLog!
+    private var assignments: InMemoryAssignmentLog!
+
+    override func setUp() {
+        super.setUp()
+        notifications = InMemoryNotificationLog()
+        assignments = InMemoryAssignmentLog()
+    }
+
+    override func tearDown() {
+        notifications = nil
+        assignments = nil
+        super.tearDown()
+    }
+
+    // MARK: - Registry
+
+    func testRegistryRegistersBuiltInsByDefault() {
+        let registry = AutomationActionRegistry()
+        let types = registry.registeredActionTypes()
+        XCTAssertEqual(
+            types,
+            ["set_value", "set_status", "send_notification", "validate", "assign"]
+        )
+    }
+
+    func testRegistryCanOptOutOfBuiltIns() {
+        let registry = AutomationActionRegistry(registerBuiltIns: false)
+        XCTAssertTrue(registry.registeredActionTypes().isEmpty)
+    }
+
+    func testRegistryThrowsUnknownActionType() {
+        let registry = AutomationActionRegistry()
+        var doc = TestSupport.makeDocument(fields: [:])
+        XCTAssertThrowsError(try registry.execute(
+            actionType: "does_not_exist",
+            parameters: [:],
+            on: &doc,
+            context: automationContext()
+        )) { error in
+            XCTAssertEqual(
+                error as? AutomationActionError,
+                .unknownActionType("does_not_exist")
+            )
+        }
+    }
+
+    func testRegistryReplacesHandlerOnDuplicateRegistration() throws {
+        let registry = AutomationActionRegistry()
+        registry.register(ReplacementSetValueHandler())
+        var doc = TestSupport.makeDocument(fields: [:])
+        try registry.execute(
+            actionType: "set_value",
+            parameters: ["field": "x", "value": "anything"],
+            on: &doc,
+            context: automationContext()
+        )
+        XCTAssertEqual(doc.fields["x"], .string("replaced"))
+    }
+
+    // MARK: - SetValueHandler
+
+    func testSetValueInfersIntFromDigits() throws {
+        var doc = TestSupport.makeDocument(fields: [:])
+        try SetValueHandler().execute(
+            document: &doc,
+            parameters: ["field": "qty", "value": "42"],
+            context: automationContext()
+        )
+        XCTAssertEqual(doc.fields["qty"], .int(42))
+    }
+
+    func testSetValueInfersBoolFromKeyword() throws {
+        var doc = TestSupport.makeDocument(fields: [:])
+        try SetValueHandler().execute(
+            document: &doc,
+            parameters: ["field": "paid", "value": "true"],
+            context: automationContext()
+        )
+        XCTAssertEqual(doc.fields["paid"], .bool(true))
+    }
+
+    func testSetValueHonoursExplicitStringType() throws {
+        var doc = TestSupport.makeDocument(fields: [:])
+        try SetValueHandler().execute(
+            document: &doc,
+            parameters: ["field": "ref", "value": "42", "type": "string"],
+            context: automationContext()
+        )
+        XCTAssertEqual(doc.fields["ref"], .string("42"))
+    }
+
+    func testSetValueRejectsMissingField() {
+        var doc = TestSupport.makeDocument(fields: [:])
+        XCTAssertThrowsError(try SetValueHandler().execute(
+            document: &doc,
+            parameters: ["value": "42"],
+            context: automationContext()
+        )) { error in
+            XCTAssertEqual(
+                error as? AutomationActionError,
+                .missingParameter(actionType: "set_value", name: "field")
+            )
+        }
+    }
+
+    func testSetValueRejectsInvalidExplicitType() {
+        var doc = TestSupport.makeDocument(fields: [:])
+        XCTAssertThrowsError(try SetValueHandler().execute(
+            document: &doc,
+            parameters: ["field": "x", "value": "abc", "type": "int"],
+            context: automationContext()
+        )) { error in
+            if case .invalidParameter(let actionType, let name, _) = error as? AutomationActionError {
+                XCTAssertEqual(actionType, "set_value")
+                XCTAssertEqual(name, "value")
+            } else {
+                XCTFail("expected invalidParameter, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - SetStatusHandler
+
+    func testSetStatusChangesStatus() throws {
+        var doc = TestSupport.makeDocument(fields: [:])
+        doc.status = "Draft"
+        try SetStatusHandler().execute(
+            document: &doc,
+            parameters: ["status": "Approved"],
+            context: automationContext()
+        )
+        XCTAssertEqual(doc.status, "Approved")
+    }
+
+    func testSetStatusRejectsMissingStatus() {
+        var doc = TestSupport.makeDocument(fields: [:])
+        XCTAssertThrowsError(try SetStatusHandler().execute(
+            document: &doc,
+            parameters: [:],
+            context: automationContext()
+        ))
+    }
+
+    // MARK: - SendNotificationHandler
+
+    func testSendNotificationWritesEntryToSink() throws {
+        var doc = TestSupport.makeDocument(
+            id: "SI-001",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(1000)]
+        )
+        try SendNotificationHandler().execute(
+            document: &doc,
+            parameters: [
+                "channel": "email",
+                "recipient": "ops@example.com",
+                "subject": "Invoice posted",
+                "body": "Total: {grandTotal}"
+            ],
+            context: automationContext(appId: "app.test", docType: "SalesInvoice", documentId: "SI-001")
+        )
+        let entries = notifications.entries
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.channel, "email")
+        XCTAssertEqual(entries.first?.recipient, "ops@example.com")
+        XCTAssertEqual(entries.first?.subject, "Invoice posted")
+        XCTAssertEqual(entries.first?.body, "Total: 1000.0")
+        XCTAssertEqual(entries.first?.appId, "app.test")
+        XCTAssertEqual(entries.first?.documentId, "SI-001")
+    }
+
+    func testSendNotificationInterpolationLeavesUnknownPlaceholders() throws {
+        var doc = TestSupport.makeDocument(fields: ["title": .string("Hi")])
+        try SendNotificationHandler().execute(
+            document: &doc,
+            parameters: ["body": "Hello {title}, about {missing}"],
+            context: automationContext()
+        )
+        XCTAssertEqual(notifications.entries.first?.body, "Hello Hi, about {missing}")
+    }
+
+    // MARK: - ValidateHandler
+
+    func testValidateSucceedsWhenConditionTrue() throws {
+        var doc = TestSupport.makeDocument(fields: ["amount": .double(10)])
+        try ValidateHandler().execute(
+            document: &doc,
+            parameters: ["expression": "amount > 0", "message": "positive only"],
+            context: automationContext()
+        )
+    }
+
+    func testValidateThrowsWhenConditionFalse() {
+        var doc = TestSupport.makeDocument(fields: ["amount": .double(-1)])
+        XCTAssertThrowsError(try ValidateHandler().execute(
+            document: &doc,
+            parameters: ["expression": "amount > 0", "message": "positive only"],
+            context: automationContext()
+        )) { error in
+            if case .validationFailed(let message) = error as? AutomationActionError {
+                XCTAssertEqual(message, "positive only")
+            } else {
+                XCTFail("expected validationFailed, got \(error)")
+            }
+        }
+    }
+
+    func testValidateSurfacesExpressionError() {
+        var doc = TestSupport.makeDocument(fields: [:])
+        // Leading comparison operator with no LHS — the evaluator throws
+        // `unexpectedToken`. We assert the handler wraps it.
+        XCTAssertThrowsError(try ValidateHandler().execute(
+            document: &doc,
+            parameters: ["expression": ">5"],
+            context: automationContext()
+        )) { error in
+            if case .expressionFailed(let actionType, _, _) = error as? AutomationActionError {
+                XCTAssertEqual(actionType, "validate")
+            } else {
+                XCTFail("expected expressionFailed, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - AssignHandler
+
+    func testAssignRecordsUserTarget() throws {
+        var doc = TestSupport.makeDocument(
+            id: "SI-042",
+            docType: "SalesInvoice",
+            fields: [:]
+        )
+        try AssignHandler().execute(
+            document: &doc,
+            parameters: ["user": "alice", "note": "please review"],
+            context: automationContext(
+                appId: "app.test",
+                docType: "SalesInvoice",
+                documentId: "SI-042"
+            )
+        )
+        XCTAssertEqual(assignments.entries.count, 1)
+        XCTAssertEqual(assignments.entries.first?.target, .user("alice"))
+        XCTAssertEqual(assignments.entries.first?.note, "please review")
+        XCTAssertEqual(assignments.entries.first?.documentId, "SI-042")
+    }
+
+    func testAssignRecordsRoleTarget() throws {
+        var doc = TestSupport.makeDocument(fields: [:])
+        try AssignHandler().execute(
+            document: &doc,
+            parameters: ["role": "Auditor"],
+            context: automationContext()
+        )
+        XCTAssertEqual(assignments.entries.first?.target, .role("Auditor"))
+    }
+
+    func testAssignRejectsMissingTarget() {
+        var doc = TestSupport.makeDocument(fields: [:])
+        XCTAssertThrowsError(try AssignHandler().execute(
+            document: &doc,
+            parameters: ["note": "nobody?"],
+            context: automationContext()
+        ))
+    }
+
+    // MARK: - Runner
+
+    func testRunnerFiresMatchingRuleOnSaveAndPersistsMutation() throws {
+        let harness = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        try harness.registry.register(invoiceDocType())
+
+        let runner = AutomationRunner(
+            emitter: harness.emitter,
+            gateway: harness.engine,
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+        runner.register(
+            rules: [
+                AutomationRule(
+                    id: "rule-1",
+                    name: "Auto-post flag",
+                    docType: "SalesInvoice",
+                    triggerEvent: "onSave",
+                    conditionExpression: "grandTotal > 100",
+                    actions: [
+                        AutomationAction(
+                            type: "set_value",
+                            parameters: ["field": "autoposted", "value": "true"]
+                        )
+                    ]
+                )
+            ],
+            appId: "app.test"
+        )
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-001",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(500)]
+        ))
+
+        let reloaded = try XCTUnwrap(harness.engine.fetch(docType: "SalesInvoice", id: "SI-001"))
+        XCTAssertEqual(reloaded.fields["autoposted"], .bool(true))
+    }
+
+    func testRunnerSkipsRuleWhenConditionFalse() throws {
+        let harness = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        try harness.registry.register(invoiceDocType())
+
+        let runner = AutomationRunner(
+            emitter: harness.emitter,
+            gateway: harness.engine,
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+        runner.register(
+            rules: [
+                AutomationRule(
+                    id: "rule-1",
+                    name: "Big-order notifier",
+                    docType: "SalesInvoice",
+                    triggerEvent: "onSave",
+                    conditionExpression: "grandTotal > 1000",
+                    actions: [
+                        AutomationAction(
+                            type: "send_notification",
+                            parameters: ["subject": "Big order"]
+                        )
+                    ]
+                )
+            ],
+            appId: "app.test"
+        )
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-002",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(25)]
+        ))
+
+        XCTAssertTrue(notifications.entries.isEmpty)
+    }
+
+    func testRunnerMatchesFrappeStyleAliases() throws {
+        let harness = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        try harness.registry.register(invoiceDocType())
+
+        let runner = AutomationRunner(
+            emitter: harness.emitter,
+            gateway: harness.engine,
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+        runner.register(
+            rules: [
+                AutomationRule(
+                    id: "rule-1",
+                    name: "On update notifier",
+                    docType: "SalesInvoice",
+                    triggerEvent: "on_update",
+                    conditionExpression: "",
+                    actions: [
+                        AutomationAction(
+                            type: "send_notification",
+                            parameters: [:]
+                        )
+                    ]
+                )
+            ],
+            appId: "app.test"
+        )
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-003",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(1)]
+        ))
+        XCTAssertEqual(notifications.entries.count, 1)
+    }
+
+    func testRunnerFiresOnSubmitButNotOnSaveWhenTriggerIsOnSubmit() throws {
+        let harness = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        try harness.registry.register(invoiceDocType(isSubmittable: true))
+
+        let runner = AutomationRunner(
+            emitter: harness.emitter,
+            gateway: harness.engine,
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+        runner.register(
+            rules: [
+                AutomationRule(
+                    id: "rule-submit",
+                    name: "On-submit only",
+                    docType: "SalesInvoice",
+                    triggerEvent: "onSubmit",
+                    conditionExpression: "",
+                    actions: [
+                        AutomationAction(
+                            type: "send_notification",
+                            parameters: ["subject": "submitted"]
+                        )
+                    ]
+                )
+            ],
+            appId: "app.test"
+        )
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-004",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(10)]
+        ))
+        XCTAssertTrue(
+            notifications.entries.isEmpty,
+            "save should not trigger an onSubmit rule"
+        )
+
+        // Refetch to pick up the persisted `updatedAt` before submit.
+        var doc = try XCTUnwrap(harness.engine.fetch(docType: "SalesInvoice", id: "SI-004"))
+        try harness.engine.submit(&doc)
+        XCTAssertEqual(notifications.entries.count, 1)
+    }
+
+    func testRunnerReentrancyGuardBreaksFeedbackLoops() throws {
+        let harness = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        try harness.registry.register(invoiceDocType())
+
+        let runner = AutomationRunner(
+            emitter: harness.emitter,
+            gateway: harness.engine,
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+        // This rule mutates the document on save, which would fire another
+        // DocumentSavedEvent. Without the re-entrancy guard this would loop
+        // until stack overflow.
+        runner.register(
+            rules: [
+                AutomationRule(
+                    id: "feedback",
+                    name: "Feedback",
+                    docType: "SalesInvoice",
+                    triggerEvent: "onSave",
+                    conditionExpression: "",
+                    actions: [
+                        AutomationAction(
+                            type: "set_value",
+                            parameters: ["field": "counter", "value": "1"]
+                        )
+                    ]
+                )
+            ],
+            appId: "app.test"
+        )
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-loop",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(1)]
+        ))
+
+        let reloaded = try XCTUnwrap(harness.engine.fetch(docType: "SalesInvoice", id: "SI-loop"))
+        XCTAssertEqual(reloaded.fields["counter"], .int(1))
+    }
+
+    func testRunnerReportsRuleFailure() throws {
+        let harness = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        try harness.registry.register(invoiceDocType())
+
+        let reportedErrors = ErrorCollector()
+
+        let runner = AutomationRunner(
+            emitter: harness.emitter,
+            gateway: harness.engine,
+            notificationSink: notifications,
+            assignmentSink: assignments,
+            errorReporter: { reportedErrors.append($0) }
+        )
+        runner.register(
+            rules: [
+                AutomationRule(
+                    id: "bad-rule",
+                    name: "Bad",
+                    docType: "SalesInvoice",
+                    triggerEvent: "onSave",
+                    conditionExpression: "",
+                    actions: [
+                        AutomationAction(
+                            type: "set_value",
+                            parameters: ["value": "missing field"]
+                        )
+                    ]
+                )
+            ],
+            appId: "app.test"
+        )
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-err",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(1)]
+        ))
+
+        XCTAssertEqual(reportedErrors.count, 1)
+    }
+
+    func testRunnerUnregisterRemovesRulesForApp() throws {
+        let harness = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        try harness.registry.register(invoiceDocType())
+
+        let runner = AutomationRunner(
+            emitter: harness.emitter,
+            gateway: harness.engine,
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+        runner.register(
+            rules: [
+                AutomationRule(
+                    id: "r",
+                    name: "R",
+                    docType: "SalesInvoice",
+                    triggerEvent: "onSave",
+                    conditionExpression: "",
+                    actions: [AutomationAction(
+                        type: "send_notification",
+                        parameters: [:]
+                    )]
+                )
+            ],
+            appId: "app.test"
+        )
+        XCTAssertEqual(runner.ruleCount(forAppId: "app.test"), 1)
+
+        runner.unregister(appId: "app.test")
+        XCTAssertEqual(runner.ruleCount(forAppId: "app.test"), 0)
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-u", docType: "SalesInvoice", fields: ["grandTotal": .double(1)]
+        ))
+        XCTAssertTrue(notifications.entries.isEmpty)
+    }
+
+    // MARK: - AutomationActionDispatcher bridge
+
+    func testDispatcherInvokesRegistryForDocumentEvent() throws {
+        let harness = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        try harness.registry.register(invoiceDocType())
+
+        let dispatcher = AutomationActionDispatcher(
+            gateway: harness.engine,
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-dispatch",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(5)]
+        ))
+
+        try dispatcher.dispatch(
+            action: ExtensionActionDeclaration(
+                actionType: "send_notification",
+                parameters: ["subject": "From dispatcher"]
+            ),
+            context: ExtensionActionContext(
+                appId: "app.bridge",
+                origin: .documentEvent(
+                    trigger: .onSave,
+                    documentId: "SI-dispatch",
+                    docType: "SalesInvoice"
+                )
+            )
+        )
+
+        XCTAssertEqual(notifications.entries.count, 1)
+        XCTAssertEqual(notifications.entries.first?.subject, "From dispatcher")
+        XCTAssertEqual(notifications.entries.first?.appId, "app.bridge")
+    }
+
+    func testDispatcherPersistsDocumentMutationThroughGateway() throws {
+        let harness = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        try harness.registry.register(invoiceDocType())
+
+        let dispatcher = AutomationActionDispatcher(
+            gateway: harness.engine,
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-mutate",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(5)]
+        ))
+
+        try dispatcher.dispatch(
+            action: ExtensionActionDeclaration(
+                actionType: "set_value",
+                parameters: ["field": "approved", "value": "true"]
+            ),
+            context: ExtensionActionContext(
+                appId: "app.bridge",
+                origin: .documentEvent(
+                    trigger: .onSave,
+                    documentId: "SI-mutate",
+                    docType: "SalesInvoice"
+                )
+            )
+        )
+
+        let reloaded = try XCTUnwrap(harness.engine.fetch(docType: "SalesInvoice", id: "SI-mutate"))
+        XCTAssertEqual(reloaded.fields["approved"], .bool(true))
+    }
+
+    func testDispatcherEndToEndThroughExtensionPointResolver() throws {
+        let harness = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        let dispatcher = AutomationActionDispatcher(
+            gateway: harness.engine,
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+        let resolver = ExtensionPointResolver(
+            emitter: harness.emitter,
+            dispatcher: dispatcher
+        )
+        let installer = AppInstaller(
+            database: harness.database,
+            schemaValidator: SchemaValidator(),
+            registry: harness.registry,
+            extensionResolver: resolver
+        )
+
+        let docType = invoiceDocType(appId: "app.e2e", isSubmittable: true)
+        let manifest = AppManifest(
+            id: "app.e2e",
+            name: "e2e",
+            version: "0.1.0",
+            minimumCoreVersion: "1.0.0",
+            description: "",
+            doctypes: [docType],
+            workflows: [],
+            permissions: [],
+            reports: [],
+            automationRules: [],
+            dashboards: [],
+            localizations: [],
+            extensionPoints: ExtensionPoints(
+                documentEventSubscriptions: [
+                    DocumentEventSubscription(
+                        id: "sub",
+                        docTypeSelector: "SalesInvoice",
+                        trigger: .onSubmit,
+                        actions: [
+                            ExtensionActionDeclaration(
+                                actionType: "send_notification",
+                                parameters: ["subject": "submitted"]
+                            )
+                        ]
+                    )
+                ]
+            )
+        )
+
+        try installer.install(manifest)
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-e2e",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(10)]
+        ))
+        // Refetch so the submit's optimistic-concurrency check matches the DB.
+        var doc = try XCTUnwrap(harness.engine.fetch(docType: "SalesInvoice", id: "SI-e2e"))
+        try harness.engine.submit(&doc)
+
+        XCTAssertEqual(notifications.entries.count, 1)
+        XCTAssertEqual(notifications.entries.first?.subject, "submitted")
+        XCTAssertEqual(notifications.entries.first?.appId, "app.e2e")
+    }
+
+    // MARK: - AppInstaller → Runner wiring
+
+    func testAppInstallerRegistersAndUnregistersAutomationRulesWithRunner() throws {
+        let harness = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        let runner = AutomationRunner(
+            emitter: harness.emitter,
+            gateway: harness.engine,
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+        let installer = AppInstaller(
+            database: harness.database,
+            schemaValidator: SchemaValidator(),
+            registry: harness.registry,
+            automationRunner: runner
+        )
+
+        let rule = AutomationRule(
+            id: "rule-1",
+            name: "Notify",
+            docType: "SalesInvoice",
+            triggerEvent: "onSave",
+            conditionExpression: "",
+            actions: [AutomationAction(
+                type: "send_notification",
+                parameters: ["subject": "hi"]
+            )]
+        )
+
+        let manifest = AppManifest(
+            id: "app.install",
+            name: "install",
+            version: "0.1.0",
+            minimumCoreVersion: "1.0.0",
+            description: "",
+            doctypes: [invoiceDocType(appId: "app.install")],
+            workflows: [],
+            permissions: [],
+            reports: [],
+            automationRules: [rule],
+            dashboards: [],
+            localizations: []
+        )
+
+        try installer.install(manifest)
+        XCTAssertEqual(runner.ruleCount(forAppId: "app.install"), 1)
+
+        try harness.engine.save(TestSupport.makeDocument(
+            id: "SI-install",
+            docType: "SalesInvoice",
+            fields: ["grandTotal": .double(1)]
+        ))
+        XCTAssertEqual(notifications.entries.count, 1)
+
+        try installer.uninstall(appId: "app.install")
+        XCTAssertEqual(runner.ruleCount(forAppId: "app.install"), 0)
+    }
+
+    func testDispatcherSchedulerOriginRunsHandlerAgainstPlaceholder() throws {
+        let dispatcher = AutomationActionDispatcher(
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+
+        try dispatcher.dispatch(
+            action: ExtensionActionDeclaration(
+                actionType: "send_notification",
+                parameters: ["subject": "daily"]
+            ),
+            context: ExtensionActionContext(
+                appId: "app.sched",
+                origin: .scheduler(declarationId: "daily-1", interval: .daily)
+            )
+        )
+        XCTAssertEqual(notifications.entries.first?.subject, "daily")
+        XCTAssertEqual(notifications.entries.first?.appId, "app.sched")
+    }
+
+    // MARK: - Fixtures
+
+    private func automationContext(
+        appId: String = "app.test",
+        docType: String = "",
+        documentId: String = ""
+    ) -> AutomationContext {
+        AutomationContext(
+            appId: appId,
+            trigger: "onSave",
+            docType: docType,
+            documentId: documentId,
+            userId: "tester",
+            now: Date(),
+            notificationSink: notifications,
+            assignmentSink: assignments
+        )
+    }
+
+    private func invoiceDocType(
+        appId: String = "app.test",
+        isSubmittable: Bool = false
+    ) -> DocType {
+        TestSupport.makeDocType(
+            id: "SalesInvoice",
+            appId: appId,
+            fields: [
+                TestSupport.numberField("grandTotal")
+            ],
+            isSubmittable: isSubmittable,
+            syncPolicy: isSubmittable
+                ? TestSupport.submittableSyncPolicy()
+                : TestSupport.defaultSyncPolicy(),
+            titleField: "grandTotal"
+        )
+    }
+}
+
+// MARK: - Test Doubles
+
+private struct ReplacementSetValueHandler: AutomationActionHandler {
+    static let actionType = "set_value"
+    func execute(
+        document: inout Document,
+        parameters: [String: String],
+        context: AutomationContext
+    ) throws {
+        let field = parameters["field"] ?? "x"
+        document.fields[field] = .string("replaced")
+    }
+}
+
+private final class ErrorCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var items: [Error] = []
+
+    func append(_ error: Error) {
+        lock.lock()
+        items.append(error)
+        lock.unlock()
+    }
+
+    var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return items.count
+    }
+}


### PR DESCRIPTION
## Summary

Implements the P1.2 automation runtime as specified in ADR-019 and ADR-025. The runtime executes declarative automation rules in response to document lifecycle events, with a registry-based dispatch system for built-in and custom action handlers.

## Key Changes

- **AutomationActionRegistry** (`AutomationActionRegistry.swift`): Thread-safe registry mapping `actionType` strings to handler implementations. Supports registration of custom handlers and built-in handlers by default.

- **Five built-in action handlers** (`BuiltInActionHandlers.swift`):
  - `SetValueHandler`: Sets document field values with automatic type inference
  - `SetStatusHandler`: Changes document workflow status
  - `SendNotificationHandler`: Emits notification log entries with field interpolation
  - `ValidateHandler`: Evaluates boolean expressions and throws on failure
  - `AssignHandler`: Records document assignments to users or roles

- **AutomationRunner** (`AutomationRunner.swift`): Event-driven runner that subscribes to document lifecycle events (save, submit, cancel), matches rules against registered `AutomationRule` declarations, evaluates condition expressions, and dispatches actions through the registry. Includes re-entrancy guards to prevent feedback loops from handler mutations.

- **AutomationActionDispatcher** (`AutomationActionDispatcher.swift`): Bridges the automation registry to the `ExtensionActionDispatcher` seam, enabling P1.3 extension-point subscriptions to route through the same handler infrastructure.

- **AutomationSinks** (`AutomationSinks.swift`): In-memory sinks for notifications and assignments (`InMemoryNotificationLog`, `InMemoryAssignmentLog`) that record side effects for inspection and future persistence.

- **AutomationContext & Handler Protocol** (`AutomationActionHandler.swift`): Defines the context passed to handlers (appId, trigger, document metadata, sinks, expression evaluator) and the `AutomationActionHandler` protocol that all handlers conform to.

- **Comprehensive test coverage** (`AutomationTests.swift`): 867 lines of tests covering registry behavior, all five built-in handlers, the runner's event wiring and re-entrancy guard, rule matching and condition evaluation, and error reporting.

- **Integration with AppInstaller**: Updated to wire the `AutomationRunner` into the app installation lifecycle so rules are registered/unregistered with app manifests.

## Notable Implementation Details

- **Post-commit execution**: Handlers run after document persistence (not inside the transaction) to avoid blocking saves. Validation failures are reported via error callback rather than rolling back commits.
- **Re-entrancy guard**: Both runner and dispatcher track in-flight document IDs to prevent infinite loops when handlers mutate and re-persist documents.
- **Registry-based dispatch**: New action types are added by registering handler implementations compiled into Core; downloaded apps cannot register custom handlers (per ADR-008).
- **Expression evaluation**: Condition expressions and validation rules use the shared `ExpressionEvaluator` for consistent semantics.
- **Thread safety**: Registry, runner, and sinks use locks to support concurrent access from event handlers and tests.

https://claude.ai/code/session_01AHiQ66pmrQb2j79L8XmPKk