### PR TITLE
P1.4: Implement periodic task scheduler with cron support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -371,12 +371,14 @@ See [ADR-015](Docs/ADR/ADR-015-declarative-hooks-app-extension.md) and [ADR-026]
 
 **Location:** `mercantis core/Scheduling/`
 
-Because Mercantis Core is a pure client-side library (no server process), background tasks execute within the app process using Swift Concurrency (`Task`, `TaskGroup`).
+Because Mercantis Core is a pure client-side library (no server process), background tasks execute within the app process using Swift Concurrency (`Task`).
 
-- **Scheduled tasks** — A `SchedulerService` checks for due tasks on app launch and periodically while the app is active. Tasks are declared in app manifests under `schedulerEvents`.
-- **Task types:** `all` (every 5 min), `hourly`, `daily`, `weekly`, `monthly`, `cron` (custom cron expression).
-- **Queue categories:** `short` (< 5 s, UI-blocking permitted), `default` (< 60 s), `long` (> 60 s, runs as a background task).
-- Failed tasks are retried with exponential backoff. Failures are logged to `audit_log`.
+- **Scheduled tasks** — `SchedulerService` checks for due tasks on app launch and periodically while the app is active. Tasks are declared in app manifests under `schedulerEvents` and registered via `ExtensionPointResolver` → `ExtensionSchedulerRegistrar`. (P1.4 — 2026-04-24)
+- **Task types:** `all` (every tick), `hourly`, `daily`, `weekly`, `monthly`, `cron` (custom expression).
+- **Cron support:** dependency-free five-field parser (minute, hour, day-of-month, month, day-of-week). Supports `*`, integer, comma-separated lists, inclusive ranges, and `*/step`. Day-of-week accepts `0`–`7` with both `0` and `7` binding to Sunday. When both day fields are explicit, the matcher uses Vixie union semantics. `@yearly` / `@daily` aliases are not supported.
+- **Persistence:** the v6 `scheduler_state(taskKey, lastRunAt)` table records the last-run timestamp per task. Task keys are `"<appId>::<declarationId>"`. Reinstall preserves cadence (the resolver only forgets the in-memory binding); full uninstall calls `SchedulerService.unregister(appId:)` which wipes every row whose key starts with `"<appId>::"`.
+- **Tick loop:** `start()` opts into a `Task` loop running every `tickInterval` (default 60 s). The first tick fires immediately so a task that came due while the app was closed catches up on launch instead of waiting a full interval. Tests and CLI hosts can drive the scheduler manually via `tick()` without `start()`.
+- **Queue categories** (`short` / `default` / `long`) and `audit_log` writes for failed scheduled runs are not yet implemented; the current loop is a single in-process tick.
 - Sync operations (push/receive) are themselves scheduled background tasks.
 
 **AutomationActionRegistry:** Automation action dispatch uses a registry of `AutomationActionHandler` protocol conformances keyed by `actionType` string. Built-in action types: `set_value`, `set_status`, `send_notification`, `validate`, `assign`. New action types are added by registering a conformance compiled into Core. See [ADR-025](Docs/ADR/ADR-025-automation-action-registry.md).
@@ -580,9 +582,14 @@ mercantis core/
 │   └── PermissionEngine.swift    # canPerform / canAccessField / canAccessRow
 ├── Reporting/
 │   └── ReportEngine.swift        # ReportEngine, ReportResult
+├── Scheduling/
+│   ├── ScheduledTask.swift          # key + appId + interval + dispatch + RetryPolicy
+│   ├── CronExpression.swift         # 5-field cron parser + matcher
+│   ├── SchedulerPersistence.swift   # scheduler_state read/write/clear
+│   └── SchedulerService.swift       # ExtensionSchedulerRegistrar + tick loop
 ├── Storage/
 │   ├── MercantisDatabase.swift   # GRDB DatabasePool wrapper
-│   └── MigrationRunner.swift     # Versioned schema migrations (v1–v3)
+│   └── MigrationRunner.swift     # Versioned schema migrations (v1–v6)
 ├── SyncEngine/
 │   ├── CloudAdapter.swift        # Protocol boundary + NoOpCloudAdapter (ADR-018)
 │   ├── ConflictResolver.swift    # LWW / VCM / AO resolution
@@ -615,9 +622,7 @@ mercantis core/
 | `Cache/` — cross-subsystem `CacheManager` | §4.14 | — | P3.4 |
 | `Files/` — attachments + sandboxed storage | §4.18 | — | P3.1 |
 | `ImportExport/` — CSV/JSON importer + exporter + fixtures | §4.20 | — | P3.3 |
-| `Naming/` — strategy registry + `NamingService` | §4.11 | ADR-014 | P1.1 |
 | `Printing/` — `PrintFormat`, `PDFGenerator`, `LetterHead` | §4.17 | — | P3.2 |
-| `Scheduling/` — `SchedulerService` + `ScheduledTask` | §4.13 | — | P1.4 |
 
 ---
 

--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -1,6 +1,6 @@
 # Enhancement Proposal
 
-_Last updated: 2026-04-24 (P1.2 — Automation runtime shipped)_
+_Last updated: 2026-04-24 (P1.4 — Scheduler shipped)_
 
 Companion document to [`IMPLEMENTATION-STATUS.md`](./IMPLEMENTATION-STATUS.md). The status doc catalogues _what is_; this doc proposes _what to do next_. Each item is labelled with effort (S/M/L), risk, and the ADR or architecture section it closes.
 
@@ -280,16 +280,80 @@ Coverage in `ExtensionPointsTests.swift`:
   `AppInstaller` or call `restoreExtensionPoints()` at launch; Hub/app-shell
   integration is the consumer for that wiring.
 
-### P1.4 — Implement the Scheduler [M, medium risk] — §4.13
+### P1.4 — Implement the Scheduler [M, medium risk] — §4.13 *(done — 2026-04-24)*
+
+`mercantis core/Scheduling/` ships the periodic-task scheduler that fills the
+`ExtensionSchedulerRegistrar` seam left by P1.3.
 
 ```
 mercantis core/Scheduling/
-├── ScheduledTask.swift              // type, handler, retryPolicy
-├── SchedulerService.swift           // cron/interval matcher; due-check on launch + every 60s while active
-└── SchedulerPersistence.swift       // `scheduler_state` table: lastRun per task key
+├── ScheduledTask.swift              // key + appId + interval + dispatch + RetryPolicy
+├── CronExpression.swift             // dependency-free 5-field cron parser + matcher
+├── SchedulerPersistence.swift       // scheduler_state read/write/clear (key-scoped + prefix-scoped)
+└── SchedulerService.swift           // ExtensionSchedulerRegistrar conformance + tick loop
 ```
 
-Cron support is the only non-trivial piece. A dependency-free subset (minute, hour, day-of-month, month, day-of-week, no `@yearly` aliases) covers Frappe's typical use and fits in ~200 lines.
+Migration v6 adds the `scheduler_state(taskKey, lastRunAt)` table. Task keys
+are composed as `"<appId>::<declarationId>"` so a manifest-declared
+`SchedulerEventDeclaration` lands on a stable identity that survives
+reinstall (resolver's `clear(appId:)` cancels the in-memory binding but
+deliberately leaves the persisted row alone, so cadence is preserved across
+upgrades). Full uninstall calls `SchedulerService.unregister(appId:)` which
+wipes every row whose key starts with `"<appId>::"`.
+
+`AppInstaller` now takes an optional `schedulerService:` parameter and calls
+`unregister(appId:)` after `extensionResolver?.clear(appId:)` on uninstall.
+The resolver path drops in-memory state per task; the new installer step is
+the only place that drops persisted state.
+
+`SchedulerService.start()` runs an opt-in `Task` loop that ticks on
+`tickInterval` (default 60 s); the first tick fires immediately so a task
+that came due while the app was closed catches up on launch instead of
+waiting a full interval. Hosts that prefer to drive the scheduler manually
+(tests, CLI) call `tick()` directly without `start()`.
+
+The cron parser supports the dependency-free subset called out in the
+original P1.4 sketch: `*`, integer, comma-separated lists, inclusive
+ranges, and `*/step`. Day-of-week accepts `0`–`7` with both `0` and `7`
+binding to Sunday (Vixie-cron compatibility). When both day-of-month and
+day-of-week are explicit, the matcher uses the union (Vixie semantics) so
+`"0 12 1 * 5"` fires at noon on the 1st of every month *or* every Friday.
+`@yearly` / `@daily` aliases are intentionally not supported — the
+`ScheduleInterval` enum already exposes `.daily` / `.hourly` / `.weekly`
+/ `.monthly` for those cases.
+
+Coverage in `SchedulerTests.swift` (24 tests):
+- `CronExpression` — wildcard, exact, comma-list, inclusive range, step
+  with wildcard / range, Sunday-as-zero-or-seven, wrong field count,
+  out-of-range, inverted range, zero step, non-integer, exact-time match,
+  Vixie union semantics, `nextFireDate` advance + roll-to-next-day.
+- `SchedulerPersistence` — round-trip, upsert, prefix-scoped clear.
+- `SchedulerService` — first-fire on no-`lastRun`, daily / hourly cadence
+  throttling, cron cadence per minute, invalid-cron error reporting,
+  process-restart preserves `lastRun`, restart fires immediately for
+  backlogged tasks, handle cancel stops dispatch, handle cancel preserves
+  cadence for reinstall, `unregister(appId:)` wipes persistence,
+  `ExtensionSchedulerRegistrar` conformance via the protocol type.
+- `MigrationRunnerTests` — extended to assert v6 brings
+  `highestAppliedVersion()` to 6 and creates `scheduler_state`.
+- End-to-end test routes a manifest-declared scheduler event through
+  `AppInstaller.install` → `ExtensionPointResolver` → `SchedulerService` →
+  `LoggingExtensionActionDispatcher`, then verifies that
+  `installer.uninstall` clears both the in-memory binding and the persisted
+  row.
+
+**Known follow-ups (not scoped to P1.4):**
+- The main app (`mercantis_coreApp.swift`) still does not construct an
+  `AppInstaller` / `SchedulerService` at launch. Hub/app-shell integration
+  is the consumer for that wiring.
+- Scheduler-triggered automation rules (`AutomationRule.triggerEvent ==
+  "onSchedule"`) — P1.2 registers them but never fires. The runner needs
+  to register itself as a `ScheduledTask` per matching rule when the
+  scheduler is wired to the runner; deferred until host-app wiring lands.
+- Background-task budget categories (`short` / `default` / `long` from
+  §4.13) and `audit_log` writes for failed runs are not implemented; the
+  current loop is a single in-process tick. Sufficient for the cadences
+  the manifest exposes today.
 
 ### P1.5 — Turn `WorkflowGuardStage` and `PermissionStage` into real stages [S, low risk] — ADR-022 *(done — 2026-04-23)*
 
@@ -530,8 +594,9 @@ A 4–6 week plan if one engineer is the target:
 | 4 | P1.1 Naming subsystem ✅ (2026-04-23). |
 | 5 | P1.3 Extension-point resolution ✅ (2026-04-24). |
 | 6 | P1.2 Automation runtime ✅ (2026-04-24) (fills the `ExtensionActionDispatcher` seam). |
+| 6 | P1.4 Scheduler ✅ (2026-04-24) (fills the `ExtensionSchedulerRegistrar` seam). |
 
-P1.4 Scheduler, P1.6 FieldValue expansion, and P1.7 row-level expressions slot in as individual PRs alongside the above.
+P1.6 FieldValue expansion and P1.7 row-level expressions slot in as individual PRs alongside the above.
 
 P2.6 (Core library productization) should happen before Hub development begins in earnest — it is not large work but it is a prerequisite for the Core/Hub boundary being real. P2.7 (Hub readiness gap analysis) is a documentation item that can run in parallel with any P1 work. P2.4 (dashboard runtime) and P2.8 (richer field/control model) are both medium-term items best driven by Hub's concrete needs rather than by speculative pre-design.
 

--- a/Docs/IMPLEMENTATION-STATUS.md
+++ b/Docs/IMPLEMENTATION-STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-_Last updated: 2026-04-23_
+_Last updated: 2026-04-24 (P1.4 — Scheduler shipped)_
 
 A candid map between `ARCHITECTURE.md` / the ADR set and what is actually present in `mercantis core/`. Each entry is graded:
 
@@ -34,7 +34,7 @@ The goal is not to assign blame; it's to give future contributors an honest star
 | `Permissions/` | Yes | `PermissionEngine.swift` is the only file and matches the revised §4.4 / ADR-011 (flat surface — see P0.5). `PermissionContext.swift` and `PermissionEvaluators.swift` were documented by earlier revisions but are no longer part of the target shape. |
 | `Printing/` | **No** | `LetterHead.swift`, `PDFGenerator.swift`, `PrintFormat.swift` absent. (Docs correctly mark §4.17 _planned_, but §7's tree still lists them.) |
 | `Reporting/` | Yes | `ReportEngine.swift` only. |
-| `Scheduling/` | **No** | §4.13 describes `SchedulerService.swift`, `ScheduledTask.swift`. Neither exists. |
+| `Scheduling/` | Yes | Ships `ScheduledTask`, `CronExpression`, `SchedulerPersistence`, `SchedulerService` (P1.4 / §4.13, 2026-04-24). `SchedulerService` conforms to `ExtensionSchedulerRegistrar` so manifest-declared `schedulerEvents` are registered through `ExtensionPointResolver` exactly like document-event subscriptions. Cadence is persisted in the v6 `scheduler_state` table. |
 | `Storage/` | Yes | Matches §4.3. |
 | `SyncEngine/` | Yes | Also contains `CloudAdapter.swift` with a `NoOpCloudAdapter` — not listed in §7 but referenced elsewhere (ADR-018). |
 | `UIShell/` | Yes (much larger than §7) | See §4 "UIShell reality" below. |
@@ -67,7 +67,7 @@ The goal is not to assign blame; it's to give future contributors an honest star
 
 ### 2.3 Storage — §4.3
 
-- **Shipped** — `MercantisDatabase`, `MigrationRunner`. Five versioned migrations: **v1** creates the advertised tables (`doctypes`, `fields`, `documents`, `document_children`, `sync_queue`, `audit_log`, `apps`, `workflows`); **v2** adds `docStatus` + `amendedFrom` columns (ADR-013); **v3** adds `document_versions` (ADR-024); **v4** adds the `sync_state` key/value table (P0.3 bookmark persistence); **v5** adds `naming_counters` for sequential series IDs (P1.1 / ADR-014).
+- **Shipped** — `MercantisDatabase`, `MigrationRunner`. Six versioned migrations: **v1** creates the advertised tables (`doctypes`, `fields`, `documents`, `document_children`, `sync_queue`, `audit_log`, `apps`, `workflows`); **v2** adds `docStatus` + `amendedFrom` columns (ADR-013); **v3** adds `document_versions` (ADR-024); **v4** adds the `sync_state` key/value table (P0.3 bookmark persistence); **v5** adds `naming_counters` for sequential series IDs (P1.1 / ADR-014); **v6** adds `scheduler_state(taskKey, lastRunAt)` so `SchedulerService` can survive process restarts (P1.4).
 - **Partial** — Migrations are forward-only (as intended) but there is no test suite asserting schema shape.
 - **Partial** — `audit_log` has neither a writer nor a reader API. Created, never used.
 
@@ -108,7 +108,7 @@ The goal is not to assign blame; it's to give future contributors an honest star
 
 - **Shipped** — `AppManifest` (Codable), `AppInstaller.install(_:)`, `AppInstaller.uninstall(appId:)`, `installApp` mutation flow.
 - **Shipped (P1.3, 2026-04-24)** — `AppManifest.extensionPoints: ExtensionPoints`, `ExtensionPointResolver` binds `documentEventSubscription` declarations to the typed `EventEmitter` and forwards `schedulerEvent` declarations to an `ExtensionSchedulerRegistrar`. `AppInstaller.install` / `uninstall` now call the resolver; `AppInstaller.restoreExtensionPoints()` rebinds on launch. Action dispatch routes through the `ExtensionActionDispatcher` seam that P1.2's `AutomationActionRegistry` will conform to; the default `LoggingExtensionActionDispatcher` records dispatches for test assertions until then.
-- **Missing** — The main app (`mercantis_coreApp.swift`) does not yet construct an `AppInstaller` or call `restoreExtensionPoints()` at launch. P1.2 will plug in the real action dispatcher; P1.4 the real scheduler registrar.
+- **Missing** — The main app (`mercantis_coreApp.swift`) does not yet construct an `AppInstaller` or call `restoreExtensionPoints()` at launch. The real action dispatcher (P1.2) and real scheduler registrar (P1.4) both ship and are ready to wire — Hub / app-shell integration is the consumer.
 
 ### 2.10 Document Lifecycle — §4.10 / ADR-013
 
@@ -123,7 +123,10 @@ The goal is not to assign blame; it's to give future contributors an honest star
 
 ### 2.12 Scheduling & Automation — §4.13 / ADR-019 / ADR-025
 
-- **Missing entirely.** No `SchedulerService`, no `ScheduledTask`, no `AutomationActionRegistry`, no `AutomationActionHandler`, no built-in actions. `AppManifest.automationRules: [AutomationRule]` decodes but has no runtime that executes them.
+- **Shipped (Automation, P1.2 — 2026-04-24)** — see §2.9 for the runner / registry wiring; covered separately in `AutomationTests.swift`.
+- **Shipped (Scheduling, P1.4 — 2026-04-24)** — `mercantis core/Scheduling/` ships `ScheduledTask`, `CronExpression`, `SchedulerPersistence`, and `SchedulerService`. `SchedulerService` conforms to `ExtensionSchedulerRegistrar`, so `ExtensionPointResolver` registers manifest-declared `schedulerEvents` against the real service rather than the recording stub. Last-run state survives process restarts via the v6 `scheduler_state` table. `AppInstaller.uninstall` calls `SchedulerService.unregister(appId:)` to wipe persisted state on full uninstall; reinstall preserves cadence.
+- **Cron support** — dependency-free five-field parser (minute, hour, day-of-month, month, day-of-week). Supports `*`, integer, comma-separated lists, inclusive ranges, and `*/step`. Day-of-week accepts `0`–`7` with both `0` and `7` binding to Sunday. When both day fields are explicit, the matcher uses Vixie union semantics (DOM OR DOW). `@yearly` / `@daily` aliases are not supported — `ScheduleInterval` already covers those cases.
+- **Known follow-ups** — `mercantis_coreApp.swift` still does not construct an `AppInstaller` / `SchedulerService` at launch; the host app / Hub will own that wiring. Scheduler-triggered automation rules (`triggerEvent == "onSchedule"`) are still no-ops because the runner is not wired to the scheduler. Background-task budget categories (`short` / `default` / `long` from §4.13) and `audit_log` writes for failed scheduled runs are not yet implemented.
 
 ### 2.13 Caching Layer — §4.14
 
@@ -177,7 +180,7 @@ Both `Modules` and `DocTypes` route through `RecordCollectionHostView`, so all s
 
 ## 3. Test coverage
 
-- **XCTest tests written in `mercantis coreTests/`.** Covers `ExpressionEvaluator`, `MetaComposer`, `ConflictResolver`, `ValidationPipeline`, `DocumentEngine` (save/fetch/concurrency/submit/cancel/amend), and `MigrationRunner` (v1/v2/v3 + idempotency).
+- **XCTest tests written in `mercantis coreTests/`.** Covers `ExpressionEvaluator`, `MetaComposer`, `ConflictResolver`, `ValidationPipeline`, `DocumentEngine` (save/fetch/concurrency/submit/cancel/amend), `MigrationRunner` (v1–v6 + idempotency), `Naming`, `Automation`, `ExtensionPoints`, and `Scheduler` (cron parser, persistence, due-check, ExtensionSchedulerRegistrar conformance, end-to-end through `AppInstaller`).
 - **Wire-up pending.** The test target does not yet exist in `project.pbxproj`. `mercantis coreTests/README.md` lists the one-time Xcode setup. After that, `⌘U` or `xcodebuild test` runs the suite.
 - Other subsystems remain intentionally uncovered until their implementation settles (see P0.2/P0.5 in `Docs/ENHANCEMENT-PROPOSAL.md`).
 
@@ -201,10 +204,10 @@ This is a useful parallel tool but also a **duplicate installer code path**. The
 
 If you open the repo today expecting to find everything ARCHITECTURE.md §7 advertises, here is the short list of what _to stop looking for_:
 
-- `Automation/`, `Cache/`, `Files/`, `ImportExport/`, `Printing/`, `Scheduling/` — do not exist. (`Naming/` shipped P1.1 — see §2.11.)
+- `Cache/`, `Files/`, `ImportExport/`, `Printing/` — do not exist. (`Naming/` shipped P1.1 — see §2.11; `Automation/` shipped P1.2; `Scheduling/` shipped P1.4 — see §2.12.)
 - A chain-style `PermissionEvaluator` protocol — does not exist; `PermissionEngine` is a flat class, and §4.4 / ADR-011 now describe it as such (P0.5).
 - AST in `ExpressionEvaluator` — does not exist; direct-eval recursive descent.
 - Role-filtered `availableReports` — does not exist; returns all.
 - Any XCTest target — does not exist.
 
-Everything else in the doc is at least partially real. The _engine_ is in good shape; the _shell around the engine_ (scheduling, automation runtime) is the remaining gap. Naming shipped in P1.1 (§2.11); extension-point resolution — the load-bearing wiring that binds manifest-declared events into `EventEmitter` — shipped in P1.3 (§2.9).
+Everything else in the doc is at least partially real. The _engine_ is in good shape; what remains is host-app wiring (constructing `AppInstaller` / `SchedulerService` at launch) and the `Files` / `Printing` / `ImportExport` subsystems. Naming shipped in P1.1 (§2.11); extension-point resolution — the load-bearing wiring that binds manifest-declared events into `EventEmitter` — shipped in P1.3 (§2.9); the automation runtime shipped in P1.2 (§2.12); the periodic-task scheduler shipped in P1.4 (§2.12).

--- a/mercantis core/AppRuntime/AppInstaller.swift
+++ b/mercantis core/AppRuntime/AppInstaller.swift
@@ -18,19 +18,22 @@ public final class AppInstaller {
     private let registry: MetadataRegistry
     private let extensionResolver: ExtensionPointResolver?
     private let automationRunner: AutomationRunner?
+    private let schedulerService: SchedulerService?
 
     public init(
         database: MercantisDatabase,
         schemaValidator: SchemaValidator,
         registry: MetadataRegistry,
         extensionResolver: ExtensionPointResolver? = nil,
-        automationRunner: AutomationRunner? = nil
+        automationRunner: AutomationRunner? = nil,
+        schedulerService: SchedulerService? = nil
     ) {
         self.database = database
         self.schemaValidator = schemaValidator
         self.registry = registry
         self.extensionResolver = extensionResolver
         self.automationRunner = automationRunner
+        self.schedulerService = schedulerService
     }
 
     // MARK: - Install
@@ -226,12 +229,19 @@ public final class AppInstaller {
 
         // 8. Release declarative extension-point bindings owned by this app
         //    (ADR-015, P1.3). Safe when no resolver is wired or when the app
-        //    had no declarations.
+        //    had no declarations. The resolver cancels per-task handles
+        //    which forget the in-memory binding; persisted scheduler state
+        //    is wiped in step 10.
         extensionResolver?.clear(appId: appId)
 
         // 9. Release the app's `AutomationRule`s from the runner
         //    (ADR-019, P1.2). Safe when no runner is wired.
         automationRunner?.unregister(appId: appId)
+
+        // 10. Drop persisted scheduler `lastRun` rows for this app
+        //     (P1.4). Reinstall preserves cadence; full uninstall does
+        //     not, so this only runs on uninstall.
+        schedulerService?.unregister(appId: appId)
     }
 
     // MARK: - Restore

--- a/mercantis core/Scheduling/CronExpression.swift
+++ b/mercantis core/Scheduling/CronExpression.swift
@@ -1,0 +1,257 @@
+//
+//  CronExpression.swift
+//  mercantis core
+//
+//  P1.4 — Dependency-free cron expression parser + matcher.
+//
+//  Supports the five-field cron subset used by Frappe-style scheduler hooks:
+//
+//      minute  hour  dayOfMonth  month  dayOfWeek
+//
+//  Each field accepts:
+//    - `*`                       — any value
+//    - integer                   — exact match
+//    - comma-separated list      — `1,15,30`
+//    - inclusive range           — `9-17`
+//    - step                      — `*/5` or `0-30/2`
+//
+//  Day-of-week is `0` (Sunday) through `6` (Saturday). `7` is also accepted
+//  as an alias for Sunday (Vixie-cron compatibility).
+//
+//  Aliases like `@yearly`, `@daily`, `@reboot` are intentionally NOT
+//  supported — `ScheduleInterval` already exposes `.daily` / `.hourly` /
+//  `.monthly` for those cases, and accepting both forms here would just
+//  duplicate the matrix.
+//
+
+import Foundation
+
+/// A parsed cron expression. (P1.4, §4.13)
+///
+/// Use `CronExpression.parse(_:)` to build one; `matches(_:in:)` returns
+/// whether a given `Date` (taken to the nearest minute) satisfies all five
+/// fields. `nextFireDate(after:in:)` walks forward minute-by-minute until
+/// it finds the next match — sufficient for the launch + every-60-seconds
+/// due-check the scheduler performs, while staying small enough to read.
+public struct CronExpression: Equatable, Sendable {
+
+    public let minutes: Set<Int>           // 0..59
+    public let hours: Set<Int>             // 0..23
+    public let daysOfMonth: Set<Int>       // 1..31
+    public let months: Set<Int>            // 1..12
+    public let daysOfWeek: Set<Int>        // 0..6  (Sunday == 0)
+
+    /// True when both day-of-month and day-of-week were specified explicitly
+    /// (i.e. neither is `*`). Vixie-cron treats this as an OR rather than
+    /// AND — a tick fires when *either* matches. Kept here so the matcher
+    /// can apply that rule and the parser stays the single source of truth.
+    public let dayFieldsAreUnion: Bool
+
+    public init(
+        minutes: Set<Int>,
+        hours: Set<Int>,
+        daysOfMonth: Set<Int>,
+        months: Set<Int>,
+        daysOfWeek: Set<Int>,
+        dayFieldsAreUnion: Bool
+    ) {
+        self.minutes = minutes
+        self.hours = hours
+        self.daysOfMonth = daysOfMonth
+        self.months = months
+        self.daysOfWeek = daysOfWeek
+        self.dayFieldsAreUnion = dayFieldsAreUnion
+    }
+
+    // MARK: - Parsing
+
+    public enum ParseError: Error, Equatable, Sendable {
+        case wrongFieldCount(expected: Int, found: Int, expression: String)
+        case invalidField(field: String, reason: String)
+        case stepNotPositive(field: String)
+        case rangeInverted(field: String)
+        case valueOutOfRange(field: String, value: Int, min: Int, max: Int)
+    }
+
+    /// Parse a 5-field cron expression. Whitespace between fields collapses;
+    /// leading / trailing whitespace is ignored.
+    public static func parse(_ expression: String) throws -> CronExpression {
+        let trimmed = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fields = trimmed.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+        guard fields.count == 5 else {
+            throw ParseError.wrongFieldCount(
+                expected: 5,
+                found: fields.count,
+                expression: expression
+            )
+        }
+
+        let minutes = try parseField(fields[0], min: 0, max: 59)
+        let hours   = try parseField(fields[1], min: 0, max: 23)
+        let dom     = try parseField(fields[2], min: 1, max: 31)
+        let months  = try parseField(fields[3], min: 1, max: 12)
+
+        // Day-of-week parses with extended range so `7` is accepted, then
+        // normalised to `0` (Sunday).
+        let dowRaw  = try parseField(fields[4], min: 0, max: 7)
+        var dow: Set<Int> = []
+        for v in dowRaw {
+            dow.insert(v == 7 ? 0 : v)
+        }
+
+        let dayFieldsAreUnion = (fields[2] != "*") && (fields[4] != "*")
+
+        return CronExpression(
+            minutes: minutes,
+            hours: hours,
+            daysOfMonth: dom,
+            months: months,
+            daysOfWeek: dow,
+            dayFieldsAreUnion: dayFieldsAreUnion
+        )
+    }
+
+    private static func parseField(
+        _ raw: String,
+        min low: Int,
+        max high: Int
+    ) throws -> Set<Int> {
+        var values: Set<Int> = []
+        // Comma splits a list of sub-expressions; each is parsed independently.
+        for piece in raw.split(separator: ",").map(String.init) {
+            try expand(
+                piece: piece,
+                fieldName: raw,
+                low: low,
+                high: high,
+                into: &values
+            )
+        }
+        if values.isEmpty {
+            throw ParseError.invalidField(field: raw, reason: "empty after expansion")
+        }
+        return values
+    }
+
+    private static func expand(
+        piece: String,
+        fieldName: String,
+        low: Int,
+        high: Int,
+        into values: inout Set<Int>
+    ) throws {
+        // Step syntax: `expr/step`. Step on its own is illegal; expr defaults
+        // to the full range when piece starts with `*/N`.
+        var base = piece
+        var step = 1
+
+        if let slash = piece.firstIndex(of: "/") {
+            base = String(piece[..<slash])
+            let stepStr = String(piece[piece.index(after: slash)...])
+            guard let parsedStep = Int(stepStr), parsedStep > 0 else {
+                throw ParseError.stepNotPositive(field: fieldName)
+            }
+            step = parsedStep
+        }
+
+        let (lo, hi): (Int, Int)
+        if base == "*" {
+            lo = low
+            hi = high
+        } else if let dash = base.firstIndex(of: "-") {
+            let loStr = String(base[..<dash])
+            let hiStr = String(base[base.index(after: dash)...])
+            guard let loVal = Int(loStr), let hiVal = Int(hiStr) else {
+                throw ParseError.invalidField(field: fieldName, reason: "non-integer range bounds in '\(base)'")
+            }
+            guard loVal <= hiVal else {
+                throw ParseError.rangeInverted(field: fieldName)
+            }
+            lo = loVal
+            hi = hiVal
+        } else {
+            guard let exact = Int(base) else {
+                throw ParseError.invalidField(field: fieldName, reason: "non-integer value '\(base)'")
+            }
+            lo = exact
+            hi = exact
+        }
+
+        guard lo >= low, hi <= high else {
+            throw ParseError.valueOutOfRange(
+                field: fieldName,
+                value: lo < low ? lo : hi,
+                min: low,
+                max: high
+            )
+        }
+
+        var v = lo
+        while v <= hi {
+            values.insert(v)
+            v += step
+        }
+    }
+
+    // MARK: - Matching
+
+    /// True when `date` (truncated to the minute) satisfies every field.
+    public func matches(_ date: Date, in calendar: Calendar = Calendar(identifier: .gregorian)) -> Bool {
+        let comps = calendar.dateComponents(
+            [.minute, .hour, .day, .month, .weekday],
+            from: date
+        )
+        guard
+            let minute  = comps.minute,
+            let hour    = comps.hour,
+            let day     = comps.day,
+            let month   = comps.month,
+            let weekday = comps.weekday    // 1..7, Sunday == 1
+        else { return false }
+
+        guard minutes.contains(minute) else { return false }
+        guard hours.contains(hour) else { return false }
+        guard months.contains(month) else { return false }
+
+        let dowMatches = daysOfWeek.contains(weekday - 1)
+        let domMatches = daysOfMonth.contains(day)
+
+        if dayFieldsAreUnion {
+            return dowMatches || domMatches
+        }
+        return dowMatches && domMatches
+    }
+
+    /// Walk minute-by-minute starting one minute after `from` until a match
+    /// is found. Returns `nil` after `cap` ticks (defaults to one year of
+    /// minutes — large enough that any valid cron expression matches at
+    /// least once, small enough to bound a runaway loop on a malformed but
+    /// parseable expression like `0 0 31 2 *`).
+    public func nextFireDate(
+        after from: Date,
+        in calendar: Calendar = Calendar(identifier: .gregorian),
+        cap: Int = 60 * 24 * 366
+    ) -> Date? {
+        // Truncate to the minute, then start scanning at the next minute.
+        var probe: Date = {
+            let comps = calendar.dateComponents(
+                [.year, .month, .day, .hour, .minute],
+                from: from
+            )
+            let truncated = calendar.date(from: comps) ?? from
+            return calendar.date(byAdding: .minute, value: 1, to: truncated) ?? from
+        }()
+
+        var ticks = 0
+        while ticks < cap {
+            if matches(probe, in: calendar) { return probe }
+            guard let next = calendar.date(byAdding: .minute, value: 1, to: probe) else {
+                return nil
+            }
+            probe = next
+            ticks += 1
+        }
+        return nil
+    }
+}
+

--- a/mercantis core/Scheduling/ScheduledTask.swift
+++ b/mercantis core/Scheduling/ScheduledTask.swift
@@ -1,0 +1,65 @@
+//
+//  ScheduledTask.swift
+//  mercantis core
+//
+//  P1.4 / §4.13 — Internal representation of one scheduler registration.
+//
+
+import Foundation
+
+/// One scheduled task registered with `SchedulerService`. (§4.13, P1.4)
+///
+/// A `ScheduledTask` is created when `ExtensionPointResolver` forwards a
+/// `SchedulerEventDeclaration` to the scheduler at install time. The task
+/// carries the cadence and the dispatch closure that runs the declaration's
+/// actions. The closure stays opaque to the scheduler — it is built by the
+/// resolver and binds the action list to the `ExtensionActionDispatcher`.
+public struct ScheduledTask: Sendable {
+
+    /// Stable identity for this task, used as the `scheduler_state` key. The
+    /// scheduler composes this from `appId::declarationId` so reinstalling
+    /// the same app preserves the last-run timestamp and the next firing time
+    /// is calculated from when the task last ran, not from when it was last
+    /// registered.
+    public let key: String
+
+    /// App that owns this task. Used by `unregister(appId:)` to drop every
+    /// task belonging to an uninstalled app in one call.
+    public let appId: String
+
+    /// Cadence at which the task should fire.
+    public let interval: ScheduleInterval
+
+    /// Closure invoked when the task is due. Synchronous and `Sendable` —
+    /// long work should `Task.detached` from inside the closure rather than
+    /// block the scheduler's tick.
+    public let dispatch: @Sendable () -> Void
+
+    /// Retry policy applied if `dispatch` throws. The scheduler does not
+    /// catch errors from `dispatch` directly — its closures are produced by
+    /// `ExtensionPointResolver`, which already routes failures through its
+    /// own `errorReporter`. The policy here governs scheduler-internal
+    /// retries (e.g. transient persistence failures); kept as a typed value
+    /// so future internal retries don't need a signature change.
+    public let retryPolicy: RetryPolicy
+
+    public init(
+        key: String,
+        appId: String,
+        interval: ScheduleInterval,
+        retryPolicy: RetryPolicy = .none,
+        dispatch: @escaping @Sendable () -> Void
+    ) {
+        self.key = key
+        self.appId = appId
+        self.interval = interval
+        self.retryPolicy = retryPolicy
+        self.dispatch = dispatch
+    }
+
+    public enum RetryPolicy: Sendable, Equatable {
+        case none
+        case fixed(attempts: Int, delay: TimeInterval)
+        case exponentialBackoff(attempts: Int, base: TimeInterval)
+    }
+}

--- a/mercantis core/Scheduling/SchedulerPersistence.swift
+++ b/mercantis core/Scheduling/SchedulerPersistence.swift
@@ -1,0 +1,138 @@
+//
+//  SchedulerPersistence.swift
+//  mercantis core
+//
+//  P1.4 — Persists each scheduled task's last-run timestamp so the
+//  launch-time due-check survives process restarts.
+//
+
+import Foundation
+import GRDB
+
+/// SQLite-backed `lastRun` store for `SchedulerService`. (P1.4, §4.13)
+///
+/// One row per task key in the `scheduler_state` table (created by
+/// migration v6). Reads / writes are routed through `MercantisDatabase` so
+/// they share the same `DatabasePool` as every other Core write — no
+/// independent connection lifecycle to worry about.
+public final class SchedulerPersistence: @unchecked Sendable {
+
+    private let database: MercantisDatabase
+    private let isoFormatter: ISO8601DateFormatter
+
+    public init(database: MercantisDatabase) {
+        self.database = database
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        self.isoFormatter = f
+    }
+
+    /// Last time the task with `key` ran, or `nil` if it has never run on
+    /// this device. Persistence read failures degrade to `nil` rather than
+    /// throw — the scheduler treats that the same as "never run", which
+    /// triggers a conservative immediate fire on next due-check.
+    public func lastRun(forKey key: String) -> Date? {
+        do {
+            return try database.read { db in
+                let row = try Row.fetchOne(
+                    db,
+                    sql: "SELECT lastRunAt FROM scheduler_state WHERE taskKey = ?",
+                    arguments: [key]
+                )
+                guard let raw: String = row?["lastRunAt"] else { return nil }
+                return self.parse(raw)
+            }
+        } catch {
+            return nil
+        }
+    }
+
+    /// Snapshot of every persisted last-run timestamp. Used by the service
+    /// at boot so it can decide which tasks fell behind while the app was
+    /// closed without N round-trips to SQLite.
+    public func loadAll() -> [String: Date] {
+        do {
+            return try database.read { db in
+                let rows = try Row.fetchAll(db, sql: "SELECT taskKey, lastRunAt FROM scheduler_state")
+                var out: [String: Date] = [:]
+                for row in rows {
+                    if let key: String = row["taskKey"],
+                       let raw: String = row["lastRunAt"],
+                       let parsed = self.parse(raw) {
+                        out[key] = parsed
+                    }
+                }
+                return out
+            }
+        } catch {
+            return [:]
+        }
+    }
+
+    /// Record that the task with `key` ran at `at`. Upserts the row, so a
+    /// missing-task and an existing-task call both resolve in one statement.
+    public func recordRun(key: String, at: Date) {
+        let stamp = isoFormatter.string(from: at)
+        do {
+            try database.write { db in
+                try db.execute(
+                    sql: """
+                        INSERT INTO scheduler_state (taskKey, lastRunAt) VALUES (?, ?)
+                        ON CONFLICT(taskKey) DO UPDATE SET lastRunAt = excluded.lastRunAt
+                        """,
+                    arguments: [key, stamp]
+                )
+            }
+        } catch {
+            // Persistence failure is non-fatal: the in-memory `lastRun` map
+            // inside `SchedulerService` still advances, so this process keeps
+            // a sane cadence. A fresh process restart could re-fire the task
+            // — preferred over silently losing it.
+        }
+    }
+
+    /// Remove the persisted last-run row for `key`. Used when a single task
+    /// is deregistered. Failures are silent for the same reason as
+    /// `recordRun(key:at:)`.
+    public func clear(key: String) {
+        do {
+            try database.write { db in
+                try db.execute(
+                    sql: "DELETE FROM scheduler_state WHERE taskKey = ?",
+                    arguments: [key]
+                )
+            }
+        } catch {
+            // See `recordRun(key:at:)`.
+        }
+    }
+
+    /// Remove every persisted last-run row whose key starts with
+    /// `appPrefix` — the scheduler composes keys as `appId::declarationId`,
+    /// so this drops every task belonging to one app on uninstall.
+    public func clear(appPrefix: String) {
+        let likePattern = appPrefix + "::%"
+        do {
+            try database.write { db in
+                try db.execute(
+                    sql: "DELETE FROM scheduler_state WHERE taskKey LIKE ?",
+                    arguments: [likePattern]
+                )
+            }
+        } catch {
+            // See `recordRun(key:at:)`.
+        }
+    }
+
+    // MARK: - Parsing
+
+    private func parse(_ raw: String) -> Date? {
+        // The writer always emits fractional-seconds ISO-8601, but accept a
+        // plain ISO-8601 string too for forward-compat with hand-written
+        // rows in tests.
+        if let parsed = isoFormatter.date(from: raw) {
+            return parsed
+        }
+        return ISO8601DateFormatter().date(from: raw)
+    }
+}

--- a/mercantis core/Scheduling/SchedulerService.swift
+++ b/mercantis core/Scheduling/SchedulerService.swift
@@ -1,0 +1,292 @@
+//
+//  SchedulerService.swift
+//  mercantis core
+//
+//  P1.4 / §4.13 — Periodic task scheduler.
+//
+//  Registers `ScheduledTask`s declared by app manifests via
+//  `ExtensionPointResolver`, persists the last-run timestamp per task in
+//  `scheduler_state`, and fires each task when its cadence has elapsed.
+//
+//  ### Lifecycle
+//
+//  - `register(declaration:appId:dispatch:)` — called by
+//    `ExtensionPointResolver` at install / restore time. Returns an
+//    `ExtensionSchedulerHandle` that the resolver retains; cancelling the
+//    handle removes the task.
+//  - `start()` — kicks off the periodic tick. The first tick runs
+//    immediately so launch-time backlog catches up; subsequent ticks happen
+//    on `tickInterval` (default 60s).
+//  - `stop()` — cancels the tick task. Outstanding handles still
+//    deregister cleanly when cancelled.
+//
+//  ### Concurrency model
+//
+//  The service holds a single `NSLock` around the `tasks` and `lastRun`
+//  state. Each tick snapshots due tasks under the lock, releases it, and
+//  invokes dispatch closures outside the lock so a slow handler can't block
+//  a `register` call from another thread. Persistence writes happen after
+//  dispatch returns — handlers that do their own async work need not hold
+//  any scheduler state.
+//
+
+import Foundation
+
+/// Periodic task scheduler. (P1.4, §4.13)
+public final class SchedulerService: ExtensionSchedulerRegistrar, @unchecked Sendable {
+
+    private let persistence: SchedulerPersistence
+    private let tickInterval: TimeInterval
+    private let clock: @Sendable () -> Date
+    private let calendar: Calendar
+    private let errorReporter: (@Sendable (SchedulerError) -> Void)?
+
+    private let lock = NSLock()
+    private var tasks: [String: ScheduledTask] = [:]
+    private var lastRun: [String: Date] = [:]
+    private var cronCache: [String: CronExpression] = [:]
+    private var tickTask: Task<Void, Never>?
+    private var isStarted = false
+
+    public init(
+        persistence: SchedulerPersistence,
+        tickInterval: TimeInterval = 60,
+        calendar: Calendar = Calendar(identifier: .gregorian),
+        clock: @escaping @Sendable () -> Date = { Date() },
+        errorReporter: (@Sendable (SchedulerError) -> Void)? = nil
+    ) {
+        self.persistence = persistence
+        self.tickInterval = tickInterval
+        self.calendar = calendar
+        self.clock = clock
+        self.errorReporter = errorReporter
+        self.lastRun = persistence.loadAll()
+    }
+
+    deinit {
+        tickTask?.cancel()
+    }
+
+    // MARK: - Lifecycle
+
+    /// Begin the periodic tick loop. Idempotent — calling `start()` twice
+    /// has no effect. The first tick runs immediately, before sleeping for
+    /// `tickInterval`, so a task that came due while the app was closed
+    /// fires on the first launch tick rather than waiting a full interval.
+    public func start() {
+        lock.lock()
+        if isStarted {
+            lock.unlock()
+            return
+        }
+        isStarted = true
+        lock.unlock()
+
+        let interval = tickInterval
+        tickTask = Task { [weak self] in
+            while !Task.isCancelled {
+                self?.tick()
+                let nanos = UInt64(max(interval, 0.001) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: nanos)
+            }
+        }
+    }
+
+    /// Cancel the tick loop. Tasks remain registered — call this on app
+    /// background or shutdown rather than on every uninstall.
+    public func stop() {
+        tickTask?.cancel()
+        tickTask = nil
+        lock.lock()
+        isStarted = false
+        lock.unlock()
+    }
+
+    // MARK: - Direct registration
+
+    /// Register a `ScheduledTask` directly. Used by tests and by host apps
+    /// that want to schedule first-party tasks without going through a
+    /// manifest. Returns a handle whose `cancel()` deregisters the task.
+    @discardableResult
+    public func register(_ task: ScheduledTask) -> ExtensionSchedulerHandle {
+        lock.lock()
+        tasks[task.key] = task
+        if case .cron(let expression) = task.interval {
+            cronCache[task.key] = try? CronExpression.parse(expression)
+            if cronCache[task.key] == nil {
+                lock.unlock()
+                errorReporter?(.invalidCron(taskKey: task.key, expression: expression))
+                return ExtensionSchedulerHandle { [weak self] in
+                    self?.deregister(key: task.key)
+                }
+            }
+        }
+        lock.unlock()
+
+        return ExtensionSchedulerHandle { [weak self] in
+            self?.deregister(key: task.key)
+        }
+    }
+
+    /// Manually fire a tick. Surfaced so the host can synchronously catch
+    /// up at launch (e.g. inside a `@main App`'s `init`) or test harnesses
+    /// can drive the scheduler without sleeping.
+    @discardableResult
+    public func tick() -> [String] {
+        let now = clock()
+        let due: [ScheduledTask] = {
+            lock.lock(); defer { lock.unlock() }
+            return tasks.values.filter { task in
+                isDue(task: task, at: now)
+            }
+        }()
+
+        for task in due {
+            task.dispatch()
+            recordRun(key: task.key, at: now)
+        }
+        return due.map { $0.key }
+    }
+
+    // MARK: - ExtensionSchedulerRegistrar conformance
+
+    public func register(
+        declaration: SchedulerEventDeclaration,
+        appId: String,
+        dispatch: @escaping @Sendable () -> Void
+    ) -> ExtensionSchedulerHandle {
+        let task = ScheduledTask(
+            key: Self.taskKey(appId: appId, declarationId: declaration.id),
+            appId: appId,
+            interval: declaration.interval,
+            dispatch: dispatch
+        )
+        return register(task)
+    }
+
+    /// Drop every persisted last-run row for `appId` and any in-memory
+    /// state that hasn't already been released via a handle. Called by
+    /// `AppInstaller.uninstall` *in addition to* the resolver's
+    /// per-handle teardown — the resolver path forgets the in-memory
+    /// binding (so it stops firing immediately) but deliberately leaves
+    /// `lastRun` and the persisted row in place so reinstall preserves
+    /// cadence. Full uninstall is the only point that wipes the row.
+    public func unregister(appId: String) {
+        let prefix = appId + "::"
+        lock.lock()
+        let lastRunKeys = lastRun.keys.filter { $0.hasPrefix(prefix) }
+        for key in lastRunKeys { lastRun.removeValue(forKey: key) }
+        let taskKeys = tasks.values.filter { $0.appId == appId }.map(\.key)
+        for key in taskKeys {
+            tasks.removeValue(forKey: key)
+            cronCache.removeValue(forKey: key)
+        }
+        lock.unlock()
+        persistence.clear(appPrefix: appId)
+    }
+
+    // MARK: - Inspection (test / diagnostics)
+
+    public func registeredTaskKeys() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return Array(tasks.keys)
+    }
+
+    public func taskCount(forAppId appId: String) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return tasks.values.reduce(0) { $0 + ($1.appId == appId ? 1 : 0) }
+    }
+
+    public func lastRunTimestamp(forKey key: String) -> Date? {
+        lock.lock(); defer { lock.unlock() }
+        return lastRun[key]
+    }
+
+    // MARK: - Internals
+
+    private func deregister(key: String) {
+        // Forget the in-memory binding so the next tick stops firing the
+        // task. Deliberately leave `lastRun` and the persisted row alone
+        // — see `unregister(appId:)` for the rationale (reinstall must
+        // preserve cadence).
+        lock.lock()
+        tasks.removeValue(forKey: key)
+        cronCache.removeValue(forKey: key)
+        lock.unlock()
+    }
+
+    private func recordRun(key: String, at date: Date) {
+        lock.lock()
+        lastRun[key] = date
+        lock.unlock()
+        persistence.recordRun(key: key, at: date)
+    }
+
+    /// True when `task` should fire at `now`. A task with no `lastRun`
+    /// fires immediately — the launch tick uses this to catch up tasks
+    /// whose cadence elapsed while the app was closed. Subsequent firings
+    /// are throttled by the interval's minimum gap (or the cron matcher
+    /// for `.cron`).
+    private func isDue(task: ScheduledTask, at now: Date) -> Bool {
+        let last = lastRun[task.key]
+
+        switch task.interval {
+        case .all:
+            // Fire on every tick. Used for the highest-frequency tasks.
+            // First tick always fires; subsequent ticks fire if the tick
+            // interval has fully elapsed.
+            guard let last else { return true }
+            return now.timeIntervalSince(last) >= max(tickInterval - 1, 0)
+
+        case .hourly, .daily, .weekly, .monthly:
+            guard let last else { return true }
+            return now >= nextFixedFire(after: last, interval: task.interval)
+
+        case .cron:
+            guard let cron = cronCache[task.key] else { return false }
+            // Two cases:
+            //   - Never run before: fire if `now` matches a tick window. We
+            //     treat the previous minute as the boundary so a freshly
+            //     installed task doesn't fire on a minute that already
+            //     passed before it registered.
+            //   - Has run before: fire if any cron tick fell between
+            //     `lastRun` and `now`.
+            let scanFrom = last ?? calendar.date(
+                byAdding: .minute, value: -1, to: now
+            ) ?? now
+            guard let next = cron.nextFireDate(after: scanFrom, in: calendar) else {
+                return false
+            }
+            return next <= now
+        }
+    }
+
+    /// Next time `interval` is allowed to fire after `last`. Used by the
+    /// fixed cadences (`.hourly`, `.daily`, `.weekly`, `.monthly`) — each
+    /// just adds the corresponding calendar component to `last`. We use the
+    /// calendar (not raw seconds) so daylight-saving transitions don't
+    /// shift a daily task's wall-clock time.
+    private func nextFixedFire(after last: Date, interval: ScheduleInterval) -> Date {
+        switch interval {
+        case .hourly:  return calendar.date(byAdding: .hour,  value: 1,  to: last) ?? last
+        case .daily:   return calendar.date(byAdding: .day,   value: 1,  to: last) ?? last
+        case .weekly:  return calendar.date(byAdding: .day,   value: 7,  to: last) ?? last
+        case .monthly: return calendar.date(byAdding: .month, value: 1,  to: last) ?? last
+        case .all, .cron: return last
+        }
+    }
+
+    static func taskKey(appId: String, declarationId: String) -> String {
+        "\(appId)::\(declarationId)"
+    }
+
+    // MARK: - Errors
+
+    public enum SchedulerError: Error, Sendable {
+        /// The cron expression on a registered task could not be parsed.
+        /// The task is registered (so `unregister(appId:)` still cleans it
+        /// up) but will never fire until re-registered with a valid
+        /// expression.
+        case invalidCron(taskKey: String, expression: String)
+    }
+}

--- a/mercantis core/Storage/MigrationRunner.swift
+++ b/mercantis core/Storage/MigrationRunner.swift
@@ -81,6 +81,7 @@ public struct MigrationRunner {
         runner.register(version: 3, name: "add_document_versions", sql: MigrationRunner.v3SQL)
         runner.register(version: 4, name: "add_sync_state", sql: MigrationRunner.v4SQL)
         runner.register(version: 5, name: "add_naming_counters", sql: MigrationRunner.v5SQL)
+        runner.register(version: 6, name: "add_scheduler_state", sql: MigrationRunner.v6SQL)
     }
 
     // MARK: - v1 Schema
@@ -228,6 +229,23 @@ public struct MigrationRunner {
         CREATE TABLE IF NOT EXISTS naming_counters (
             seriesKey   TEXT    PRIMARY KEY NOT NULL,
             value       INTEGER NOT NULL DEFAULT 0
+        );
+        """
+
+    // MARK: - v6 Schema — scheduler_state (P1.4)
+
+    private static let v6SQL = """
+        -- Last-run timestamps per scheduled task. Survives process restarts so
+        -- the launch-time due-check can decide whether a task should fire
+        -- immediately (cadence elapsed while the app was closed) or wait.
+        --
+        -- `taskKey` is the resolver-stable identity of one declaration:
+        --   "<appId>::<declarationId>"
+        -- which keeps it usable across reinstall (same app id, same decl id ⇒
+        -- preserved cadence) and isolates apps from each other.
+        CREATE TABLE IF NOT EXISTS scheduler_state (
+            taskKey     TEXT    PRIMARY KEY NOT NULL,
+            lastRunAt   TEXT    NOT NULL
         );
         """
 }

--- a/mercantis coreTests/MigrationRunnerTests.swift
+++ b/mercantis coreTests/MigrationRunnerTests.swift
@@ -56,7 +56,7 @@ final class MigrationRunnerTests: XCTestCase {
         MigrationRunner.registerAll(into: &runner, pool: pool)
         try runner.migrate(pool: pool)
 
-        XCTAssertEqual(try highestAppliedVersion(), 5)
+        XCTAssertEqual(try highestAppliedVersion(), 6)
     }
 
     func testV1CreatesExpectedTables() throws {
@@ -105,6 +105,16 @@ final class MigrationRunnerTests: XCTestCase {
         XCTAssertTrue(try tableExists("naming_counters"))
         XCTAssertTrue(try columnExists("seriesKey", in: "naming_counters"))
         XCTAssertTrue(try columnExists("value", in: "naming_counters"))
+    }
+
+    func testV6CreatesSchedulerStateTable() throws {
+        var runner = MigrationRunner()
+        MigrationRunner.registerAll(into: &runner, pool: pool)
+        try runner.migrate(pool: pool)
+
+        XCTAssertTrue(try tableExists("scheduler_state"))
+        XCTAssertTrue(try columnExists("taskKey", in: "scheduler_state"))
+        XCTAssertTrue(try columnExists("lastRunAt", in: "scheduler_state"))
     }
 
     func testSecondMigrateIsIdempotent() throws {

--- a/mercantis coreTests/README.md
+++ b/mercantis coreTests/README.md
@@ -40,7 +40,11 @@ the command line.
 | `ConflictResolverTests.swift` | `SyncEngine/` | LWW, VCM, AO across equal/newer/stale versions. |
 | `ValidationPipelineTests.swift` | `DocumentEngine/` | Each stage in isolation plus short-circuit ordering. |
 | `DocumentEngineTests.swift` | `DocumentEngine/` | Save/fetch round-trip, sync-queue atomicity, `DocumentVersion` recording, optimistic concurrency, submit immutability, cancel link integrity, amend. |
-| `MigrationRunnerTests.swift` | `Storage/` | v1/v2/v3 applied in order, expected tables/columns present, idempotent re-runs, custom migrations at higher versions. |
+| `MigrationRunnerTests.swift` | `Storage/` | v1–v6 applied in order, expected tables/columns present, idempotent re-runs, custom migrations at higher versions. |
+| `NamingTests.swift` | `Naming/` | Each strategy in isolation, `NamingService` dispatch, end-to-end through `DocumentEngine.save` including the counter-gap-on-validation-failure contract. |
+| `AutomationTests.swift` | `Automation/` | Each handler's happy / missing-parameter branches, registry dispatch, runner condition + re-entrancy, on-submit dispatch, scheduler-origin placeholder dispatch. |
+| `ExtensionPointsTests.swift` | `AppRuntime/` | Manifest decoding, install/uninstall lifecycle, reinstall idempotency, scheduler registrar round-trip, end-to-end event dispatch, restore on launch. |
+| `SchedulerTests.swift` | `Scheduling/` | Cron parser (wildcard / range / step / Sunday-as-zero-or-seven / errors), persistence round-trip + prefix-clear, due-check semantics for `.all` / `.hourly` / `.daily` / `.cron`, restart preserves cadence + fires backlog, handle-cancel preserves cadence for reinstall, `unregister(appId:)` wipes persistence, `ExtensionSchedulerRegistrar` conformance, end-to-end through `AppInstaller`. |
 
 Shared fixtures live in `Support/TestSupport.swift`.
 

--- a/mercantis coreTests/SchedulerTests.swift
+++ b/mercantis coreTests/SchedulerTests.swift
@@ -1,0 +1,572 @@
+//
+//  SchedulerTests.swift
+//  mercantis coreTests
+//
+//  P1.4 — Coverage for the Scheduling subsystem: cron parser, persistence,
+//  due-check semantics, and `ExtensionSchedulerRegistrar` conformance.
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class SchedulerTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private var url: URL!
+    private var database: MercantisDatabase!
+
+    override func setUpWithError() throws {
+        url = TestSupport.tempDatabaseURL("scheduler")
+        database = try TestSupport.makeDatabase(at: url)
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: url)
+        url = nil
+        database = nil
+    }
+
+    private static let utcCalendar: Calendar = {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }()
+
+    private func makeService(
+        tickInterval: TimeInterval = 60,
+        clock: @escaping @Sendable () -> Date = { Date() }
+    ) -> SchedulerService {
+        SchedulerService(
+            persistence: SchedulerPersistence(database: database),
+            tickInterval: tickInterval,
+            calendar: Self.utcCalendar,
+            clock: clock
+        )
+    }
+
+    private static func date(year: Int, month: Int, day: Int, hour: Int = 0, minute: Int = 0) -> Date {
+        var c = DateComponents()
+        c.year = year; c.month = month; c.day = day; c.hour = hour; c.minute = minute
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    // MARK: - CronExpression: parsing
+
+    func testCronParsesWildcardEveryMinute() throws {
+        let cron = try CronExpression.parse("* * * * *")
+        XCTAssertEqual(cron.minutes.count, 60)
+        XCTAssertEqual(cron.hours.count, 24)
+        XCTAssertEqual(cron.daysOfMonth.count, 31)
+        XCTAssertEqual(cron.months.count, 12)
+        XCTAssertEqual(cron.daysOfWeek.count, 7)
+        XCTAssertFalse(cron.dayFieldsAreUnion)
+    }
+
+    func testCronParsesExactValue() throws {
+        let cron = try CronExpression.parse("0 9 * * *")
+        XCTAssertEqual(cron.minutes, [0])
+        XCTAssertEqual(cron.hours, [9])
+    }
+
+    func testCronParsesCommaSeparatedList() throws {
+        let cron = try CronExpression.parse("0,15,30,45 * * * *")
+        XCTAssertEqual(cron.minutes, [0, 15, 30, 45])
+    }
+
+    func testCronParsesInclusiveRange() throws {
+        let cron = try CronExpression.parse("* 9-17 * * *")
+        XCTAssertEqual(cron.hours, Set(9...17))
+    }
+
+    func testCronParsesStepWithWildcard() throws {
+        let cron = try CronExpression.parse("*/15 * * * *")
+        XCTAssertEqual(cron.minutes, [0, 15, 30, 45])
+    }
+
+    func testCronParsesStepWithRange() throws {
+        let cron = try CronExpression.parse("0-30/10 * * * *")
+        XCTAssertEqual(cron.minutes, [0, 10, 20, 30])
+    }
+
+    func testCronAcceptsSundayAsZeroOrSeven() throws {
+        let zero = try CronExpression.parse("* * * * 0")
+        let seven = try CronExpression.parse("* * * * 7")
+        XCTAssertEqual(zero.daysOfWeek, [0])
+        XCTAssertEqual(seven.daysOfWeek, [0])
+    }
+
+    func testCronRejectsWrongFieldCount() {
+        XCTAssertThrowsError(try CronExpression.parse("* * * *"))
+        XCTAssertThrowsError(try CronExpression.parse("* * * * * *"))
+    }
+
+    func testCronRejectsOutOfRangeValue() {
+        XCTAssertThrowsError(try CronExpression.parse("60 * * * *"))
+        XCTAssertThrowsError(try CronExpression.parse("* 24 * * *"))
+        XCTAssertThrowsError(try CronExpression.parse("* * 32 * *"))
+        XCTAssertThrowsError(try CronExpression.parse("* * * 13 *"))
+    }
+
+    func testCronRejectsInvertedRange() {
+        XCTAssertThrowsError(try CronExpression.parse("30-10 * * * *"))
+    }
+
+    func testCronRejectsZeroStep() {
+        XCTAssertThrowsError(try CronExpression.parse("*/0 * * * *"))
+    }
+
+    func testCronRejectsNonIntegerValue() {
+        XCTAssertThrowsError(try CronExpression.parse("abc * * * *"))
+    }
+
+    // MARK: - CronExpression: matching
+
+    func testCronMatchesExactTime() throws {
+        let cron = try CronExpression.parse("30 14 * * *")
+        let utc = Calendar(identifier: .gregorian).withTimeZone(TimeZone(identifier: "UTC")!)
+        XCTAssertTrue(cron.matches(Self.date(year: 2026, month: 4, day: 24, hour: 14, minute: 30), in: utc))
+        XCTAssertFalse(cron.matches(Self.date(year: 2026, month: 4, day: 24, hour: 14, minute: 31), in: utc))
+        XCTAssertFalse(cron.matches(Self.date(year: 2026, month: 4, day: 24, hour: 15, minute: 30), in: utc))
+    }
+
+    func testCronDayFieldsUseUnionWhenBothExplicit() throws {
+        // "fire on the 1st of the month OR every Friday"
+        let cron = try CronExpression.parse("0 12 1 * 5")
+        XCTAssertTrue(cron.dayFieldsAreUnion)
+        let utc = Calendar(identifier: .gregorian).withTimeZone(TimeZone(identifier: "UTC")!)
+
+        // 2026-05-01 is a Friday — both match.
+        XCTAssertTrue(cron.matches(Self.date(year: 2026, month: 5, day: 1, hour: 12, minute: 0), in: utc))
+        // 2026-05-08 is a Friday but not the 1st — DOW match alone is enough under union semantics.
+        XCTAssertTrue(cron.matches(Self.date(year: 2026, month: 5, day: 8, hour: 12, minute: 0), in: utc))
+        // 2026-06-01 is a Monday — DOM match alone is enough under union semantics.
+        XCTAssertTrue(cron.matches(Self.date(year: 2026, month: 6, day: 1, hour: 12, minute: 0), in: utc))
+        // 2026-05-02 is a Saturday and not the 1st — neither matches.
+        XCTAssertFalse(cron.matches(Self.date(year: 2026, month: 5, day: 2, hour: 12, minute: 0), in: utc))
+    }
+
+    func testCronNextFireDateAdvancesPastNonMatchingMinutes() throws {
+        let cron = try CronExpression.parse("0 9 * * *")   // 09:00 daily
+        let utc = Calendar(identifier: .gregorian).withTimeZone(TimeZone(identifier: "UTC")!)
+        let from = Self.date(year: 2026, month: 4, day: 24, hour: 8, minute: 30)
+        let next = cron.nextFireDate(after: from, in: utc)
+        XCTAssertEqual(next, Self.date(year: 2026, month: 4, day: 24, hour: 9, minute: 0))
+    }
+
+    func testCronNextFireDateRollsToNextDay() throws {
+        let cron = try CronExpression.parse("0 9 * * *")
+        let utc = Calendar(identifier: .gregorian).withTimeZone(TimeZone(identifier: "UTC")!)
+        let from = Self.date(year: 2026, month: 4, day: 24, hour: 9, minute: 0)
+        let next = cron.nextFireDate(after: from, in: utc)
+        XCTAssertEqual(next, Self.date(year: 2026, month: 4, day: 25, hour: 9, minute: 0))
+    }
+
+    // MARK: - SchedulerPersistence
+
+    func testPersistenceRoundTripsLastRun() throws {
+        let p = SchedulerPersistence(database: database)
+        let stamp = Self.date(year: 2026, month: 4, day: 24, hour: 12, minute: 0)
+        p.recordRun(key: "app.x::daily", at: stamp)
+
+        XCTAssertEqual(p.lastRun(forKey: "app.x::daily")?.timeIntervalSince1970, stamp.timeIntervalSince1970, accuracy: 0.01)
+        XCTAssertEqual(p.loadAll().count, 1)
+    }
+
+    func testPersistenceUpsertsExistingKey() {
+        let p = SchedulerPersistence(database: database)
+        let early = Self.date(year: 2026, month: 4, day: 1)
+        let later = Self.date(year: 2026, month: 4, day: 10)
+        p.recordRun(key: "app.x::daily", at: early)
+        p.recordRun(key: "app.x::daily", at: later)
+
+        XCTAssertEqual(p.lastRun(forKey: "app.x::daily")?.timeIntervalSince1970, later.timeIntervalSince1970, accuracy: 0.01)
+        XCTAssertEqual(p.loadAll().count, 1)
+    }
+
+    func testPersistenceClearByPrefixDropsAppRows() {
+        let p = SchedulerPersistence(database: database)
+        let now = Self.date(year: 2026, month: 4, day: 24)
+        p.recordRun(key: "app.a::daily",  at: now)
+        p.recordRun(key: "app.a::weekly", at: now)
+        p.recordRun(key: "app.b::daily",  at: now)
+
+        p.clear(appPrefix: "app.a")
+
+        XCTAssertNil(p.lastRun(forKey: "app.a::daily"))
+        XCTAssertNil(p.lastRun(forKey: "app.a::weekly"))
+        XCTAssertNotNil(p.lastRun(forKey: "app.b::daily"))
+    }
+
+    // MARK: - SchedulerService: cadence
+
+    func testTickFiresTaskWithNoLastRun() {
+        let service = makeService()
+        var fired = 0
+        let task = ScheduledTask(
+            key: "app.x::daily",
+            appId: "app.x",
+            interval: .daily,
+            dispatch: { fired += 1 }
+        )
+        service.register(task)
+
+        let firedKeys = service.tick()
+        XCTAssertEqual(firedKeys, ["app.x::daily"])
+        XCTAssertEqual(fired, 1)
+    }
+
+    func testTickHonoursDailyCadenceAndDoesNotRefire() {
+        var clockNow = Self.date(year: 2026, month: 4, day: 24, hour: 12)
+        let service = makeService(clock: { clockNow })
+        var fired = 0
+        service.register(ScheduledTask(
+            key: "app.x::daily",
+            appId: "app.x",
+            interval: .daily,
+            dispatch: { fired += 1 }
+        ))
+
+        // First tick — fires (no lastRun).
+        XCTAssertEqual(service.tick(), ["app.x::daily"])
+
+        // 12 hours later — daily not yet due.
+        clockNow = clockNow.addingTimeInterval(12 * 3600)
+        XCTAssertEqual(service.tick(), [])
+
+        // 24 hours after the first run — fires again.
+        clockNow = Self.date(year: 2026, month: 4, day: 25, hour: 12)
+        XCTAssertEqual(service.tick(), ["app.x::daily"])
+
+        XCTAssertEqual(fired, 2)
+    }
+
+    func testHourlyCadenceFiresEveryHour() {
+        var clockNow = Self.date(year: 2026, month: 4, day: 24, hour: 9, minute: 0)
+        let service = makeService(clock: { clockNow })
+        var fired = 0
+        service.register(ScheduledTask(
+            key: "app.x::hourly",
+            appId: "app.x",
+            interval: .hourly,
+            dispatch: { fired += 1 }
+        ))
+
+        XCTAssertEqual(service.tick(), ["app.x::hourly"])    // first run
+        clockNow = clockNow.addingTimeInterval(30 * 60)       // +30 min
+        XCTAssertEqual(service.tick(), [])
+        clockNow = clockNow.addingTimeInterval(30 * 60)       // +60 min total
+        XCTAssertEqual(service.tick(), ["app.x::hourly"])
+        XCTAssertEqual(fired, 2)
+    }
+
+    func testCronCadenceFiresAtMatchingMinute() {
+        var clockNow = Self.date(year: 2026, month: 4, day: 24, hour: 8, minute: 59)
+        let service = makeService(clock: { clockNow })
+        var fired = 0
+        // 09:00 daily.
+        service.register(ScheduledTask(
+            key: "app.x::cron",
+            appId: "app.x",
+            interval: .cron("0 9 * * *"),
+            dispatch: { fired += 1 }
+        ))
+
+        // 08:59 — not due.
+        XCTAssertEqual(service.tick(), [])
+        XCTAssertEqual(fired, 0)
+
+        // 09:00 — due.
+        clockNow = Self.date(year: 2026, month: 4, day: 24, hour: 9, minute: 0)
+        XCTAssertEqual(service.tick(), ["app.x::cron"])
+        XCTAssertEqual(fired, 1)
+
+        // 09:01 same day — already fired today, not due again.
+        clockNow = Self.date(year: 2026, month: 4, day: 24, hour: 9, minute: 1)
+        XCTAssertEqual(service.tick(), [])
+
+        // 09:00 next day — due.
+        clockNow = Self.date(year: 2026, month: 4, day: 25, hour: 9, minute: 0)
+        XCTAssertEqual(service.tick(), ["app.x::cron"])
+        XCTAssertEqual(fired, 2)
+    }
+
+    func testCronInvalidExpressionReportsErrorAndDoesNotFire() {
+        let reportedExpectation = expectation(description: "errorReporter")
+        let service = SchedulerService(
+            persistence: SchedulerPersistence(database: database),
+            tickInterval: 60,
+            calendar: Self.utcCalendar,
+            errorReporter: { error in
+                if case .invalidCron = error { reportedExpectation.fulfill() }
+            }
+        )
+
+        var fired = 0
+        service.register(ScheduledTask(
+            key: "app.x::bad-cron",
+            appId: "app.x",
+            interval: .cron("nonsense"),
+            dispatch: { fired += 1 }
+        ))
+
+        wait(for: [reportedExpectation], timeout: 0.1)
+        XCTAssertEqual(service.tick(), [])
+        XCTAssertEqual(fired, 0)
+    }
+
+    // MARK: - SchedulerService: persistence + restart
+
+    func testLastRunSurvivesServiceRestart() {
+        let originalNow = Self.date(year: 2026, month: 4, day: 24, hour: 12)
+        var clockNow = originalNow
+
+        let first = makeService(clock: { clockNow })
+        first.register(ScheduledTask(
+            key: "app.x::daily",
+            appId: "app.x",
+            interval: .daily,
+            dispatch: {}
+        ))
+        XCTAssertEqual(first.tick(), ["app.x::daily"])
+        XCTAssertNotNil(first.lastRunTimestamp(forKey: "app.x::daily"))
+
+        // Simulate process restart: build a new service against the same DB.
+        let second = makeService(clock: { clockNow })
+        XCTAssertEqual(
+            second.lastRunTimestamp(forKey: "app.x::daily")?.timeIntervalSince1970,
+            originalNow.timeIntervalSince1970,
+            accuracy: 0.01
+        )
+
+        // Re-register and tick on the same calendar day — should not re-fire.
+        var fired = 0
+        second.register(ScheduledTask(
+            key: "app.x::daily",
+            appId: "app.x",
+            interval: .daily,
+            dispatch: { fired += 1 }
+        ))
+        XCTAssertEqual(second.tick(), [])
+        XCTAssertEqual(fired, 0)
+
+        // Advance past 24h — should fire.
+        clockNow = clockNow.addingTimeInterval(25 * 3600)
+        XCTAssertEqual(second.tick(), ["app.x::daily"])
+        XCTAssertEqual(fired, 1)
+    }
+
+    func testRestartFiresImmediatelyForBackloggedTask() {
+        let originalNow = Self.date(year: 2026, month: 4, day: 24, hour: 12)
+
+        let first = makeService(clock: { originalNow })
+        first.register(ScheduledTask(
+            key: "app.x::daily",
+            appId: "app.x",
+            interval: .daily,
+            dispatch: {}
+        ))
+        XCTAssertEqual(first.tick(), ["app.x::daily"])
+
+        // App stays closed for three days; on next launch the task is
+        // overdue and should fire on the first tick.
+        let later = originalNow.addingTimeInterval(3 * 24 * 3600)
+        let second = makeService(clock: { later })
+        var fired = 0
+        second.register(ScheduledTask(
+            key: "app.x::daily",
+            appId: "app.x",
+            interval: .daily,
+            dispatch: { fired += 1 }
+        ))
+        XCTAssertEqual(second.tick(), ["app.x::daily"])
+        XCTAssertEqual(fired, 1)
+    }
+
+    // MARK: - SchedulerService: lifecycle / handles
+
+    func testHandleCancelStopsFurtherDispatch() {
+        var clockNow = Self.date(year: 2026, month: 4, day: 24)
+        let service = makeService(clock: { clockNow })
+        var fired = 0
+        let handle = service.register(ScheduledTask(
+            key: "app.x::daily",
+            appId: "app.x",
+            interval: .daily,
+            dispatch: { fired += 1 }
+        ))
+
+        XCTAssertEqual(service.tick(), ["app.x::daily"])
+        XCTAssertEqual(fired, 1)
+
+        handle.cancel()
+
+        clockNow = clockNow.addingTimeInterval(48 * 3600)
+        XCTAssertEqual(service.tick(), [])
+        XCTAssertEqual(fired, 1)
+    }
+
+    func testHandleCancelPreservesPersistedLastRunForReinstall() {
+        let originalNow = Self.date(year: 2026, month: 4, day: 24, hour: 12)
+        var clockNow = originalNow
+        let service = makeService(clock: { clockNow })
+
+        let handle = service.register(ScheduledTask(
+            key: "app.x::daily",
+            appId: "app.x",
+            interval: .daily,
+            dispatch: {}
+        ))
+        XCTAssertEqual(service.tick(), ["app.x::daily"])
+
+        handle.cancel()
+
+        // Re-register the same task — handle.cancel() is the reinstall
+        // path. Last-run must be preserved so we don't fire again until
+        // 24 h have passed.
+        var fired = 0
+        service.register(ScheduledTask(
+            key: "app.x::daily",
+            appId: "app.x",
+            interval: .daily,
+            dispatch: { fired += 1 }
+        ))
+
+        // 12 hours later — daily not due.
+        clockNow = clockNow.addingTimeInterval(12 * 3600)
+        XCTAssertEqual(service.tick(), [])
+        XCTAssertEqual(fired, 0)
+
+        // 25 hours later — daily due.
+        clockNow = originalNow.addingTimeInterval(25 * 3600)
+        XCTAssertEqual(service.tick(), ["app.x::daily"])
+        XCTAssertEqual(fired, 1)
+    }
+
+    func testUnregisterByAppIdWipesPersistedRows() {
+        let now = Self.date(year: 2026, month: 4, day: 24)
+        let service = makeService(clock: { now })
+
+        service.register(ScheduledTask(key: "app.a::daily", appId: "app.a", interval: .daily, dispatch: {}))
+        service.register(ScheduledTask(key: "app.a::weekly", appId: "app.a", interval: .weekly, dispatch: {}))
+        service.register(ScheduledTask(key: "app.b::daily", appId: "app.b", interval: .daily, dispatch: {}))
+        _ = service.tick()
+
+        service.unregister(appId: "app.a")
+
+        XCTAssertEqual(service.taskCount(forAppId: "app.a"), 0)
+        XCTAssertEqual(service.taskCount(forAppId: "app.b"), 1)
+
+        // Persistence is gone for app.a too — verify by spinning a fresh service.
+        let restarted = makeService()
+        XCTAssertNil(restarted.lastRunTimestamp(forKey: "app.a::daily"))
+        XCTAssertNil(restarted.lastRunTimestamp(forKey: "app.a::weekly"))
+        XCTAssertNotNil(restarted.lastRunTimestamp(forKey: "app.b::daily"))
+    }
+
+    // MARK: - ExtensionSchedulerRegistrar conformance
+
+    func testServiceConformsToExtensionSchedulerRegistrar() {
+        let now = Self.date(year: 2026, month: 4, day: 24)
+        let service = makeService(clock: { now })
+        let registrar: ExtensionSchedulerRegistrar = service
+
+        var fired = 0
+        let handle = registrar.register(
+            declaration: SchedulerEventDeclaration(
+                id: "daily-cleanup",
+                interval: .daily,
+                actions: []
+            ),
+            appId: "app.test.registrar",
+            dispatch: { fired += 1 }
+        )
+        XCTAssertEqual(service.taskCount(forAppId: "app.test.registrar"), 1)
+
+        XCTAssertEqual(service.tick(), ["app.test.registrar::daily-cleanup"])
+        XCTAssertEqual(fired, 1)
+
+        handle.cancel()
+        XCTAssertEqual(service.taskCount(forAppId: "app.test.registrar"), 0)
+    }
+
+    // MARK: - End-to-end: AppInstaller + ExtensionPointResolver + SchedulerService
+
+    func testSchedulerWiredThroughExtensionPointResolverAndAppInstaller() throws {
+        let originalNow = Self.date(year: 2026, month: 4, day: 24, hour: 12)
+        var clockNow = originalNow
+
+        let scheduler = makeService(clock: { clockNow })
+        let dispatcher = LoggingExtensionActionDispatcher()
+        let registry = MetadataRegistry(database: database)
+        let emitter = EventEmitter()
+        let resolver = ExtensionPointResolver(
+            emitter: emitter,
+            dispatcher: dispatcher,
+            schedulerRegistrar: scheduler
+        )
+        let installer = AppInstaller(
+            database: database,
+            schemaValidator: SchemaValidator(),
+            registry: registry,
+            extensionResolver: resolver,
+            schedulerService: scheduler
+        )
+
+        let manifest = AppManifest(
+            id: "app.test.sched.e2e",
+            name: "Scheduler E2E",
+            version: "0.1.0",
+            minimumCoreVersion: "1.0.0",
+            description: "",
+            doctypes: [],
+            workflows: [],
+            permissions: [],
+            reports: [],
+            automationRules: [],
+            dashboards: [],
+            localizations: [],
+            extensionPoints: ExtensionPoints(
+                schedulerEvents: [
+                    SchedulerEventDeclaration(
+                        id: "daily-cleanup",
+                        interval: .daily,
+                        actions: [ExtensionActionDeclaration(actionType: "send_notification")]
+                    )
+                ]
+            )
+        )
+
+        try installer.install(manifest)
+        XCTAssertEqual(scheduler.taskCount(forAppId: manifest.id), 1)
+
+        // First tick fires the action through the dispatcher.
+        XCTAssertEqual(scheduler.tick().count, 1)
+        XCTAssertEqual(dispatcher.entries.count, 1)
+        XCTAssertEqual(dispatcher.entries.first?.actionType, "send_notification")
+        XCTAssertEqual(dispatcher.entries.first?.appId, manifest.id)
+
+        // Same day — not due.
+        clockNow = clockNow.addingTimeInterval(2 * 3600)
+        XCTAssertEqual(scheduler.tick(), [])
+
+        // Uninstall releases the binding and wipes scheduler persistence.
+        try installer.uninstall(appId: manifest.id)
+        XCTAssertEqual(scheduler.taskCount(forAppId: manifest.id), 0)
+
+        let restarted = makeService(clock: { clockNow })
+        XCTAssertNil(restarted.lastRunTimestamp(forKey: "\(manifest.id)::daily-cleanup"))
+    }
+}
+
+// MARK: - Calendar timezone helper
+
+private extension Calendar {
+    func withTimeZone(_ tz: TimeZone) -> Calendar {
+        var c = self
+        c.timeZone = tz
+        return c
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `SchedulerService` that fills the `ExtensionSchedulerRegistrar` seam, enabling apps to declare periodic tasks (hourly, daily, weekly, monthly, or custom cron expressions) that fire on a configurable tick interval while the app is active and survive process restarts via SQLite persistence.

## Key Changes

- **CronExpression.swift** — Dependency-free 5-field cron parser supporting wildcards, ranges, lists, and step syntax. Includes a minute-by-minute matcher and next-fire-date calculator. Handles Vixie-cron semantics where both day-of-month and day-of-week being explicit triggers OR logic instead of AND.

- **SchedulerService.swift** — Core scheduler that:
  - Registers `ScheduledTask` instances and conforms to `ExtensionSchedulerRegistrar`
  - Runs an opt-in `Task` loop (`start()` / `stop()`) that ticks every 60 seconds (configurable)
  - Fires tasks on first launch immediately (catches backlog from app closure) and respects cadence thereafter
  - Uses a single `NSLock` around task/lastRun state; snapshots due tasks under lock, releases it, then dispatches outside the lock to avoid blocking concurrent registrations
  - Provides `unregister(appId:)` to drop all persisted state for an uninstalled app

- **SchedulerPersistence.swift** — SQLite-backed store for last-run timestamps:
  - Reads/writes to `scheduler_state(taskKey, lastRunAt)` table via `MercantisDatabase`
  - Supports key-scoped clear (single task) and prefix-scoped clear (all tasks for an app)
  - Gracefully degrades read failures to `nil` (treated as "never run")

- **ScheduledTask.swift** — Internal representation carrying key, appId, interval, dispatch closure, and retry policy.

- **Migration v6** — Adds `scheduler_state` table with `taskKey` (primary key) and `lastRunAt` (ISO8601 timestamp).

- **AppInstaller integration** — Now accepts optional `schedulerService:` parameter and calls `unregister(appId:)` after extension resolver cleanup on uninstall. Resolver's `clear(appId:)` drops in-memory bindings; installer's `unregister(appId:)` is the only point that wipes persisted state, preserving cadence across reinstalls.

- **Comprehensive test suite** (572 lines) — Covers cron parsing (wildcards, ranges, lists, steps, edge cases), matching semantics (day-field union), persistence round-trips, cadence enforcement (daily/hourly/weekly/monthly/cron), launch-time backlog catch-up, handle cancellation, app uninstall cleanup, and `ExtensionSchedulerRegistrar` conformance.

## Notable Implementation Details

- Task keys are composed as `"<appId>::<declarationId>"` for stable identity across reinstalls
- First tick runs immediately on `start()` so launch-time due-check happens before the first sleep
- Cron expressions that never match (e.g., `0 0 31 2 *`) are bounded to one year of minute-by-minute checks to prevent runaway loops
- Dispatch closures are `@Sendable` and run synchronously; long work should `Task.detach` from inside
- Concurrency model uses a single lock around in-memory state; persistence writes happen after dispatch returns so handlers doing async work don't block the scheduler

https://claude.ai/code/session_01Vvk69Yu21hxJAnyCsJqpqX