### PR TITLE
P1.6: Expand FieldValue enum with typed date, data, and array cases

### DIFF
--- a/Docs/ARCHITECTURE-CHANGELOG.md
+++ b/Docs/ARCHITECTURE-CHANGELOG.md
@@ -137,6 +137,6 @@ The following topics were identified during this assessment but are not yet deci
 | Dynamic Link field type semantics | How `dynamic_link` fields (where the DocType is specified by another field) are resolved and validated. |
 | Backlink query support | How to efficiently query "all documents that link to this document" without full-table scans. |
 | ~~Sync queue pruning strategy~~ | Resolved in [ADR-028](ADR/ADR-028-sync-queue-pruning.md) (2026-04-23): acknowledged `.pushed` / `.applied` rows are deleted by `SyncEngine.pruneSyncQueue` once outside a configurable retention window, throttled by a persisted `sync_state` watermark. |
-| FieldValue type system deepening | Explicit `date`, `dateTime`, `data`, and `array` cases in `FieldValue`; type narrowing rules. |
+| ~~FieldValue type system deepening~~ | Resolved in P1.6 (2026-04-24): `FieldValue` gained `.date`, `.dateTime`, `.data`, and `.array` with a tagged-envelope wire format that preserves backward-compatible decoding of the legacy untagged primitives. |
 | Cross-document lookup in ExpressionEngine | A `lookup(docType, name, field)` function for reading a field from another document in expressions. |
 | Server-side validation via CloudAdapter | Whether the CloudAdapter protocol should include a server-side validation round-trip for documents before final commit. |

--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -1,6 +1,6 @@
 # Enhancement Proposal
 
-_Last updated: 2026-04-24 (P1.4 — Scheduler shipped)_
+_Last updated: 2026-04-24 (P1.6 — FieldValue expansion shipped)_
 
 Companion document to [`IMPLEMENTATION-STATUS.md`](./IMPLEMENTATION-STATUS.md). The status doc catalogues _what is_; this doc proposes _what to do next_. Each item is labelled with effort (S/M/L), risk, and the ADR or architecture section it closes.
 
@@ -388,9 +388,36 @@ Coverage in `ValidationPipelineTests.swift`:
 - `testWorkflowGuardSkipsRoleCheckForSystemContext`
 - `testWorkflowGuardReportsEvaluationErrorForMalformedCondition`
 
-### P1.6 — Expand `FieldValue` [S, low risk] — ARCHITECTURE-CHANGELOG follow-up
+### P1.6 — Expand `FieldValue` [S, low risk] — ARCHITECTURE-CHANGELOG follow-up *(done — 2026-04-24)*
 
-Add `.date(Date)`, `.dateTime(Date)`, `.data(Data)`, `.array([FieldValue])`. Decoder needs a disambiguation key (currently `FieldValue` is likely coded as a tagged enum — confirm during the changeset). This is a prerequisite for P2.8 (richer field controls) and for `FieldType.date` / `FieldType.datetime` to round-trip correctly rather than relying on string encoding.
+`FieldValue` now has nine cases: the original `.string` / `.int` / `.double` / `.bool` / `.null` primitives plus `.date(Date)`, `.dateTime(Date)`, `.data(Data)`, and `.array([FieldValue])`.
+
+Encoding uses a two-shape wire format. The legacy primitives still encode as untagged JSON (`"abc"`, `42`, `true`, `null`) so existing database rows and sync-queue blobs decode byte-for-byte. The four new cases encode as a tagged envelope:
+
+```json
+{ "$type": "date",     "$value": "2026-04-24T10:00:00Z" }
+{ "$type": "datetime", "$value": "2026-04-24T10:00:00Z" }
+{ "$type": "data",     "$value": "<base64>" }
+{ "$type": "array",    "$value": [ <FieldValue>, ... ] }
+```
+
+Decoder probes the tagged envelope first (`$type` tag dispatch) and falls back to the untagged primitive path, so a mixed-version dataset decodes without a migration.
+
+Downstream wiring followed the new cases out:
+
+- `TypeCoercionStage.isTypeCompatible` accepts typed `.date` / `.dateTime` for `.date` / `.datetime` fields and still accepts ISO8601 strings for backward compat; `.attachment` fields accept `.string` (id) or inline `.data`.
+- `RequiredFieldStage.isValueEmpty` treats typed dates as never empty, `.data` as empty iff the payload has zero bytes, and `.array` as empty iff it has zero elements.
+- `ExpressionEvaluator.numericValue` / `fieldValueToExprValue` surface dates as `timeIntervalSince1970`, so expressions like `start < end` work without a dedicated date AST; `.data` / `.array` fall through to `.null` for comparison purposes.
+- `ReportEngine.formatValue`, `GenericListView.displayValue`, and `BuiltInActionHandlers.stringify` emit deterministic display strings for every new case instead of returning `nil`.
+- `NamingService` strategies: `FormatStrategy` and `FieldDerivedStrategy` now stringify typed dates as ISO8601; `.data` and `.array` are rejected with `NamingError.missingFieldValue` (they are not naming-convertible).
+- `FieldValueDecoder` (the `set_value` handler's literal parser) gained `date` / `datetime` / `data` type tags so manifest-declared automation rules can target the typed cases; `array` is deliberately unsupported as a manifest string literal (constructed in code only).
+- `GenericFormView.dateBinding` now writes typed `.date` / `.dateTime` on save (based on the field's declared `FieldType`) and reads typed values first, falling back to the ISO8601-string path only for legacy rows.
+
+Coverage in `FieldValueTests.swift` (24 tests): tagged-envelope encode/decode for each new case, untagged primitive round-trip (backward-compat), explicit wire-shape assertion on the `data` envelope, unknown-`$type` rejection, recursive `.array` equality, `TypeCoercionStage` happy-paths and the bool-for-date rejection, `RequiredFieldStage` emptiness matrix for the new cases, `ExpressionEvaluator` ordering typed dates by epoch seconds and treating opaque values as null, `FormatStrategy` / `FieldDerivedStrategy` dispatch on `.date` / `.dateTime` plus rejection of `.data`, and `FieldValueDecoder` parsing `"date"` / `"data"` with a malformed-value rejection.
+
+**Known follow-ups (not scoped to P1.6):**
+- `FieldType` does not yet expose a dedicated "array" type or "data" type surface in the form builder; the new `FieldValue` cases are a storage/expression-layer expansion. Rendering new control types is P2.8 work.
+- `TypeCoercionStage` allows `.date` ↔ `.dateTime` interchange today (either typed case satisfies either field type). A stricter separation can land once the UI picker treats the two as distinct; keeping them interchangeable now avoids a forced migration for existing rows that used `.string` indiscriminately.
 
 ### P1.7 — Row-level permissions take a condition expression [M, medium risk] — ADR-011
 
@@ -595,8 +622,9 @@ A 4–6 week plan if one engineer is the target:
 | 5 | P1.3 Extension-point resolution ✅ (2026-04-24). |
 | 6 | P1.2 Automation runtime ✅ (2026-04-24) (fills the `ExtensionActionDispatcher` seam). |
 | 6 | P1.4 Scheduler ✅ (2026-04-24) (fills the `ExtensionSchedulerRegistrar` seam). |
+| 6 | P1.6 FieldValue expansion ✅ (2026-04-24) (tagged envelope, backward-compatible decode). |
 
-P1.6 FieldValue expansion and P1.7 row-level expressions slot in as individual PRs alongside the above.
+P1.7 row-level expressions slots in as an individual PR alongside the above; it now has typed dates to compare against via `ExpressionEvaluator`.
 
 P2.6 (Core library productization) should happen before Hub development begins in earnest — it is not large work but it is a prerequisite for the Core/Hub boundary being real. P2.7 (Hub readiness gap analysis) is a documentation item that can run in parallel with any P1 work. P2.4 (dashboard runtime) and P2.8 (richer field/control model) are both medium-term items best driven by Hub's concrete needs rather than by speculative pre-design.
 

--- a/Docs/IMPLEMENTATION-STATUS.md
+++ b/Docs/IMPLEMENTATION-STATUS.md
@@ -95,7 +95,7 @@ The goal is not to assign blame; it's to give future contributors an honest star
 ### 2.7 Expression Engine — §4.7 / ADR-017
 
 - **Partial** — Hand-rolled tokeniser + recursive-descent parser that **evaluates inline**. There is no AST type, no intermediate representation, and therefore no static field-reference analysis, no constant folding, and no source-position errors. The doc's "typed AST" claim is aspirational.
-- **Partial** — `FieldValue` has cases `.string`, `.int`, `.double`, `.bool`, `.null`. No `.date`, `.dateTime`, `.data`, `.array`. Already captured in the ARCHITECTURE-CHANGELOG follow-up list.
+- **Shipped (P1.6, 2026-04-24)** — `FieldValue` now includes `.date(Date)`, `.dateTime(Date)`, `.data(Data)`, and `.array([FieldValue])`. The four new cases encode as a tagged envelope (`{"$type": "date|datetime|data|array", "$value": ...}`) so they round-trip distinctly; the legacy primitives (`.string` / `.int` / `.double` / `.bool` / `.null`) still encode as untagged JSON and existing payloads continue to decode. Downstream wiring updated: `TypeCoercionStage` accepts typed dates for `.date` / `.datetime` fields and `.data` for `.attachment`; `RequiredFieldStage` treats typed dates as always non-empty and an empty `.data` / `.array` as empty; `ExpressionEvaluator` compares dates as epoch seconds; `GenericFormView.dateBinding` writes typed `.date` / `.dateTime` on save.
 - **Partial** — Numeric literal parsing consumes `-` only when it is the first token, so `a - 1` tokenises fine but `1 + -2` does not. Unary minus is not supported mid-expression.
 - **Partial** — No `lookup(docType, name, field)` (also already on the follow-up list).
 

--- a/mercantis core/Automation/BuiltInActionHandlers.swift
+++ b/mercantis core/Automation/BuiltInActionHandlers.swift
@@ -41,8 +41,9 @@ public enum BuiltInAutomationActions {
 ///   `FieldValueDecoder.decode(_:)` so `"42"` becomes `.int(42)`,
 ///   `"true"` becomes `.bool(true)`, etc.
 /// - `type` (optional) — force a specific `FieldValue` case:
-///   `"string" | "int" | "double" | "bool" | "null"`. When present,
-///   overrides the automatic inference.
+///   `"string" | "int" | "double" | "bool" | "null" | "date" | "datetime" | "data"`.
+///   When present, overrides the automatic inference. The `"array"` case is not
+///   expressible as a manifest string literal and must be constructed in code.
 public struct SetValueHandler: AutomationActionHandler {
     public static let actionType = "set_value"
     public init() {}
@@ -273,6 +274,33 @@ enum FieldValueDecoder {
                 }
             case "null":
                 return .null
+            case "date":
+                guard let d = ISO8601DateFormatter().date(from: raw) else {
+                    throw AutomationActionError.invalidParameter(
+                        actionType: "set_value",
+                        name: "value",
+                        reason: "expected ISO8601 date, got '\(raw)'"
+                    )
+                }
+                return .date(d)
+            case "datetime":
+                guard let d = ISO8601DateFormatter().date(from: raw) else {
+                    throw AutomationActionError.invalidParameter(
+                        actionType: "set_value",
+                        name: "value",
+                        reason: "expected ISO8601 datetime, got '\(raw)'"
+                    )
+                }
+                return .dateTime(d)
+            case "data":
+                guard let data = Data(base64Encoded: raw) else {
+                    throw AutomationActionError.invalidParameter(
+                        actionType: "set_value",
+                        name: "value",
+                        reason: "expected base64, got '\(raw)'"
+                    )
+                }
+                return .data(data)
             default:
                 throw AutomationActionError.invalidParameter(
                     actionType: "set_value",
@@ -342,6 +370,9 @@ enum ParameterInterpolator {
         case .double(let d): return String(d)
         case .bool(let b):   return b ? "true" : "false"
         case .null:          return ""
+        case .date(let d), .dateTime(let d): return ISO8601DateFormatter().string(from: d)
+        case .data(let d):   return d.base64EncodedString()
+        case .array(let xs): return "[\(xs.count) items]"
         }
     }
 }

--- a/mercantis core/DocumentEngine/ValidationPipeline.swift
+++ b/mercantis core/DocumentEngine/ValidationPipeline.swift
@@ -183,9 +183,15 @@ public struct TypeCoercionStage: ValidationStage {
 
     private func isTypeCompatible(value: FieldValue, fieldType: FieldType) -> Bool {
         switch fieldType {
-        case .text, .longText, .email, .phone, .select, .status, .multiselect, .link, .attachment:
+        case .text, .longText, .email, .phone, .select, .status, .multiselect, .link:
             if case .string = value { return true }
             return false
+        case .attachment:
+            // Attachments identify a blob — string id today, P1.6 `.data` inline path.
+            switch value {
+            case .string, .data: return true
+            default: return false
+            }
         case .number:
             switch value {
             case .int, .double: return true
@@ -201,10 +207,17 @@ public struct TypeCoercionStage: ValidationStage {
         case .boolean:
             if case .bool = value { return true }
             return false
-        case .date, .datetime:
-            // Dates are stored as ISO8601 strings.
-            if case .string = value { return true }
-            return false
+        case .date:
+            // P1.6: typed `.date`; ISO8601 string retained for legacy payloads.
+            switch value {
+            case .date, .dateTime, .string: return true
+            default: return false
+            }
+        case .datetime:
+            switch value {
+            case .dateTime, .date, .string: return true
+            default: return false
+            }
         case .formula:
             // Formula fields are computed — any stored value is acceptable.
             return true
@@ -246,7 +259,9 @@ public struct RequiredFieldStage: ValidationStage {
         switch value {
         case .null: return true
         case .string(let s): return s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        case .int, .double, .bool: return false
+        case .int, .double, .bool, .date, .dateTime: return false
+        case .data(let d): return d.isEmpty
+        case .array(let xs): return xs.isEmpty
         }
     }
 }

--- a/mercantis core/ExpressionEngine/ExpressionEvaluator.swift
+++ b/mercantis core/ExpressionEngine/ExpressionEvaluator.swift
@@ -379,6 +379,10 @@ public final class ExpressionEvaluator {
         case .string(let s): return Double(s) ?? 0
         case .bool(let b): return b ? 1 : 0
         case .null: return 0
+        // P1.6: dates compare/order as epoch seconds so `created > 0` and
+        // `created < deadline` work without adding a dedicated date AST.
+        case .date(let d), .dateTime(let d): return d.timeIntervalSince1970
+        case .data, .array: return 0
         }
     }
 
@@ -389,6 +393,8 @@ public final class ExpressionEvaluator {
         case .double(let d): return .number(d)
         case .bool(let b): return .bool(b)
         case .null: return .null
+        case .date(let d), .dateTime(let d): return .number(d.timeIntervalSince1970)
+        case .data, .array: return .null
         }
     }
 }

--- a/mercantis core/Metadata/FieldDefinition.swift
+++ b/mercantis core/Metadata/FieldDefinition.swift
@@ -29,16 +29,67 @@ public enum FieldType: String, Codable, Sendable, CaseIterable {
 }
 
 /// A value that can be assigned to a field.
+///
+/// The primitive cases (`.string`, `.int`, `.double`, `.bool`, `.null`) encode
+/// as untagged JSON so existing persisted payloads and sync-queue blobs
+/// round-trip byte-for-byte. The typed cases added in P1.6
+/// (`.date`, `.dateTime`, `.data`, `.array`) encode as a tagged envelope
+/// `{"$type": "<tag>", "$value": <payload>}` to disambiguate them from the
+/// string form the legacy wire used for dates and attachments.
 public enum FieldValue: Sendable, Equatable {
     case string(String)
     case int(Int)
     case double(Double)
     case bool(Bool)
     case null
+    case date(Date)
+    case dateTime(Date)
+    case data(Data)
+    case array([FieldValue])
 }
 
 extension FieldValue: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type  = "$type"
+        case value = "$value"
+    }
+
+    /// Tag strings used by the tagged envelope. Kept stable on the wire.
+    private enum Tag {
+        static let date     = "date"
+        static let dateTime = "datetime"
+        static let data     = "data"
+        static let array    = "array"
+    }
+
     public init(from decoder: Decoder) throws {
+        // Tagged envelope path — used by the new P1.6 cases. Old payloads never
+        // emit an object shape for a field value, so probing with `try?` is safe.
+        if let keyed = try? decoder.container(keyedBy: CodingKeys.self),
+           let tag = try? keyed.decode(String.self, forKey: .type) {
+            switch tag {
+            case Tag.date:
+                self = .date(try keyed.decode(Date.self, forKey: .value))
+                return
+            case Tag.dateTime:
+                self = .dateTime(try keyed.decode(Date.self, forKey: .value))
+                return
+            case Tag.data:
+                self = .data(try keyed.decode(Data.self, forKey: .value))
+                return
+            case Tag.array:
+                self = .array(try keyed.decode([FieldValue].self, forKey: .value))
+                return
+            default:
+                throw DecodingError.dataCorruptedError(
+                    forKey: .type,
+                    in: keyed,
+                    debugDescription: "Unknown FieldValue type tag '\(tag)'"
+                )
+            }
+        }
+
+        // Legacy untagged primitive path.
         let container = try decoder.singleValueContainer()
         if container.decodeNil() {
             self = .null
@@ -56,13 +107,38 @@ extension FieldValue: Codable {
     }
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
         switch self {
-        case .string(let s): try container.encode(s)
-        case .int(let i):    try container.encode(i)
-        case .double(let d): try container.encode(d)
-        case .bool(let b):   try container.encode(b)
-        case .null:          try container.encodeNil()
+        case .string(let s):
+            var c = encoder.singleValueContainer()
+            try c.encode(s)
+        case .int(let i):
+            var c = encoder.singleValueContainer()
+            try c.encode(i)
+        case .double(let d):
+            var c = encoder.singleValueContainer()
+            try c.encode(d)
+        case .bool(let b):
+            var c = encoder.singleValueContainer()
+            try c.encode(b)
+        case .null:
+            var c = encoder.singleValueContainer()
+            try c.encodeNil()
+        case .date(let d):
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            try c.encode(Tag.date, forKey: .type)
+            try c.encode(d, forKey: .value)
+        case .dateTime(let d):
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            try c.encode(Tag.dateTime, forKey: .type)
+            try c.encode(d, forKey: .value)
+        case .data(let d):
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            try c.encode(Tag.data, forKey: .type)
+            try c.encode(d, forKey: .value)
+        case .array(let xs):
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            try c.encode(Tag.array, forKey: .type)
+            try c.encode(xs, forKey: .value)
         }
     }
 }

--- a/mercantis core/Naming/FieldDerivedStrategy.swift
+++ b/mercantis core/Naming/FieldDerivedStrategy.swift
@@ -39,7 +39,9 @@ public struct FieldDerivedStrategy: NamingStrategy {
             return String(n)
         case .double(let d):
             return String(d)
-        case .bool, .null:
+        case .date(let d), .dateTime(let d):
+            return ISO8601DateFormatter().string(from: d)
+        case .bool, .null, .data, .array:
             throw NamingError.missingFieldValue(fieldKey: fieldKey)
         }
     }

--- a/mercantis core/Naming/FormatStrategy.swift
+++ b/mercantis core/Naming/FormatStrategy.swift
@@ -12,9 +12,9 @@ import Foundation
 /// and `document.fields["year"]`, concatenated with the dash literal in between.
 ///
 /// Unknown keys throw `NamingError.missingFieldValue`; unbalanced braces throw
-/// `NamingError.malformedAutonameToken`. Dates and other typed values that
-/// `FieldValue` cannot yet represent (see P1.6) are not supported — string /
-/// int / double / bool values only, converted to their natural string form.
+/// `NamingError.malformedAutonameToken`. Dates are expanded as ISO8601 strings;
+/// opaque values (`.data`, `.array`) are not stringifiable and throw
+/// `NamingError.missingFieldValue`.
 public struct FormatStrategy: NamingStrategy {
 
     public var handles: Set<String> { ["format"] }
@@ -67,7 +67,8 @@ public struct FormatStrategy: NamingStrategy {
         case .int(let n): return String(n)
         case .double(let d): return String(d)
         case .bool(let b): return String(b)
-        case .null: return nil
+        case .date(let d), .dateTime(let d): return ISO8601DateFormatter().string(from: d)
+        case .null, .data, .array: return nil
         }
     }
 }

--- a/mercantis core/Reporting/ReportEngine.swift
+++ b/mercantis core/Reporting/ReportEngine.swift
@@ -90,7 +90,23 @@ public final class ReportEngine {
         case .int(let i):    return "\(i)"
         case .double(let d): return String(format: "%.2f", d)
         case .bool(let b):   return b ? "Yes" : "No"
+        case .date(let d):   return Self.dateFormatter.string(from: d)
+        case .dateTime(let d): return Self.dateTimeFormatter.string(from: d)
+        case .data(let d):   return "<\(d.count) bytes>"
+        case .array(let xs): return "[\(xs.count) items]"
         case .null, nil:     return nil
         }
     }
+
+    private static let dateFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withFullDate]
+        return f
+    }()
+
+    private static let dateTimeFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
 }

--- a/mercantis core/UIShell/GenericFormView.swift
+++ b/mercantis core/UIShell/GenericFormView.swift
@@ -328,14 +328,24 @@ public struct GenericFormView: View {
     private func dateBinding(for field: FieldDefinition) -> Binding<Date> {
         Binding<Date>(
             get: {
-                if case .string(let s) = document.fields[field.key] {
-                    return ISO8601DateFormatter().date(from: s) ?? Date()
+                switch document.fields[field.key] {
+                case .date(let d), .dateTime(let d): return d
+                case .string(let s): return ISO8601DateFormatter().date(from: s) ?? Date()
+                default: return Date()
                 }
-                return Date()
             },
             set: { newValue in
-                let str = ISO8601DateFormatter().string(from: newValue)
-                document.fields[field.key] = .string(str)
+                // P1.6: write typed `.date` / `.dateTime` based on the declared
+                // field type. Falls back to ISO8601 string only for UI fields
+                // without a date type (should not happen through `dateField`).
+                switch field.type {
+                case .date:
+                    document.fields[field.key] = .date(newValue)
+                case .datetime:
+                    document.fields[field.key] = .dateTime(newValue)
+                default:
+                    document.fields[field.key] = .string(ISO8601DateFormatter().string(from: newValue))
+                }
             }
         )
     }

--- a/mercantis core/UIShell/GenericListView.swift
+++ b/mercantis core/UIShell/GenericListView.swift
@@ -195,6 +195,9 @@ public struct GenericListView: View {
         case .int(let i): return "\(i)"
         case .double(let d): return String(format: "%.2f", d)
         case .bool(let b): return b ? "Yes" : "No"
+        case .date(let d), .dateTime(let d): return ISO8601DateFormatter().string(from: d)
+        case .data(let d): return "<\(d.count) bytes>"
+        case .array(let xs): return "[\(xs.count) items]"
         case .null, nil: return "—"
         }
     }

--- a/mercantis coreTests/FieldValueTests.swift
+++ b/mercantis coreTests/FieldValueTests.swift
@@ -1,0 +1,405 @@
+//
+//  FieldValueTests.swift
+//  mercantis coreTests
+//
+//  P1.6 — Covers the expanded FieldValue enum: .date, .dateTime, .data,
+//  .array. Verifies tagged-envelope encoding, backward-compatible decoding of
+//  legacy untagged payloads, recursive equality, and the downstream behaviour
+//  that ValidationPipeline / ExpressionEvaluator / Reporting / Naming /
+//  Automation expose for the new cases.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class FieldValueTests: XCTestCase {
+
+    // MARK: - Codable round-trip
+
+    private func encoder() -> JSONEncoder {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }
+
+    private func decoder() -> JSONDecoder {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }
+
+    private func roundTrip(_ value: FieldValue, file: StaticString = #file, line: UInt = #line) throws {
+        // Round-trip inside `[String: FieldValue]` to match the production
+        // shape — FieldValue always travels inside Document.fields or a sync
+        // queue payload, never as a top-level JSON fragment.
+        let data = try encoder().encode(["k": value])
+        let decoded = try decoder().decode([String: FieldValue].self, from: data)
+        XCTAssertEqual(decoded["k"], value, file: file, line: line)
+    }
+
+    func testLegacyPrimitiveCasesRoundTrip() throws {
+        try roundTrip(.string("hello"))
+        try roundTrip(.string(""))
+        try roundTrip(.int(42))
+        try roundTrip(.int(-7))
+        try roundTrip(.double(3.14))
+        try roundTrip(.bool(true))
+        try roundTrip(.bool(false))
+        try roundTrip(.null)
+    }
+
+    func testLegacyPrimitivesEncodeAsUntaggedJSON() throws {
+        // Backward-compat: existing DB rows and sync-queue payloads predate the
+        // tagged envelope. New encodes of the legacy cases must match the old
+        // wire shape so a mixed-version reader doesn't break. Production always
+        // encodes inside `[String: FieldValue]`, so assert on that shape.
+        let enc = encoder()
+        enc.outputFormatting = [.sortedKeys]
+
+        XCTAssertEqual(try String(decoding: enc.encode(["k": FieldValue.string("x")]), as: UTF8.self), "{\"k\":\"x\"}")
+        XCTAssertEqual(try String(decoding: enc.encode(["k": FieldValue.int(7)]), as: UTF8.self), "{\"k\":7}")
+        XCTAssertEqual(try String(decoding: enc.encode(["k": FieldValue.bool(true)]), as: UTF8.self), "{\"k\":true}")
+        XCTAssertEqual(try String(decoding: enc.encode(["k": FieldValue.null]), as: UTF8.self), "{\"k\":null}")
+    }
+
+    func testDateCaseRoundTrips() throws {
+        let d = Date(timeIntervalSince1970: 1_700_000_000)
+        try roundTrip(.date(d))
+        try roundTrip(.dateTime(d))
+    }
+
+    func testDataCaseRoundTrips() throws {
+        try roundTrip(.data(Data([0x00, 0x01, 0xFF])))
+        try roundTrip(.data(Data()))
+    }
+
+    func testArrayCaseRoundTripsRecursively() throws {
+        try roundTrip(.array([]))
+        try roundTrip(.array([.string("a"), .int(1), .null]))
+        // Nested arrays — recursion.
+        try roundTrip(.array([.array([.bool(true), .double(2.5)]), .string("ok")]))
+    }
+
+    func testTaggedEnvelopeShapeIsStable() throws {
+        // The wire format is part of the sync contract; keep it explicit so
+        // a refactor that changes tag names trips this test. Encoded inside a
+        // dict to mirror the production `[String: FieldValue]` call site.
+        let enc = encoder()
+        enc.outputFormatting = [.sortedKeys]
+        let json = try String(decoding: enc.encode(["k": FieldValue.data(Data([0x41]))]), as: UTF8.self)
+        XCTAssertTrue(json.contains("\"$type\":\"data\""), "got: \(json)")
+        XCTAssertTrue(json.contains("\"$value\":\"QQ==\""), "got: \(json)")
+    }
+
+    func testDecoderRejectsUnknownTypeTag() {
+        let bad = Data(#"{"k":{"$type":"unknown","$value":1}}"#.utf8)
+        XCTAssertThrowsError(try decoder().decode([String: FieldValue].self, from: bad))
+    }
+
+    func testDecoderFallsBackToUntaggedPrimitives() throws {
+        // Exact shape a v1 payload would have written (inside a [String: FieldValue]
+        // dict, which is the production storage and sync-queue format).
+        func decodeOne(_ raw: String) throws -> FieldValue {
+            let data = Data("{\"k\":\(raw)}".utf8)
+            let dict = try decoder().decode([String: FieldValue].self, from: data)
+            return dict["k"] ?? .null
+        }
+        XCTAssertEqual(try decodeOne("\"abc\""), .string("abc"))
+        XCTAssertEqual(try decodeOne("42"), .int(42))
+        XCTAssertEqual(try decodeOne("3.5"), .double(3.5))
+        XCTAssertEqual(try decodeOne("true"), .bool(true))
+        XCTAssertEqual(try decodeOne("null"), .null)
+    }
+
+    // MARK: - Equality
+
+    func testEqualityForNewCases() {
+        let d = Date(timeIntervalSince1970: 1)
+        XCTAssertEqual(FieldValue.date(d), .date(d))
+        XCTAssertNotEqual(FieldValue.date(d), .dateTime(d))           // distinct cases
+        XCTAssertEqual(FieldValue.dateTime(d), .dateTime(d))
+        XCTAssertEqual(FieldValue.data(Data([1, 2])), .data(Data([1, 2])))
+        XCTAssertNotEqual(FieldValue.data(Data([1])), .data(Data([2])))
+        XCTAssertEqual(FieldValue.array([.int(1), .string("a")]),
+                       .array([.int(1), .string("a")]))
+        XCTAssertNotEqual(FieldValue.array([.int(1)]), .array([.int(2)]))
+    }
+
+    // MARK: - Validation: type coercion
+
+    func testTypeCoercionAcceptsTypedDateForDateField() {
+        let docType = TestSupport.makeDocType(fields: [
+            FieldDefinition(key: "due", label: "Due", type: .date, required: false)
+        ])
+        let doc = TestSupport.makeDocument(
+            docType: docType.id,
+            fields: ["due": .date(Date())]
+        )
+        let errors = TypeCoercionStage().validate(
+            document: doc,
+            context: ValidationContext(docType: docType)
+        )
+        XCTAssertTrue(errors.isEmpty)
+    }
+
+    func testTypeCoercionAcceptsTypedDateTimeForDatetimeField() {
+        let docType = TestSupport.makeDocType(fields: [
+            FieldDefinition(key: "at", label: "At", type: .datetime, required: false)
+        ])
+        let doc = TestSupport.makeDocument(
+            docType: docType.id,
+            fields: ["at": .dateTime(Date())]
+        )
+        let errors = TypeCoercionStage().validate(
+            document: doc,
+            context: ValidationContext(docType: docType)
+        )
+        XCTAssertTrue(errors.isEmpty)
+    }
+
+    func testTypeCoercionStillAcceptsLegacyStringDate() {
+        // Backward-compat for rows written before P1.6.
+        let docType = TestSupport.makeDocType(fields: [
+            FieldDefinition(key: "due", label: "Due", type: .date, required: false)
+        ])
+        let doc = TestSupport.makeDocument(
+            docType: docType.id,
+            fields: ["due": .string("2026-04-24T00:00:00Z")]
+        )
+        let errors = TypeCoercionStage().validate(
+            document: doc,
+            context: ValidationContext(docType: docType)
+        )
+        XCTAssertTrue(errors.isEmpty)
+    }
+
+    func testTypeCoercionRejectsBoolForDateField() {
+        let docType = TestSupport.makeDocType(fields: [
+            FieldDefinition(key: "due", label: "Due", type: .date, required: false)
+        ])
+        let doc = TestSupport.makeDocument(
+            docType: docType.id,
+            fields: ["due": .bool(true)]
+        )
+        let errors = TypeCoercionStage().validate(
+            document: doc,
+            context: ValidationContext(docType: docType)
+        )
+        XCTAssertEqual(errors.count, 1)
+        XCTAssertEqual(errors.first?.field, "due")
+    }
+
+    func testTypeCoercionAcceptsInlineDataForAttachment() {
+        let docType = TestSupport.makeDocType(fields: [
+            FieldDefinition(key: "avatar", label: "Avatar", type: .attachment, required: false)
+        ])
+        let doc = TestSupport.makeDocument(
+            docType: docType.id,
+            fields: ["avatar": .data(Data([0xFF]))]
+        )
+        let errors = TypeCoercionStage().validate(
+            document: doc,
+            context: ValidationContext(docType: docType)
+        )
+        XCTAssertTrue(errors.isEmpty)
+    }
+
+    // MARK: - Validation: required
+
+    func testRequiredEmptinessForNewCases() {
+        // Required-empty rules:
+        // - typed dates are never empty (they always carry a Date).
+        // - .data is empty only when the underlying Data has 0 bytes.
+        // - .array is empty only when there are 0 elements.
+        let docType = TestSupport.makeDocType(fields: [
+            FieldDefinition(key: "when", label: "When", type: .date, required: true),
+            FieldDefinition(key: "blob", label: "Blob", type: .attachment, required: true),
+            FieldDefinition(key: "tags", label: "Tags", type: .multiselect, required: true)
+        ])
+
+        let populated = TestSupport.makeDocument(
+            docType: docType.id,
+            fields: [
+                "when": .date(Date()),
+                "blob": .data(Data([0x01])),
+                "tags": .array([.string("a")])
+            ]
+        )
+        XCTAssertTrue(
+            RequiredFieldStage().validate(
+                document: populated,
+                context: ValidationContext(docType: docType)
+            ).isEmpty
+        )
+
+        let empty = TestSupport.makeDocument(
+            docType: docType.id,
+            fields: [
+                "when": .date(Date()),      // still populated
+                "blob": .data(Data()),      // 0 bytes → empty
+                "tags": .array([])          // 0 items → empty
+            ]
+        )
+        let errors = RequiredFieldStage().validate(
+            document: empty,
+            context: ValidationContext(docType: docType)
+        )
+        XCTAssertEqual(Set(errors.map { $0.field }), ["blob", "tags"])
+    }
+
+    // MARK: - ExpressionEvaluator
+
+    func testExpressionEvaluatorComparesDatesAsEpochSeconds() throws {
+        let early = Date(timeIntervalSince1970: 1_000_000)
+        let late  = Date(timeIntervalSince1970: 2_000_000)
+        let ctx: [String: FieldValue] = ["start": .date(early), "end": .dateTime(late)]
+        let eval = ExpressionEvaluator()
+        XCTAssertTrue(try eval.evaluateBool(expression: "start < end", context: ctx))
+        XCTAssertFalse(try eval.evaluateBool(expression: "start > end", context: ctx))
+    }
+
+    func testExpressionEvaluatorTreatsOpaqueValuesAsNullForComparison() throws {
+        let ctx: [String: FieldValue] = ["blob": .data(Data([0x01]))]
+        let eval = ExpressionEvaluator()
+        // Opaque values compare as .null — the only way equality to a number
+        // can succeed is the `!=` leg that matches any non-null literal.
+        XCTAssertTrue(try eval.evaluateBool(expression: "blob != 1", context: ctx))
+    }
+
+    // MARK: - Naming: FormatStrategy & FieldDerivedStrategy
+
+    func testFormatStrategyStringifiesDates() throws {
+        let docType = TestSupport.makeDocType(
+            id: "Invoice",
+            fields: [FieldDefinition(key: "issued", label: "Issued", type: .date, required: false)],
+            autoname: "format:INV-{issued}"
+        )
+        let doc = TestSupport.makeDocument(
+            docType: docType.id,
+            fields: ["issued": .date(Date(timeIntervalSince1970: 0))]
+        )
+        let service = NamingService()
+        let resolved = try service.resolve(
+            docType: docType,
+            document: doc,
+            context: NamingContext(now: Date())
+        )
+        XCTAssertTrue(resolved.hasPrefix("INV-1970-01-01"), "got: \(resolved)")
+    }
+
+    func testFormatStrategyRejectsDataAndArray() {
+        let docType = TestSupport.makeDocType(
+            id: "Thing",
+            fields: [FieldDefinition(key: "payload", label: "Payload", type: .attachment, required: false)],
+            autoname: "format:THG-{payload}"
+        )
+        let doc = TestSupport.makeDocument(
+            docType: docType.id,
+            fields: ["payload": .data(Data([0xAA]))]
+        )
+        let service = NamingService()
+        XCTAssertThrowsError(
+            try service.resolve(
+                docType: docType,
+                document: doc,
+                context: NamingContext(now: Date())
+            )
+        ) { error in
+            guard case NamingError.missingFieldValue(let key) = error else {
+                return XCTFail("expected missingFieldValue, got \(error)")
+            }
+            XCTAssertEqual(key, "payload")
+        }
+    }
+
+    func testFieldDerivedStrategyAcceptsDateValues() throws {
+        let docType = TestSupport.makeDocType(
+            id: "Stamp",
+            fields: [FieldDefinition(key: "at", label: "At", type: .datetime, required: false)],
+            autoname: "field:at"
+        )
+        let doc = TestSupport.makeDocument(
+            docType: docType.id,
+            fields: ["at": .dateTime(Date(timeIntervalSince1970: 0))]
+        )
+        let service = NamingService()
+        let resolved = try service.resolve(
+            docType: docType,
+            document: doc,
+            context: NamingContext(now: Date())
+        )
+        XCTAssertTrue(resolved.hasPrefix("1970-01-01"), "got: \(resolved)")
+    }
+
+    func testFieldDerivedStrategyRejectsOpaqueValues() {
+        let docType = TestSupport.makeDocType(
+            id: "Stamp",
+            fields: [FieldDefinition(key: "blob", label: "Blob", type: .attachment, required: false)],
+            autoname: "field:blob"
+        )
+        let doc = TestSupport.makeDocument(
+            docType: docType.id,
+            fields: ["blob": .data(Data([0xAA]))]
+        )
+        let service = NamingService()
+        XCTAssertThrowsError(
+            try service.resolve(
+                docType: docType,
+                document: doc,
+                context: NamingContext(now: Date())
+            )
+        )
+    }
+
+    // MARK: - Automation: FieldValueDecoder
+
+    func testFieldValueDecoderParsesTypedDate() throws {
+        // `set_value` handler parameters are untyped strings; the decoder
+        // needs an explicit "date" tag to produce a typed FieldValue.date.
+        let iso = "2026-04-24T10:00:00Z"
+        let registry = AutomationActionRegistry()
+        var doc = TestSupport.makeDocument(fields: [:])
+        try registry.execute(
+            actionType: "set_value",
+            parameters: ["field": "due", "value": iso, "type": "date"],
+            on: &doc,
+            context: AutomationContext(trigger: "on_save")
+        )
+        guard case .date(let d) = doc.fields["due"] else {
+            return XCTFail("expected .date, got \(String(describing: doc.fields["due"]))")
+        }
+        XCTAssertEqual(
+            ISO8601DateFormatter().string(from: d),
+            iso
+        )
+    }
+
+    func testFieldValueDecoderParsesBase64Data() throws {
+        let registry = AutomationActionRegistry()
+        var doc = TestSupport.makeDocument(fields: [:])
+        try registry.execute(
+            actionType: "set_value",
+            parameters: ["field": "blob", "value": "QUI=", "type": "data"],
+            on: &doc,
+            context: AutomationContext(trigger: "on_save")
+        )
+        guard case .data(let d) = doc.fields["blob"] else {
+            return XCTFail("expected .data, got \(String(describing: doc.fields["blob"]))")
+        }
+        XCTAssertEqual(d, Data([0x41, 0x42]))
+    }
+
+    func testFieldValueDecoderRejectsMalformedDate() {
+        let registry = AutomationActionRegistry()
+        var doc = TestSupport.makeDocument(fields: [:])
+        XCTAssertThrowsError(
+            try registry.execute(
+                actionType: "set_value",
+                parameters: ["field": "due", "value": "not-a-date", "type": "date"],
+                on: &doc,
+                context: AutomationContext(trigger: "on_save")
+            )
+        )
+    }
+}
+

--- a/mercantis coreTests/README.md
+++ b/mercantis coreTests/README.md
@@ -45,6 +45,7 @@ the command line.
 | `AutomationTests.swift` | `Automation/` | Each handler's happy / missing-parameter branches, registry dispatch, runner condition + re-entrancy, on-submit dispatch, scheduler-origin placeholder dispatch. |
 | `ExtensionPointsTests.swift` | `AppRuntime/` | Manifest decoding, install/uninstall lifecycle, reinstall idempotency, scheduler registrar round-trip, end-to-end event dispatch, restore on launch. |
 | `SchedulerTests.swift` | `Scheduling/` | Cron parser (wildcard / range / step / Sunday-as-zero-or-seven / errors), persistence round-trip + prefix-clear, due-check semantics for `.all` / `.hourly` / `.daily` / `.cron`, restart preserves cadence + fires backlog, handle-cancel preserves cadence for reinstall, `unregister(appId:)` wipes persistence, `ExtensionSchedulerRegistrar` conformance, end-to-end through `AppInstaller`. |
+| `FieldValueTests.swift` | `Metadata/` | Tagged-envelope encode/decode for the P1.6 cases (`.date`, `.dateTime`, `.data`, `.array`), untagged primitive round-trip (backward-compat), recursive `.array` equality, `TypeCoercionStage` / `RequiredFieldStage` behaviour on typed dates and inline data, `ExpressionEvaluator` comparing dates as epoch seconds, `FormatStrategy` / `FieldDerivedStrategy` stringification of dates and rejection of opaque values, `FieldValueDecoder` parsing `"date"` / `"data"` parameters in `set_value`. |
 
 Shared fixtures live in `Support/TestSupport.swift`.
 


### PR DESCRIPTION
## Summary

Extends the `FieldValue` enum with four new cases—`.date(Date)`, `.dateTime(Date)`, `.data(Data)`, and `.array([FieldValue])`—to enable proper type representation for dates, attachments, and collections. Implements a backward-compatible two-shape wire format: legacy primitives (string, int, double, bool, null) continue to encode as untagged JSON, while new cases use a tagged envelope `{"$type": "<tag>", "$value": <payload>}` for disambiguation.

## Key Changes

- **FieldValue enum expansion** (`FieldDefinition.swift`)
  - Added four new cases with proper `Codable` support
  - Decoder probes tagged envelope first, falls back to untagged primitives for backward compatibility
  - Encoder uses untagged JSON for legacy cases, tagged envelope for new cases
  - Tag strings (`"date"`, `"datetime"`, `"data"`, `"array"`) are stable on the wire

- **Validation pipeline updates** (`ValidationPipeline.swift`)
  - `TypeCoercionStage`: accepts typed `.date`/`.dateTime` for date fields; still accepts ISO8601 strings for legacy payloads; `.attachment` fields accept both string IDs and inline `.data`
  - `RequiredFieldStage`: typed dates are never empty; `.data` is empty only when zero bytes; `.array` is empty only when zero elements

- **Expression evaluation** (`ExpressionEvaluator.swift`)
  - Dates surface as `timeIntervalSince1970` for numeric comparison, enabling expressions like `start < end` without dedicated date AST
  - Opaque values (`.data`, `.array`) fall through to `.null` for comparison

- **Naming strategies** (`FormatStrategy.swift`, `FieldDerivedStrategy.swift`)
  - `FormatStrategy` stringifies dates as ISO8601; rejects opaque values
  - `FieldDerivedStrategy` accepts typed dates; rejects opaque values

- **Automation support** (`BuiltInActionHandlers.swift`)
  - `SetValueHandler` extended to parse `"date"`, `"datetime"`, and `"data"` type tags
  - `FieldValueDecoder` handles ISO8601 date parsing and base64 data decoding
  - `ParameterInterpolator` converts new cases back to strings for template expansion

- **UI layer updates** (`GenericFormView.swift`, `GenericListView.swift`)
  - Date bindings now read/write typed `.date`/`.dateTime` based on field type declaration
  - List view displays new cases with sensible summaries

- **Reporting** (`ReportEngine.swift`)
  - Formats dates with ISO8601 formatters; displays data/array summaries

- **Comprehensive test coverage** (`FieldValueTests.swift`)
  - 405 lines of tests covering round-trip encoding, backward-compatible decoding, equality, validation, expression evaluation, naming, and automation

## Implementation Details

- Mixed-version datasets decode without migration: old payloads (untagged primitives) and new payloads (tagged envelopes) coexist
- Date comparison in expressions uses epoch seconds, avoiding the need for a dedicated date AST
- The `.array` case is not expressible as a manifest string literal in automation (must be constructed in code)
- All downstream systems (validation, expressions, naming, automation, UI, reporting) have been wired to handle the new cases

https://claude.ai/code/session_01KTgyejQRpW2KuC7vwC4JGa