### PR TITLE
Productize Core as the MercantisCore library product (P2.6 / ADR-007)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -626,6 +626,8 @@ mercantis core/
 | `ImportExport/` — CSV/JSON importer + exporter + fixtures | §4.20 | — | P3.3 |
 | `Printing/` — `PrintFormat`, `PDFGenerator`, `LetterHead` | §4.17 | — | P3.2 |
 
+**SwiftPM module boundary.** `Package.swift` exposes a `MercantisCore` library product so Hub and third-party apps can `import MercantisCore` from a resolved package dependency (ADR-007, P2.6). The library target points at `mercantis core/` with `exclude: ["Assets.xcassets", "mercantis_coreApp.swift", "UIShell", "Views"]` — every engine subsystem above is part of the public package; the SwiftUI shell and `@main` entry stay in the Xcode app target. GRDB is declared as a SwiftPM dependency on the library target. The `mercantis` CLI executable continues to use its `MercantisCLI/SQLite3` system-library path; consolidating the two persistence stacks remains P2.3.
+
 ---
 
 ## 8. Architecture Decision Records

--- a/Docs/ADR/ADR-007-hub-on-core-public-apis.md
+++ b/Docs/ADR/ADR-007-hub-on-core-public-apis.md
@@ -1,6 +1,6 @@
 # ADR-007 — Hub Built Exclusively on Core Public APIs
 
-**Status:** Accepted  
+**Status:** Accepted (SwiftPM library product realized 2026-04-25, P2.6)
 **Date:** 2026-04-12
 
 ---
@@ -34,7 +34,7 @@ If Hub needs functionality that Core does not yet provide, the correct approach 
 - Feature development sometimes requires coordinated changes in both Core and Hub.
 
 **Neutral:**
-- Mercantis Hub (`mercantis.app`) is structured as an Xcode project that imports Core as a Swift package or embedded framework.
+- Mercantis Hub (`mercantis.app`) is structured as an Xcode project that imports Core as a Swift package or embedded framework. As of 2026-04-25 (P2.6) `Package.swift` exposes a `MercantisCore` library product covering the engine subsystems; the SwiftUI shell and `@main` entry stay in the Xcode app target. Hub can resolve and `import MercantisCore` from a standard `.package(url:from:)` dependency today.
 
 ---
 

--- a/Docs/ARCHITECTURE-CHANGELOG.md
+++ b/Docs/ARCHITECTURE-CHANGELOG.md
@@ -1,5 +1,36 @@
 # Mercantis Core — Architecture Changelog
 
+## Revision: 2026-04-25 (MercantisCore library product shipped — P2.6)
+
+This revision records the productization of Core as a reusable Swift package library, completing the precondition for ADR-007's "Hub imports Core as a Swift package or embedded framework" wiring. Hub — or any third-party app — can now consume Core via a standard `.package(url: ...)` dependency.
+
+### Code updated
+
+| File | Summary |
+|---|---|
+| `Package.swift` | Added a `.library(name: "MercantisCore", targets: ["MercantisCore"])` product. New `MercantisCore` target points at `mercantis core/` with `exclude:` for the four UI / app-shell entries (`Assets.xcassets`, `mercantis_coreApp.swift`, `UIShell`, `Views`). Added GRDB (`https://github.com/groue/GRDB.swift`, `from: "6.0.0"`) as a SwiftPM dependency, threaded through the library target only. The CLI executable continues to use its `MercantisCLI/SQLite3` system-library path; consolidating the two persistence stacks remains P2.3. |
+
+### Boundary established
+
+- Library compile set: `AppRuntime/`, `Automation/`, `Customization/`, `DocumentEngine/`, `ExpressionEngine/`, `Metadata/`, `Naming/`, `Notifications/`, `Permissions/`, `Reporting/`, `Scheduling/`, `Storage/`, `SyncEngine/`, `Workflows/` — 51 source files.
+- Excluded from the library: SwiftUI views in `UIShell/` and `Views/`, the `@main` `mercantis_coreApp.swift` entry, and `Assets.xcassets`. These continue to compile inside the Xcode app target only.
+- No engine source file imports SwiftUI / AppKit / UIKit. The boundary is one-way (UI → engine).
+- Access-modifier audit: every top-level engine type is `public` with `public init`s and `public func`s. Manifest / DocType value types expose `public let` / `public var` members. Two helpers in `Automation/BuiltInActionHandlers.swift` (`FieldValueDecoder`, `ParameterInterpolator`) are deliberately internal; nothing else needed visibility changes.
+
+### Doc updates
+
+| File | Summary |
+|---|---|
+| `Docs/ENHANCEMENT-PROPOSAL.md` P2.6 | Marked done. Detailed product/target shape, exclude list, GRDB wiring, audit summary, and the three known follow-ups (Xcode app target migration, SwiftPM test target wiring, P2.3 CLI consolidation). Sequencing footer updated. |
+
+### Known follow-ups
+
+- The Xcode app target (`mercantis core`) still compiles the engine source directly via project membership. Migrating it to consume the SwiftPM `MercantisCore` product instead is a `.pbxproj` change best made in Xcode itself; the library declaration alone is sufficient for Hub to consume Core today.
+- The XCTest files under `mercantis coreTests/` use `@testable import mercantis_core` (the Xcode app module name); mirroring them as a SwiftPM `testTarget` against `MercantisCore` would require switching the import and is left as follow-up to the Xcode test-target wire-up tracked in P0.1.
+- The CLI consolidating onto `MercantisCore` instead of its own raw-SQLite path remains P2.3.
+
+---
+
 ## Revision: 2026-04-25 (Row-level permission expressions shipped — P1.7)
 
 This revision replaces the equality-only `rowFilter` argument on `PermissionEngine.canAccessRow` with a sandboxed boolean `rowExpression` evaluated by `ExpressionEvaluator` (ADR-017) over the document's fields plus a `user.*` namespace. P1.6's typed `.date` / `.dateTime` cases land here as the comparison surface for deadline-style row predicates. No callers of the old signature existed in the codebase, so the swap was direct.

--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -1,6 +1,6 @@
 # Enhancement Proposal
 
-_Last updated: 2026-04-25 (P1.7 — row-level expression permissions shipped)_
+_Last updated: 2026-04-25 (P2.6 — MercantisCore library product shipped)_
 
 Companion document to [`IMPLEMENTATION-STATUS.md`](./IMPLEMENTATION-STATUS.md). The status doc catalogues _what is_; this doc proposes _what to do next_. Each item is labelled with effort (S/M/L), risk, and the ADR or architecture section it closes.
 
@@ -531,20 +531,27 @@ Until this is in place, every module home page falls back to `GenericListView`, 
 
 `DocumentEngine.list(docType:filters:)` is equality-only. Add `sortBy:`, `limit:`, and `where:` (expression) to match the advertised signature. The index definitions in `IndexDefinition` exist but are not yet used by the list path.
 
-### P2.6 — Productize Core as a reusable library target [M, low risk] — ADR-007
+### P2.6 — Productize Core as a reusable library target [M, low risk] — ADR-007 *(done — 2026-04-25)*
 
-`Package.swift` currently declares a single `.executable` product (`mercantis`) that wraps `MercantisCLI/Sources`. The `mercantis core/` engine exists as an embedded Xcode framework target inside `mercantis.core.app.xcodeproj`, but there is **no `.library` product in `Package.swift`** that Hub — or any third-party app — could reference with a standard `.package(url:from:)` dependency.
+`Package.swift` now declares a `.library(name: "MercantisCore", targets: ["MercantisCore"])` product alongside the existing `mercantis` executable. Hub — or any third-party app — can pull Core in with a standard `.package(url:from:)` dependency and `import MercantisCore`.
 
-ADR-007 states: "Mercantis Hub is structured as an Xcode project that imports Core as a Swift package or embedded framework." That presupposes an importable, versioned package product. Right now the Core/Hub boundary is architecturally correct but not mechanically enforced. Hub cannot `import MercantisCore` from a resolved Swift package dependency because no such product exists.
+```swift
+products: [
+    .library(name: "MercantisCore", targets: ["MercantisCore"]),
+    .executable(name: "mercantis", targets: ["mercantis"])
+]
+```
 
-Required work:
-- Extract `mercantis core/` source files into a proper `.library` target in `Package.swift` (e.g. target name `MercantisCore`).
-- Declare a `.library(name: "MercantisCore", targets: ["MercantisCore"])` product.
-- Audit `public` vs. `internal` access modifiers deliberately — every `public` member becomes part of the enforced API surface that Hub (and any third party) must use. Internal implementation details become un-importable by design.
-- The CLI target (`mercantis`) continues as an `.executable` that declares a dependency on `MercantisCore`.
-- The Xcode app target (`mercantis core`) becomes a consumer of the `MercantisCore` package target.
+The `MercantisCore` target points at the existing `mercantis core/` directory with `exclude:` for the four UI / app-shell entries (`Assets.xcassets`, `mercantis_coreApp.swift`, `UIShell/`, `Views/`). Engine subsystems — `AppRuntime/`, `Automation/`, `Customization/`, `DocumentEngine/`, `ExpressionEngine/`, `Metadata/`, `Naming/`, `Notifications/`, `Permissions/`, `Reporting/`, `Scheduling/`, `Storage/`, `SyncEngine/`, `Workflows/` (51 source files) — compile into the library; SwiftUI views and the App entry stay in the Xcode app target. GRDB is added as a SwiftPM dependency (`https://github.com/groue/GRDB.swift`, `from: "6.0.0"`) and threaded through the library target only — the CLI continues to use its `MercantisCLI/SQLite3` system-library path (consolidating the two persistence stacks is P2.3).
 
-Until this is done, the Core/Hub split is aspirational: the right design, but not an enforced Swift module boundary. ADR-007's "public/internal boundary in Core is enforced by the Swift module system" consequence is not yet true.
+Access-modifier audit: every top-level engine type (`DocumentEngine`, `MercantisDatabase`, `SyncEngine`, `WorkflowEngine`, `MetaComposer`, `MetadataRegistry`, `PermissionEngine`, `ValidationPipeline`, `ExpressionEvaluator`, `ReportEngine`, `AppInstaller`, `AutomationActionRegistry`, `AutomationRunner`, `SchedulerService`, `EventEmitter`, `NamingService`, `ConflictResolver`, …) is declared `public` with `public init`s and `public func`s. Manifest / DocType value types (`Document`, `DocType`, `FieldDefinition`, `FieldValue`, `PermissionRule`, `IndexDefinition`, `ResolvedMeta`, `MutationRecord`, `WorkflowDefinition`, …) expose `public let` / `public var` members. Two helpers in `Automation/BuiltInActionHandlers.swift` (`FieldValueDecoder`, `ParameterInterpolator`) are deliberately internal — they're implementation detail of the built-in action handlers. No engine source file imports SwiftUI / AppKit / UIKit; the boundary is one-way (UI → engine).
+
+ADR-007's "public/internal boundary in Core is enforced by the Swift module system" consequence is now true at the SwiftPM target level.
+
+**Known follow-ups (not scoped to P2.6):**
+- The Xcode app target (`mercantis core`) still compiles the engine source directly (via project membership). Migrating it to consume the `MercantisCore` SwiftPM product instead — so the Xcode-side build path also enforces the module boundary — is a `.pbxproj` change best done in Xcode itself: remove engine-folder file references from the app target's compile sources, add the local SwiftPM package as a dependency, and link `MercantisCore` in the app target. The library declaration itself is sufficient for Hub to start consuming Core today.
+- The XCTest files in `mercantis coreTests/` use `@testable import mercantis_core` (the Xcode app module name). They are not yet wired as a SwiftPM `testTarget` against `MercantisCore`. P0.1 already tracks the Xcode-side wire-up; mirroring as a SwiftPM test target would require `@testable import MercantisCore` and is left to follow up.
+- The CLI target consolidating onto `MercantisCore` (instead of its own raw-SQLite path) remains P2.3.
 
 ### P2.7 — Hub-on-Core readiness: what is sufficient vs. what is still missing [S, low risk] — ADR-007
 
@@ -644,8 +651,9 @@ A 4–6 week plan if one engineer is the target:
 | 6 | P1.4 Scheduler ✅ (2026-04-24) (fills the `ExtensionSchedulerRegistrar` seam). |
 | 6 | P1.6 FieldValue expansion ✅ (2026-04-24) (tagged envelope, backward-compatible decode). |
 | 7 | P1.7 row-level expression permissions ✅ (2026-04-25) (`user.*` namespace, fail-closed). |
+| 7 | P2.6 MercantisCore library product ✅ (2026-04-25) (Hub-importable engine target; UI stays in the app). |
 
-P2.6 (Core library productization) should happen before Hub development begins in earnest — it is not large work but it is a prerequisite for the Core/Hub boundary being real. P2.7 (Hub readiness gap analysis) is a documentation item that can run in parallel with any P1 work. P2.4 (dashboard runtime) and P2.8 (richer field/control model) are both medium-term items best driven by Hub's concrete needs rather than by speculative pre-design.
+P2.6 (Core library productization) ✅ shipped 2026-04-25 — the `MercantisCore` library product now exists, so Hub development can start importing Core via `.package(url: ...)`. P2.7 (Hub readiness gap analysis) is a documentation item that can run in parallel with any P1 work. P2.4 (dashboard runtime) and P2.8 (richer field/control model) are both medium-term items best driven by Hub's concrete needs rather than by speculative pre-design.
 
 P3.6 (POS platform) should not begin until P1.1, P3.2, P2.8, and P1.2/P1.3 are substantially complete. The sequencing dependency is real: a POS without naming, printing, richer controls, and automation is not a POS.
 

--- a/Docs/IMPLEMENTATION-STATUS.md
+++ b/Docs/IMPLEMENTATION-STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-_Last updated: 2026-04-24 (P1.4 — Scheduler shipped)_
+_Last updated: 2026-04-25 (P2.6 — MercantisCore library product shipped)_
 
 A candid map between `ARCHITECTURE.md` / the ADR set and what is actually present in `mercantis core/`. Each entry is graded:
 
@@ -186,7 +186,18 @@ Both `Modules` and `DocTypes` route through `RecordCollectionHostView`, so all s
 
 ---
 
-## 4. The MercantisCLI target
+## 4. SwiftPM products
+
+`Package.swift` declares two products:
+
+- `.library(name: "MercantisCore", targets: ["MercantisCore"])` — the engine, importable via `.package(url:from:)`. The target points at `mercantis core/` with `exclude: ["Assets.xcassets", "mercantis_coreApp.swift", "UIShell", "Views"]`, so SwiftUI / app-shell code is deliberately not part of the library. GRDB (`https://github.com/groue/GRDB.swift`, `from: "6.0.0"`) is declared on the library target. Shipped in P2.6 (2026-04-25).
+- `.executable(name: "mercantis", targets: ["mercantis"])` — the CLI. Continues to use `MercantisCLI/SQLite3` as a system library; consolidating onto `MercantisCore` is P2.3.
+
+Notes on consumers:
+- The Xcode app target (`mercantis core`) still compiles the engine source via project membership rather than via the SwiftPM library. The `.library` declaration is sufficient for Hub to consume Core today; migrating the Xcode app to consume the SwiftPM library is a `.pbxproj` change best done in Xcode itself.
+- The XCTest files in `mercantis coreTests/` use `@testable import mercantis_core` (the Xcode app module name) and are not yet wired as a SwiftPM test target. P0.1 tracks the Xcode-side wire-up.
+
+## 5. The MercantisCLI target
 
 `MercantisCLI/` is a separate SwiftPM executable built on `swift-argument-parser`. Commands:
 
@@ -200,7 +211,7 @@ This is a useful parallel tool but also a **duplicate installer code path**. The
 
 ---
 
-## 5. Summary for new contributors
+## 6. Summary for new contributors
 
 If you open the repo today expecting to find everything ARCHITECTURE.md §7 advertises, here is the short list of what _to stop looking for_:
 

--- a/Package.swift
+++ b/Package.swift
@@ -7,10 +7,16 @@ let package = Package(
         .macOS(.v14)
     ],
     products: [
+        // The Core engine, importable by Hub or any third-party app via
+        // .package(url: ...). UI code (UIShell/, Views/) and the App entry
+        // (mercantis_coreApp.swift) deliberately stay in the Xcode app target
+        // and are not part of this library product. (ADR-007, P2.6)
+        .library(name: "MercantisCore", targets: ["MercantisCore"]),
         .executable(name: "mercantis", targets: ["mercantis"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0")
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(url: "https://github.com/groue/GRDB.swift", from: "6.0.0")
     ],
     targets: [
         .systemLibrary(
@@ -20,6 +26,19 @@ let package = Package(
             providers: [
                 .apt(["libsqlite3-dev"]),
                 .brew(["sqlite3"])
+            ]
+        ),
+        .target(
+            name: "MercantisCore",
+            dependencies: [
+                .product(name: "GRDB", package: "GRDB.swift")
+            ],
+            path: "mercantis core",
+            exclude: [
+                "Assets.xcassets",
+                "mercantis_coreApp.swift",
+                "UIShell",
+                "Views"
             ]
         ),
         .executableTarget(


### PR DESCRIPTION
`Package.swift` now declares
`.library(name: "MercantisCore", targets: ["MercantisCore"])` alongside
the existing `mercantis` executable. Hub — or any third-party app — can
pull Core in with a standard `.package(url: ...)` dependency and
`import MercantisCore`. ADR-007's "public/internal boundary in Core is
enforced by the Swift module system" consequence is now true at the
SwiftPM target level.

The `MercantisCore` target points at `mercantis core/` with `exclude:`
for the four UI / app-shell entries (`Assets.xcassets`,
`mercantis_coreApp.swift`, `UIShell/`, `Views/`). Every engine
subsystem — `AppRuntime/`, `Automation/`, `Customization/`,
`DocumentEngine/`, `ExpressionEngine/`, `Metadata/`, `Naming/`,
`Notifications/`, `Permissions/`, `Reporting/`, `Scheduling/`,
`Storage/`, `SyncEngine/`, `Workflows/` (51 source files) — compiles
into the library. SwiftUI views and the `@main` entry stay in the Xcode
app target only. GRDB is added as a SwiftPM dependency
(`https://github.com/groue/GRDB.swift`, `from: "6.0.0"`) and threaded
through the library target only; the CLI executable continues to use its
`MercantisCLI/SQLite3` system-library path (consolidating the two
persistence stacks remains P2.3).

Access-modifier audit: every top-level engine type (DocumentEngine,
MercantisDatabase, SyncEngine, WorkflowEngine, MetaComposer,
MetadataRegistry, PermissionEngine, ValidationPipeline,
ExpressionEvaluator, ReportEngine, AppInstaller,
AutomationActionRegistry, AutomationRunner, SchedulerService,
EventEmitter, NamingService, ConflictResolver, …) is `public` with
`public init`s and `public func`s; manifest / DocType value types
expose `public let` / `public var` members. Two helpers in
`Automation/BuiltInActionHandlers.swift` (`FieldValueDecoder`,
`ParameterInterpolator`) are deliberately internal. No engine source
file imports SwiftUI / AppKit / UIKit; the boundary is one-way
(UI → engine). No code changes were required.

Doc updates: `Package.swift` carries an inline comment recording the
exclude rationale; `ARCHITECTURE.md` §7 gains a "SwiftPM module
boundary" note; ADR-007 records the realization date and the live
product shape; `ENHANCEMENT-PROPOSAL.md` P2.6 is marked done with the
exclude list, GRDB wiring, audit summary, and three known follow-ups
(Xcode app target migration, SwiftPM test target wiring, P2.3 CLI
consolidation); `IMPLEMENTATION-STATUS.md` adds a "SwiftPM products"
section; new `ARCHITECTURE-CHANGELOG.md` revision dated 2026-04-25.

Known follow-ups (not scoped to P2.6):
- The Xcode app target still compiles the engine source via project
  membership rather than via the SwiftPM library. The library
  declaration is sufficient for Hub to consume Core today; migrating
  the Xcode app to consume the SwiftPM product is a `.pbxproj` change
  best made in Xcode itself.
- The XCTest files use `@testable import mercantis_core` (the Xcode
  app module name) and are not yet wired as a SwiftPM testTarget.
  P0.1 tracks the Xcode-side wire-up.
- The CLI consolidating onto `MercantisCore` instead of its own
  raw-SQLite path remains P2.3.

https://claude.ai/code/session_01JMXnZREZnVgKzQkTTj99jD