### PR TITLE
Update Mercantis Hub repository name from mercantis.app to mercantis.hub.app

### DIFF
--- a/Docs/ADR/ADR-001-core-hub-split.md
+++ b/Docs/ADR/ADR-001-core-hub-split.md
@@ -19,7 +19,7 @@ Two concerns needed to be separated:
 We will maintain two separate repositories with a strict dependency direction:
 
 - **`mercantis.core.app`** — The platform layer. Contains the infrastructure subsystems (Storage, DocumentEngine, MetadataRegistry, SyncEngine, PermissionsEngine, WorkflowEngine, ExpressionEngine, AppRuntime, Notifications). It has **no knowledge** of any specific business domain.
-- **`mercantis.app`** (Mercantis Hub) — The first-party ERP application. Declares its domain entities entirely in app manifests (DocTypes, workflows, permissions, reports) and calls only Core's public APIs. It contains **no infrastructure code**.
+- **`mercantis.hub.app`** (Mercantis Hub) — The first-party ERP application. Declares its domain entities entirely in app manifests (DocTypes, workflows, permissions, reports) and calls only Core's public APIs. It contains **no infrastructure code**.
 
 ## Consequences
 

--- a/Docs/ADR/ADR-004-declarative-app-plugin-model.md
+++ b/Docs/ADR/ADR-004-declarative-app-plugin-model.md
@@ -42,7 +42,7 @@ Mercantis Core needs an extensibility model that allows domain-specific applicat
 - Expression language is necessarily limited (see [ADR-008](ADR-008-no-executable-plugins-ios.md)).
 
 **Neutral:**
-- Hub (`mercantis.app`) is simply an app manifest; it uses the same plugin model as any third-party application.
+- Hub (`mercantis.hub.app`) is simply an app manifest; it uses the same plugin model as any third-party application.
 
 ---
 

--- a/Docs/ADR/ADR-007-hub-on-core-public-apis.md
+++ b/Docs/ADR/ADR-007-hub-on-core-public-apis.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-Mercantis Hub (`mercantis.app`) is the first-party ERP application built on Mercantis Core. There is a temptation when building a first-party app to take shortcuts: call internal Core methods, access the database directly, or add domain-specific hooks into Core's subsystems. These shortcuts create hidden coupling that makes it impossible to later separate Core from Hub.
+Mercantis Hub (`mercantis.hub.app`) is the first-party ERP application built on Mercantis Core. There is a temptation when building a first-party app to take shortcuts: call internal Core methods, access the database directly, or add domain-specific hooks into Core's subsystems. These shortcuts create hidden coupling that makes it impossible to later separate Core from Hub.
 
 ## Decision
 
@@ -34,7 +34,7 @@ If Hub needs functionality that Core does not yet provide, the correct approach 
 - Feature development sometimes requires coordinated changes in both Core and Hub.
 
 **Neutral:**
-- Mercantis Hub (`mercantis.app`) is structured as an Xcode project that imports Core as a Swift package or embedded framework. As of 2026-04-25 (P2.6) `Package.swift` exposes a `MercantisCore` library product covering the engine subsystems; the SwiftUI shell and `@main` entry stay in the Xcode app target. Hub can resolve and `import MercantisCore` from a standard `.package(url:from:)` dependency today.
+- Mercantis Hub (`mercantis.hub.app`) is structured as an Xcode project that imports Core as a Swift package or embedded framework. As of 2026-04-25 (P2.6) `Package.swift` exposes a `MercantisCore` library product covering the engine subsystems; the SwiftUI shell and `@main` entry stay in the Xcode app target. Hub can resolve and `import MercantisCore` from a standard `.package(url:from:)` dependency today.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Mercantis Core is the general-purpose platform layer that provides the foundational infrastructure for any business application built on the Mercantis ecosystem. It handles documents, workflows, sync, permissions, and app installation — all without knowing anything about specific business domains.
 
-[Mercantis Hub](https://github.com/KevinBusuttil/mercantis.app) is the first-party ERP application built entirely on top of Core's public APIs.
+[Mercantis Hub](https://github.com/KevinBusuttil/mercantis.hub.app) is the first-party ERP application built entirely on top of Core's public APIs.
 
 ## Key Capabilities
 


### PR DESCRIPTION
## Summary
This PR updates all documentation references to reflect the correct repository name for Mercantis Hub, changing from `mercantis.app` to `mercantis.hub.app` across multiple Architecture Decision Records and the README.

## Changes Made
- Updated ADR-001 (Core-Hub Split) to reference the correct Hub repository name
- Updated ADR-004 (Declarative App Plugin Model) to reference the correct Hub repository name
- Updated ADR-007 (Hub on Core Public APIs) to reference the correct Hub repository name in both the Context and Neutral sections
- Updated README.md to link to the correct Hub repository URL

## Details
All changes are documentation-only, ensuring that developers and stakeholders have accurate repository references when reviewing architectural decisions and project structure. The repository name correction (`mercantis.app` → `mercantis.hub.app`) provides clarity about the Hub's purpose and distinguishes it from the Core platform.

https://claude.ai/code/session_01M4TJfuZ8ZLveDgN9afpHVr