### PR TITLE
Promote UIShell/ to MercantisCoreUI library product

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -637,7 +637,12 @@ mercantis core/
 | `ImportExport/` — CSV/JSON importer + exporter + fixtures | §4.20 | — | P3.3 |
 | `Printing/` — `PrintFormat`, `PDFGenerator`, `LetterHead` | §4.17 | — | P3.2 |
 
-**SwiftPM module boundary.** `Package.swift` exposes a `MercantisCore` library product so Hub and third-party apps can `import MercantisCore` from a resolved package dependency (ADR-007, P2.6). The library target points at `mercantis core/` with `exclude: ["Assets.xcassets", "mercantis_coreApp.swift", "UIShell", "Views"]` — every engine subsystem above is part of the public package; the SwiftUI shell and `@main` entry stay in the Xcode app target. GRDB is declared as a SwiftPM dependency on the library target. The `mercantis` CLI executable now also depends on `MercantisCore` for its `install-app` / `list-apps` / `new-app` / `new-doctype` commands so both install surfaces share one schema and one `AppInstaller` pipeline (P2.3); the `SQLite3` system-library link is still wired for the patch commands (`migrate`, `create-patch`, `run-patch`), which operate on raw SQL patch files.
+**SwiftPM module boundary.** `Package.swift` exposes two library products so Hub and third-party apps can pick the surface they need (ADR-007, P2.6, P2.7):
+
+- `MercantisCore` — the headless engine. The target points at `mercantis core/` with `exclude: ["Assets.xcassets", "mercantis_coreApp.swift", "UIShell", "Views"]` — every engine subsystem above is part of the public package, with no SwiftUI / AppKit / UIKit imports anywhere in its transitive graph. CLI and server-side consumers depend on this product only.
+- `MercantisCoreUI` — the metadata-driven SwiftUI shell (`GenericFormView`, `GenericListView`, `NavigationShell`, `DocTypeBuilderView`, `FormBuilderView`, `CommandBarView`, `RecordCollectionHostView`, …). Sources live in `mercantis core/UIShell/`. Depends on `MercantisCore`. Apps that want the out-of-the-box renderer add this product on the app target; apps that don't need SwiftUI keep using `MercantisCore` alone (P2.7).
+
+GRDB is declared as a SwiftPM dependency on both library targets (`UIShell/DocTypeBuilderView.swift` queries `apps.payload` via GRDB to project installed `AppManifest`s into the builder context). The `mercantis` CLI executable depends on `MercantisCore` for its `install-app` / `list-apps` / `new-app` / `new-doctype` commands so both install surfaces share one schema and one `AppInstaller` pipeline (P2.3); the `SQLite3` system-library link is still wired for the patch commands (`migrate`, `create-patch`, `run-patch`), which operate on raw SQL patch files. A `MercantisCoreUITests` SwiftPM test target instantiates `GenericFormView` / `GenericListView` against an in-memory `DocumentEngine` so the new product can't bit-rot silently.
 
 ---
 

--- a/Docs/ARCHITECTURE-CHANGELOG.md
+++ b/Docs/ARCHITECTURE-CHANGELOG.md
@@ -1,5 +1,39 @@
 # Mercantis Core — Architecture Changelog
 
+## Revision: 2026-04-27 (MercantisCoreUI library product shipped — P2.7)
+
+This revision promotes `mercantis core/UIShell/` to its own SwiftPM library product (`MercantisCoreUI`) so downstream apps that `import MercantisCore` can also `import MercantisCoreUI` and reach `GenericFormView` / `GenericListView` directly, instead of hand-rolling a SwiftUI form per DocType.
+
+### Code updated
+
+| File | Summary |
+|---|---|
+| `Package.swift` | Added `.library(name: "MercantisCoreUI", targets: ["MercantisCoreUI"])` product. New `MercantisCoreUI` target points at `mercantis core/UIShell/` and depends on `MercantisCore` + GRDB. `MercantisCore`'s `exclude:` list still carries `"UIShell"` — the exclude is now load-bearing for the target partition (SwiftPM rejects overlapping source paths), not for "UI is out of scope". CLI executable target remains on `MercantisCore` only, so SwiftUI stays out of the CLI's transitive graph. New `MercantisCoreUITests` SwiftPM test target. |
+| `Tests/MercantisCoreUITests/GenericFormViewSmokeTests.swift` *(new)* | Smoke tests that build an in-memory `DocumentEngine`, register a `Customer` DocType, and instantiate `GenericFormView` / `GenericListView` against it. Catches bit-rot when engine-side public types drift. |
+
+### Boundary established
+
+- `MercantisCore` — engine library, no SwiftUI / AppKit / UIKit anywhere in its transitive graph. CLI / server-side / headless consumers depend on this only.
+- `MercantisCoreUI` — SwiftUI shell library. Sources: `mercantis core/UIShell/` (`GenericFormView`, `GenericListView`, `NavigationShell`, `DocTypeBuilderView`, `FormBuilderView`, `CommandBarView`, `RecordCollectionHostView`, `RecordWorkspaceToolbarContent`, `SelectedRecordHeader`, `DocTypeListView`, `RecordViewMode`, `RecordCollectionViewConfiguration`, plus internal theme / modifier scaffolding).
+- `GenericFormView` / `GenericListView` were already `public struct` with `public init`s — only the SwiftPM target geometry needed to change.
+
+### Doc updates
+
+| File | Summary |
+|---|---|
+| `Docs/ENHANCEMENT-PROPOSAL.md` | New P2.7 entry (UIShell promotion, marked shipped). The previous P2.7 (Hub-on-Core readiness gap analysis) renamed to P2.7a; cross-references updated. Sequencing footer updated. |
+| `Docs/IMPLEMENTATION-STATUS.md` §4 | "SwiftPM products" expanded to three products (added `MercantisCoreUI` row). UIShell row in §1 directory table cross-references the new product. |
+| `ARCHITECTURE.md` §7 | "SwiftPM module boundary" rewritten to describe both library products and the CLI's `MercantisCore`-only dependency. |
+| `README.md` | New "SwiftPM products" section with a one-line `GenericFormView` usage snippet under `import MercantisCoreUI`. |
+
+### Known follow-ups
+
+- The Xcode app target still compiles `UIShell/` via project membership rather than via the `MercantisCoreUI` SwiftPM product. Same situation as the engine target — shipping the library declaration is sufficient for Hub today; the `.pbxproj` migration is a separate item.
+- Hub's `mercantis hub/UI/CustomerFormView.swift` already has a `#if canImport(MercantisCoreUI)` block; activating it is now a Hub-side package-graph change plus matching `GenericFormView`'s actual init signature (`docType: DocType, document: Binding<Document>`, not `(docType: String, engine: DocumentEngine)`).
+- `DocTypeBuilderView`'s `fatalError`-on-DB-open-failure is a pre-existing footgun (§2.17 of `IMPLEMENTATION-STATUS.md`), not introduced by this change.
+
+---
+
 ## Revision: 2026-04-25 (ExpressionEvaluator AST shipped — P2.1)
 
 This revision records the long-promised lift of `ExpressionEngine/` from a string-walking evaluator to a typed-AST parser + interpreter, plus the install-time static-analysis wiring it unlocks.

--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -679,7 +679,33 @@ ADR-007's "public/internal boundary in Core is enforced by the Swift module syst
 - The XCTest files in `mercantis coreTests/` use `@testable import mercantis_core` (the Xcode app module name). They are not yet wired as a SwiftPM `testTarget` against `MercantisCore`. P0.1 already tracks the Xcode-side wire-up; mirroring as a SwiftPM test target would require `@testable import MercantisCore` and is left to follow up.
 - The CLI target consolidating onto `MercantisCore` (instead of its own raw-SQLite path) remains P2.3.
 
-### P2.7 — Hub-on-Core readiness: what is sufficient vs. what is still missing [S, low risk] — ADR-007
+### P2.7 — Promote `UIShell/` to a public library product (`MercantisCoreUI`) [S, low risk] — ADR-007 / ADR-016 *(done — 2026-04-27)*
+
+`UIShell/GenericFormView` and `UIShell/GenericListView` were `exclude:`'d from the `MercantisCore` SwiftPM library, so downstream apps importing `MercantisCore` couldn't render DocType-driven forms or lists — they had to hand-roll SwiftUI per DocType against `DocumentEngine` directly. Hub hit this on the very first DocType (Customer): `engine.save(_:)` worked end-to-end (validation, naming, versioning, sync queue) but the UI was a single `TextField` + `Save Customer` button.
+
+`Package.swift` now declares a second library product:
+
+```swift
+products: [
+    .library(name: "MercantisCore",   targets: ["MercantisCore"]),
+    .library(name: "MercantisCoreUI", targets: ["MercantisCoreUI"]),
+    .executable(name: "mercantis",    targets: ["mercantis"])
+]
+```
+
+The `MercantisCoreUI` target points at `mercantis core/UIShell/` and declares `MercantisCore` + GRDB as dependencies. `MercantisCore`'s `exclude:` list still carries `"UIShell"` so the two targets don't fight over the same source directory (SwiftPM rejects overlapping source paths between targets); the exclude is now load-bearing for the partition rather than for "UI is out of scope". `MercantisCore`'s transitive graph still does not import SwiftUI / AppKit / UIKit, and the `mercantis` CLI executable depends on `MercantisCore` only — so headless consumers (CLI, server-side, tests) still don't pull SwiftUI.
+
+`GenericFormView` and `GenericListView` were already `public struct` with `public init`s (the engine-side API surface was already designed for cross-module consumption); only the SwiftPM target geometry needed to change. The other UIShell types (`NavigationShell`, `DocTypeBuilderView`, `FormBuilderView`, `CommandBarView`, `RecordCollectionHostView`, `RecordWorkspaceToolbarContent`, `SelectedRecordHeader`, `DocTypeListView`, `RecordViewMode`, `RecordCollectionViewConfiguration`) ride along as part of the same product. Theme / style helpers (`MercantisTheme`, button styles, view modifiers) are deliberately internal to the UI library — they're implementation detail of the renderer.
+
+A `MercantisCoreUITests` SwiftPM test target instantiates `GenericFormView` and `GenericListView` against an in-memory `DocumentEngine` so the new product can't bit-rot silently when engine-side public types shift.
+
+**Hub-side follow-up (already prepped):** Hub's `mercantis hub/UI/CustomerFormView.swift` already has a `#if canImport(MercantisCoreUI)` block; activating it is now a Hub-side package-graph change (tick `MercantisCoreUI` on the Hub app target) plus matching the actual `GenericFormView` init signature (`docType: DocType, document: Binding<Document>` — not the speculative `(docType: String, engine: DocumentEngine)` the prep file used).
+
+**Known follow-ups (not scoped to P2.7):**
+- The Xcode app target still compiles `UIShell/` via project membership rather than via the `MercantisCoreUI` SwiftPM product. Same situation as the engine target — shipping the library declaration is sufficient for Hub today; the `.pbxproj` migration is a separate item.
+- `DocTypeBuilderView` does `fatalError` when its metadata DB won't open. That's a pre-existing footgun documented in §2.17 of `IMPLEMENTATION-STATUS.md`, not introduced by this change.
+
+### P2.7a — Hub-on-Core readiness: what is sufficient vs. what is still missing [S, low risk] — ADR-007
 
 This is a gap-analysis item, not a criticism of ADR-007. The direction in ADR-007 is correct. The question is: *how much of it is already true?*
 
@@ -783,7 +809,7 @@ A 4–6 week plan if one engineer is the target:
 | 7 | P2.2 cross-document `lookup()` ✅ (2026-04-25) (`DocumentLookupResolver` + read-through `CachingDocumentLookupResolver` with per-save invalidation; `DocumentEngine.list` `whereExpression` runs through the cached evaluator; ADR-029 lands the sandbox + budget posture). |
 | 7 | P2.3 CLI / app install consolidation ✅ (2026-04-25) (`AppInstaller.install(manifestData:)` + CLI consumes `MercantisCore`; canonical schema everywhere; `FieldDefinition` decoder lenient on layout fields; expression indexes created uniformly). |
 
-P2.6 (Core library productization) ✅ shipped 2026-04-25 — the `MercantisCore` library product now exists, so Hub development can start importing Core via `.package(url: ...)`. P2.7 (Hub readiness gap analysis) is a documentation item that can run in parallel with any P1 work. P2.4 (dashboard runtime) and P2.8 (richer field/control model) are both medium-term items best driven by Hub's concrete needs rather than by speculative pre-design.
+P2.6 (Core library productization) ✅ shipped 2026-04-25 — the `MercantisCore` library product now exists, so Hub development can start importing Core via `.package(url: ...)`. P2.7 (`MercantisCoreUI` library product) ✅ shipped 2026-04-27 — `GenericFormView` / `GenericListView` are now reachable from any package consumer; Hub can drive its DocType-driven forms off Core without hand-rolling per-DocType SwiftUI. P2.7a (Hub readiness gap analysis) is a documentation item that can run in parallel with any P1 work. P2.4 (dashboard runtime) and P2.8 (richer field/control model) are both medium-term items best driven by Hub's concrete needs rather than by speculative pre-design.
 
 P3.6 (POS platform) should not begin until P1.1, P3.2, P2.8, and P1.2/P1.3 are substantially complete. The sequencing dependency is real: a POS without naming, printing, richer controls, and automation is not a POS.
 
@@ -815,4 +841,4 @@ This is not pessimism. It is roadmap clarity.
 - **Rich dashboards** — `DashboardDefinition` decodes; nothing renders. Module home pages fall back to flat lists.
 - **POS** — requires Naming, Printing, richer field/control model, Automation runtime, and likely a purpose-built cart surface. None of these are done.
 - **Polished ERP-grade control richness** — `FieldType` covers CRUD adequately; it does not cover child-table editing UX, barcode input, image fields, or link search pickers at the level an ERP demands.
-- **Fully proven Core → Hub public API sufficiency** — Core is strong enough to start Hub. It is not yet strong enough to claim that all subsystems a production ERP needs are in place and accessible through the public API. That claim becomes true as the missing subsystems in P2.7's gap table are closed.
+- **Fully proven Core → Hub public API sufficiency** — Core is strong enough to start Hub. It is not yet strong enough to claim that all subsystems a production ERP needs are in place and accessible through the public API. That claim becomes true as the missing subsystems in P2.7a's gap table are closed.

--- a/Docs/IMPLEMENTATION-STATUS.md
+++ b/Docs/IMPLEMENTATION-STATUS.md
@@ -37,7 +37,7 @@ The goal is not to assign blame; it's to give future contributors an honest star
 | `Scheduling/` | Yes | Ships `ScheduledTask`, `CronExpression`, `SchedulerPersistence`, `SchedulerService` (P1.4 / §4.13, 2026-04-24). `SchedulerService` conforms to `ExtensionSchedulerRegistrar` so manifest-declared `schedulerEvents` are registered through `ExtensionPointResolver` exactly like document-event subscriptions. Cadence is persisted in the v6 `scheduler_state` table. |
 | `Storage/` | Yes | Matches §4.3. |
 | `SyncEngine/` | Yes | Also contains `CloudAdapter.swift` with a `NoOpCloudAdapter` — not listed in §7 but referenced elsewhere (ADR-018). |
-| `UIShell/` | Yes (much larger than §7) | See §4 "UIShell reality" below. |
+| `UIShell/` | Yes (much larger than §7) | See §4 "UIShell reality" below. Now its own SwiftPM library product `MercantisCoreUI` (P2.7). |
 | `Workflows/` | Yes | Matches §4.5. |
 | `Views/DesignSystem/` | **On disk, not in §7** | 14 files of demo/design-lab surfaces. Mentioned in prose in §5.1 but not in the tree. |
 
@@ -189,13 +189,16 @@ Both `Modules` and `DocTypes` route through `RecordCollectionHostView`, so all s
 
 ## 4. SwiftPM products
 
-`Package.swift` declares two products:
+`Package.swift` declares three products:
 
 - `.library(name: "MercantisCore", targets: ["MercantisCore"])` — the engine, importable via `.package(url:from:)`. The target points at `mercantis core/` with `exclude: ["Assets.xcassets", "mercantis_coreApp.swift", "UIShell", "Views"]`, so SwiftUI / app-shell code is deliberately not part of the library. GRDB (`https://github.com/groue/GRDB.swift`, `from: "6.0.0"`) is declared on the library target. Shipped in P2.6 (2026-04-25).
-- `.executable(name: "mercantis", targets: ["mercantis"])` — the CLI. Now depends on `MercantisCore` (P2.3) for `install-app` / `list-apps` / `new-app` / `new-doctype`. The `SQLite3` system-library link is still wired for the patch commands (`migrate`, `create-patch`, `run-patch`), which operate on `patch_log` and arbitrary SQL deltas rather than the engine schema.
+- `.library(name: "MercantisCoreUI", targets: ["MercantisCoreUI"])` — the SwiftUI shell. The target points at `mercantis core/UIShell/` and depends on `MercantisCore` + GRDB. Ships `GenericFormView`, `GenericListView`, `NavigationShell`, `DocTypeBuilderView`, `FormBuilderView`, `CommandBarView`, `RecordCollectionHostView`, and supporting view types as the public renderer surface. Hub and any third-party app that wants the out-of-the-box metadata-driven UI imports this product; headless consumers stick with `MercantisCore`. Shipped in P2.7 (2026-04-27).
+- `.executable(name: "mercantis", targets: ["mercantis"])` — the CLI. Depends on `MercantisCore` (P2.3) for `install-app` / `list-apps` / `new-app` / `new-doctype`, and intentionally does **not** depend on `MercantisCoreUI`, so SwiftUI stays out of the CLI's transitive graph. The `SQLite3` system-library link is still wired for the patch commands (`migrate`, `create-patch`, `run-patch`), which operate on `patch_log` and arbitrary SQL deltas rather than the engine schema.
+
+A SwiftPM `MercantisCoreUITests` test target instantiates `GenericFormView` / `GenericListView` against an in-memory `DocumentEngine` so the new product can't bit-rot silently.
 
 Notes on consumers:
-- The Xcode app target (`mercantis core`) still compiles the engine source via project membership rather than via the SwiftPM library. The `.library` declaration is sufficient for Hub to consume Core today; migrating the Xcode app to consume the SwiftPM library is a `.pbxproj` change best done in Xcode itself.
+- The Xcode app target (`mercantis core`) still compiles the engine source via project membership rather than via the SwiftPM library. The `.library` declarations are sufficient for Hub to consume Core today; migrating the Xcode app to consume the SwiftPM libraries is a `.pbxproj` change best done in Xcode itself.
 - The XCTest files in `mercantis coreTests/` use `@testable import mercantis_core` (the Xcode app module name) and are not yet wired as a SwiftPM test target. P0.1 tracks the Xcode-side wire-up.
 
 ## 5. The MercantisCLI target

--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,16 @@ let package = Package(
     products: [
         // The Core engine, importable by Hub or any third-party app via
         // .package(url: ...). UI code (UIShell/, Views/) and the App entry
-        // (mercantis_coreApp.swift) deliberately stay in the Xcode app target
-        // and are not part of this library product. (ADR-007, P2.6)
+        // (mercantis_coreApp.swift) deliberately stay out of this library
+        // product so headless / server-side consumers don't pull SwiftUI.
+        // (ADR-007, P2.6)
         .library(name: "MercantisCore", targets: ["MercantisCore"]),
+        // The metadata-driven SwiftUI shell (`GenericFormView`,
+        // `GenericListView`, …) sourced from `mercantis core/UIShell/`.
+        // Sits on top of `MercantisCore`, so apps that want the
+        // out-of-the-box renderer can `import MercantisCoreUI` and apps
+        // that don't need SwiftUI can stick with `MercantisCore`. (P2.7)
+        .library(name: "MercantisCoreUI", targets: ["MercantisCoreUI"]),
         .executable(name: "mercantis", targets: ["mercantis"])
     ],
     dependencies: [
@@ -34,12 +41,25 @@ let package = Package(
                 .product(name: "GRDB", package: "GRDB.swift")
             ],
             path: "mercantis core",
+            // `UIShell` stays excluded here so its sources can be claimed
+            // by the `MercantisCoreUI` target below; SwiftPM rejects
+            // overlapping source paths between targets, so the exclude is
+            // load-bearing. `Views/` is design-system scaffolding still
+            // built only by the Xcode app target.
             exclude: [
                 "Assets.xcassets",
                 "mercantis_coreApp.swift",
                 "UIShell",
                 "Views"
             ]
+        ),
+        .target(
+            name: "MercantisCoreUI",
+            dependencies: [
+                "MercantisCore",
+                .product(name: "GRDB", package: "GRDB.swift")
+            ],
+            path: "mercantis core/UIShell"
         ),
         .executableTarget(
             name: "mercantis",
@@ -52,6 +72,11 @@ let package = Package(
             linkerSettings: [
                 .linkedLibrary("sqlite3")
             ]
+        ),
+        .testTarget(
+            name: "MercantisCoreUITests",
+            dependencies: ["MercantisCoreUI", "MercantisCore"],
+            path: "Tests/MercantisCoreUITests"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ Mercantis Core is the general-purpose platform layer that provides the foundatio
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full architecture document, including subsystem descriptions, design principles, and an ASCII diagram.
 
+## SwiftPM products
+
+`Package.swift` exposes two library products:
+
+- **`MercantisCore`** — the headless engine. No SwiftUI / AppKit / UIKit anywhere in its transitive graph; safe for CLI and server-side consumers.
+- **`MercantisCoreUI`** — the metadata-driven SwiftUI shell that renders any registered `DocType`. Depends on `MercantisCore`.
+
+```swift
+import MercantisCore
+import MercantisCoreUI
+
+GenericFormView(docType: customerDocType, document: $document)
+```
+
+`GenericFormView` and `GenericListView` are driven entirely by `DocType` metadata, so adding a new entity to your app means registering a `DocType` — not writing a new SwiftUI form. See `mercantis core/UIShell/GenericFormView.swift` for the public init signature.
+
 ## Runtime UX Boundary
 
 - The default app runtime launches into the domain-neutral `NavigationShell` (`mercantis core/UIShell/NavigationShell.swift`).

--- a/Tests/MercantisCoreUITests/GenericFormViewSmokeTests.swift
+++ b/Tests/MercantisCoreUITests/GenericFormViewSmokeTests.swift
@@ -1,0 +1,168 @@
+//
+//  GenericFormViewSmokeTests.swift
+//  MercantisCoreUITests
+//
+//  Smoke coverage for the SwiftPM `MercantisCoreUI` library product
+//  introduced by P2.7 (issue #81). These tests exist to catch
+//  bit-rot — accidentally breaking the public surface of the
+//  metadata-driven form/list renderers, or breaking the package
+//  graph that lets Hub `import MercantisCoreUI`.
+//
+
+import XCTest
+import SwiftUI
+import MercantisCore
+import MercantisCoreUI
+
+final class GenericFormViewSmokeTests: XCTestCase {
+
+    func testGenericFormViewInstantiatesAgainstInMemoryDocumentEngine() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        let docType = TestHarness.makeCustomerDocType()
+        try harness.registry.register(docType)
+
+        var document = TestHarness.makeCustomerDocument()
+        try harness.engine.save(document)
+
+        let binding = Binding<Document>(
+            get: { document },
+            set: { document = $0 }
+        )
+
+        let form = GenericFormView(
+            docType: docType,
+            document: binding,
+            userRoles: ["System Manager"],
+            expressionEvaluator: harness.engine.listExpressionEvaluator
+        )
+
+        // Smoke: instantiating the view forces the SwiftPM dependency
+        // graph to compile and the public init to resolve against the
+        // engine's public types. We don't render — that would need a
+        // host environment we can't assume in a headless test target.
+        XCTAssertNotNil(form)
+    }
+
+    func testGenericListViewInstantiatesAgainstInMemoryDocumentEngine() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        let docType = TestHarness.makeCustomerDocType()
+        try harness.registry.register(docType)
+
+        let document = TestHarness.makeCustomerDocument()
+        try harness.engine.save(document)
+        let documents = try harness.engine.list(docType: docType.id)
+
+        let list = GenericListView(
+            docType: docType,
+            documents: documents,
+            onSelect: { _ in },
+            onCreate: { }
+        )
+
+        XCTAssertNotNil(list)
+        XCTAssertEqual(documents.count, 1)
+    }
+}
+
+// MARK: - Local harness
+
+/// Mirror of the in-memory engine fixture in `mercantis coreTests/`. Kept
+/// local so this test target doesn't take a `@testable` dependency on the
+/// Xcode app's `mercantis_core` module — it builds against the SwiftPM
+/// `MercantisCore` library directly.
+private enum TestHarness {
+
+    struct Bundle {
+        let database: MercantisDatabase
+        let registry: MetadataRegistry
+        let engine: DocumentEngine
+        let url: URL
+
+        func cleanUp() {
+            let dir = url.deletingLastPathComponent()
+            try? FileManager.default.removeItem(at: dir)
+        }
+    }
+
+    static func make() throws -> Bundle {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mercantis-coreui-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("metadata.sqlite")
+
+        let database = try MercantisDatabase(databaseURL: url)
+        let registry = MetadataRegistry(database: database)
+        let engine = DocumentEngine(
+            database: database,
+            registry: registry,
+            deviceId: "test-device",
+            userId: "test-user"
+        )
+        return Bundle(database: database, registry: registry, engine: engine, url: url)
+    }
+
+    static func makeCustomerDocType() -> DocType {
+        DocType(
+            id: "Customer",
+            name: "Customer",
+            module: "CRM",
+            appId: "app.mercantis.test",
+            isChildTable: false,
+            fields: [
+                FieldDefinition(
+                    key: "customer_name",
+                    label: "Customer Name",
+                    type: .text,
+                    required: true
+                ),
+                FieldDefinition(
+                    key: "email",
+                    label: "Email",
+                    type: .email,
+                    required: false
+                )
+            ],
+            permissions: [
+                PermissionRule(
+                    role: "System Manager",
+                    canRead: true,
+                    canWrite: true,
+                    canCreate: true,
+                    canDelete: true,
+                    canSubmit: true,
+                    canAmend: true
+                )
+            ],
+            syncPolicy: SyncPolicy(
+                conflictResolution: .lastWriteWins,
+                immutableAfterSubmit: false
+            ),
+            indexes: [],
+            searchFields: ["customer_name"],
+            titleField: "customer_name"
+        )
+    }
+
+    static func makeCustomerDocument() -> Document {
+        let now = Date()
+        return Document(
+            id: UUID().uuidString,
+            docType: "Customer",
+            company: "",
+            status: "",
+            createdAt: now,
+            updatedAt: now,
+            syncVersion: 0,
+            syncState: .local,
+            fields: [
+                "customer_name": .string("Acme Co"),
+                "email": .string("info@acme.example")
+            ],
+            children: [:]
+        )
+    }
+}


### PR DESCRIPTION
Closes #81.

## Summary

- Add a new `.library(name: "MercantisCoreUI", targets: ["MercantisCoreUI"])` product. Sources: `mercantis core/UIShell/`. Dependencies: `MercantisCore` + GRDB.
- Keep `MercantisCore` UI-free. Its transitive graph still has zero SwiftUI / AppKit / UIKit imports, and the `mercantis` CLI executable target keeps depending on `MercantisCore` only — so headless / server-side consumers don't pull SwiftUI.
- `GenericFormView`, `GenericListView` and the other UIShell view types (`NavigationShell`, `DocTypeBuilderView`, `FormBuilderView`, `CommandBarView`, `RecordCollectionHostView`, `RecordWorkspaceToolbarContent`, `SelectedRecordHeader`, `DocTypeListView`, `RecordViewMode`, `RecordCollectionViewConfiguration`) were already `public struct` with `public init`s — only the SwiftPM target geometry needed to change. Theme / view-modifier helpers stay internal to the UI library.
- New `MercantisCoreUITests` SwiftPM test target with one test that instantiates `GenericFormView` against an in-memory `DocumentEngine` (and a sibling test for `GenericListView`) so the new product can't bit-rot silently when engine-side public types drift.
- Docs: `Docs/IMPLEMENTATION-STATUS.md` (§4 + §1 directory row), `Docs/ENHANCEMENT-PROPOSAL.md` (new P2.7 marked shipped; the previous P2.7 gap-analysis item renamed to P2.7a; sequencing footer updated), `ARCHITECTURE.md` (§7 module boundary rewritten), `README.md` (new "SwiftPM products" section + one-line usage snippet), and `Docs/ARCHITECTURE-CHANGELOG.md` (revision entry).

## Note on `GenericFormView` init signature

The Hub repo's prep file uses `GenericFormView(docType: "Customer", engine: engine)`. Core's actual signature is:

```swift
GenericFormView(
    docType: DocType,
    document: Binding<Document>,
    userRoles: Set<String> = [],
    expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator()
)
```

Per the issue's guidance ("If `GenericFormView`'s actual init signature is something other than `GenericFormView(docType: String, engine: DocumentEngine)`, do NOT change Core to match the Hub prep — keep the signature that's natural on the Core side"), Core's signature is unchanged. Hub will need to:

1. Resolve the `DocType` via `MetadataRegistry.get("Customer")`.
2. Hold a `@State` / `@Binding` for the `Document`.
3. Pass `engine.listExpressionEvaluator` if it wants the same lookup-aware evaluator the engine uses for `list(whereExpression:)`.

## Note on `MercantisCore`'s exclude list

The issue suggests removing `"UIShell"` from `MercantisCore`'s `exclude:` list. SwiftPM rejects overlapping source paths between targets, so the entry has to stay for the partition to work — but the meaning has changed: `"UIShell"` is now load-bearing for "this directory belongs to the `MercantisCoreUI` target" rather than "UI is out of scope for the package". `MercantisCore` still doesn't compile UIShell sources; the visible behaviour is identical to what the issue asks for.

## Test plan

- [ ] `swift build` — both library targets compile, plus the CLI executable.
- [ ] `swift test` — `MercantisCoreUITests` passes (the two smoke tests).
- [ ] CLI builds without SwiftUI in its transitive graph (the `mercantis` executable target depends on `MercantisCore` only — no `MercantisCoreUI`).
- [ ] Hub repo's `#if canImport(MercantisCoreUI)` block in `mercantis hub/UI/CustomerFormView.swift` activates once Hub picks up this version of the package and ticks `MercantisCoreUI` on its app target. Hub-side adjustment to the actual init signature (see "Note on init signature" above) is required.

> Heads-up for reviewers: I couldn't run `swift build` / `swift test` locally — no Swift toolchain on the dev box. CI is the source of truth for both. The change has been validated by static inspection: every type referenced from `UIShell/` against `MercantisCore` (`DocType`, `Document`, `FieldDefinition`, `FieldValue`, `ExpressionEvaluator`, `DocumentEngine`, `MercantisDatabase`, `MetadataRegistry`, `MetaComposer`, `EventEmitter`, `ResolvedMeta`, `ResolvedFieldDefinition`, `BuiltInDocTypes`, `SchemaValidator`, `ReportEngine`, `ReportResult`, `ReportDefinition`, `DashboardDefinition`, `AppManifest`, `IndexDefinition`, `SyncPolicy`, `PermissionRule`) is `public` with `public init`s; the test target only touches the public surface (no `@testable`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KCrowHAbLh9mbvHB8NVMiT)_