### PR TITLE
Guard MercantisCore import with canImport for Xcode app target

### DIFF
--- a/mercantis core/UIShell/CommandBarView.swift
+++ b/mercantis core/UIShell/CommandBarView.swift
@@ -6,7 +6,9 @@
 //
 
 import SwiftUI
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 
 public struct CommandBarAction: Identifiable {
     public let id: String

--- a/mercantis core/UIShell/CreateRecordSheet.swift
+++ b/mercantis core/UIShell/CreateRecordSheet.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 
 /// Modal sheet used to create a new record of a given `DocType`.
 ///

--- a/mercantis core/UIShell/DocTypeBuilderView.swift
+++ b/mercantis core/UIShell/DocTypeBuilderView.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 import Combine
 import GRDB
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 
 @MainActor
 final class DocTypeToolingContext: ObservableObject {

--- a/mercantis core/UIShell/DocTypeListView.swift
+++ b/mercantis core/UIShell/DocTypeListView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 
 public struct DocTypeListView: View {
     @EnvironmentObject private var tooling: DocTypeToolingContext

--- a/mercantis core/UIShell/FormBuilderView.swift
+++ b/mercantis core/UIShell/FormBuilderView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 
 private struct BuilderPaletteGroup: Identifiable {
     let id: String

--- a/mercantis core/UIShell/GenericFormView.swift
+++ b/mercantis core/UIShell/GenericFormView.swift
@@ -6,7 +6,9 @@
 //
 
 import SwiftUI
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 
 /// A SwiftUI view that renders a form dynamically from a `DocType` and a `Document`.
 public struct GenericFormView: View {

--- a/mercantis core/UIShell/GenericListView.swift
+++ b/mercantis core/UIShell/GenericListView.swift
@@ -6,7 +6,9 @@
 //
 
 import SwiftUI
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 
 /// A SwiftUI view that renders a sortable, filterable list of documents
 /// driven entirely by `DocType` metadata.

--- a/mercantis core/UIShell/MercantisTheme.swift
+++ b/mercantis core/UIShell/MercantisTheme.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 #if os(macOS)
 import AppKit
 #elseif os(iOS)

--- a/mercantis core/UIShell/NavigationShell.swift
+++ b/mercantis core/UIShell/NavigationShell.swift
@@ -7,7 +7,9 @@
 
 import SwiftUI
 import Combine
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 #if os(macOS)
 import AppKit
 #elseif os(iOS)

--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 
 public struct RecordCollectionHostView: View {
     let preferenceKey: String

--- a/mercantis core/UIShell/RecordViewMode.swift
+++ b/mercantis core/UIShell/RecordViewMode.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 
 public enum RecordViewMode: String, CaseIterable, Codable, Hashable, Identifiable {
     case list

--- a/mercantis core/UIShell/RecordWorkspaceChrome.swift
+++ b/mercantis core/UIShell/RecordWorkspaceChrome.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 
 public struct RecordWorkspaceToolbarContent: ToolbarContent {
     let statusText: String

--- a/mercantis core/UIShell/ResolvedMetaCanvasAdapter.swift
+++ b/mercantis core/UIShell/ResolvedMetaCanvasAdapter.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(MercantisCore)
 import MercantisCore
+#endif
 
 struct CanvasSectionViewModel: Identifiable, Hashable {
     let id: String


### PR DESCRIPTION
The Xcode app target compiles UIShell/ source files via project membership into its own module, where MercantisCore isn't a separate module — so an unconditional `import MercantisCore` fails to resolve ("Unable to resolve module dependency: 'MercantisCore'").

Wrap the import in `#if canImport(MercantisCore)`. The SwiftPM MercantisCoreUI build (and any downstream package consumer like Hub) sees MercantisCore as a separate module and imports it normally, while the Xcode app build skips the directive and falls back to same-module visibility for Core types.