### PR TITLE
Hoist visualBuilderWindowID so MercantisCoreUI builds via SwiftPM

### DIFF
--- a/mercantis core/UIShell/DocTypeListView.swift
+++ b/mercantis core/UIShell/DocTypeListView.swift
@@ -203,7 +203,7 @@ public struct DocTypeListView: View {
 
     private func openVisualBuilder(for docType: DocType) {
         #if os(macOS)
-        openWindow(id: mercantis_coreApp.visualBuilderWindowID, value: docType.id)
+        openWindow(id: MercantisShellWindow.visualBuilderID, value: docType.id)
         #else
         selectedDocTypeForBuilder = docType
         #endif

--- a/mercantis core/UIShell/NavigationShell.swift
+++ b/mercantis core/UIShell/NavigationShell.swift
@@ -943,6 +943,13 @@ extension Notification.Name {
     static let mercantisOpenCommandBar = Notification.Name("mercantis.openCommandBar")
 }
 
+/// Stable identifiers for windows surfaced by `MercantisCoreUI`. Hoisted out of
+/// the app entry point so library consumers (e.g. `mercantis.hub.app`) can
+/// open these windows without depending on the standalone Xcode app target.
+public enum MercantisShellWindow {
+    public static let visualBuilderID = "visual-builder"
+}
+
 struct WorkspaceDefinition: Identifiable, Hashable {
     enum Placement: Hashable {
         case primary

--- a/mercantis core/mercantis_coreApp.swift
+++ b/mercantis core/mercantis_coreApp.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 @main
 struct mercantis_coreApp: App {
-    static let visualBuilderWindowID = "visual-builder"
-
     @StateObject private var docTypeTooling = DocTypeToolingContext()
     @StateObject private var shellRouter = UIShellRouter()
 
@@ -51,7 +49,7 @@ struct mercantis_coreApp: App {
 
     #if os(macOS)
     private var visualBuilderWindow: some Scene {
-        WindowGroup("Visual Builder", id: Self.visualBuilderWindowID, for: String.self) { $docTypeID in
+        WindowGroup("Visual Builder", id: MercantisShellWindow.visualBuilderID, for: String.self) { $docTypeID in
             NavigationStack {
                 if let selectedDocTypeID = docTypeID {
                     FormBuilderView(initialDocTypeID: selectedDocTypeID) {


### PR DESCRIPTION
## Summary

`mercantis.hub.app` consumes this repo as a SwiftPM dependency and imports the `MercantisCoreUI` library product. That library failed to build because `DocTypeListView.swift` (inside `UIShell/`) referenced `mercantis_coreApp.visualBuilderWindowID`, and `mercantis_coreApp.swift` is excluded from both `MercantisCore` and `MercantisCoreUI` in `Package.swift` — so the symbol is invisible to SwiftPM consumers.

This PR hoists the constant into `MercantisCoreUI`:

- New `public enum MercantisShellWindow { public static let visualBuilderID = "visual-builder" }` in `NavigationShell.swift` (lives inside `UIShell/`, so it ships with the library).
- `DocTypeListView.openVisualBuilder` now reads `MercantisShellWindow.visualBuilderID`.
- `mercantis_coreApp` drops its own `static let visualBuilderWindowID` and references the shared identifier when declaring the `WindowGroup`, so the standalone Xcode app target keeps working.

The companion `@MainActor` fix on `RecentDestination.title(using:)` is already on `main` (commit 2fe4eea), so it isn't part of this PR.

I also swept `UIShell/` for other symbols that resolve only via the Xcode app target (anything from `mercantis_coreApp.swift`, `Views/`, or `Assets.xcassets`):
- No `Image("…")` / `Color("…")` literals depending on `Assets.xcassets`.
- No references to types defined in `mercantis core/Views/DesignSystem/`.
- No imports beyond `SwiftUI`, `Combine`, `AppKit`, `UIKit`, `Foundation`, `MercantisCore`, `GRDB`.

After this PR, `grep -rn visualBuilderWindowID` returns nothing.

## Test plan

- [ ] `swift build` from the repo root completes cleanly (both `MercantisCore` and `MercantisCoreUI` targets) — could not run locally; no Swift toolchain in the dev sandbox and the project is macOS-only.
- [ ] `mercantis core.xcodeproj` Xcode app target still builds.
- [ ] Visual Builder window still opens from the DocType list in the standalone app.
- [ ] `mercantis.hub.app` rebuilds against the new `Package.resolved` SHA.

https://claude.ai/code/session_01FdSjwGDG2SrhbTUqTCycSK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSjwGDG2SrhbTUqTCycSK)_