### PR TITLE
W4: Add link field search-and-pick UI with backwards compatibility

### DIFF
--- a/Tests/MercantisCoreUITests/GenericFormViewSmokeTests.swift
+++ b/Tests/MercantisCoreUITests/GenericFormViewSmokeTests.swift
@@ -45,6 +45,96 @@ final class GenericFormViewSmokeTests: XCTestCase {
         XCTAssertNotNil(form)
     }
 
+    // MARK: - W4: link field smoke tests
+
+    /// GenericFormView with a link field and no provider compiles and
+    /// instantiates — existing callers that haven't wired a provider yet
+    /// are unaffected.
+    func testLinkFieldRendersWithNilProvider() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        let docType = TestHarness.makeDocTypeWithLinkField()
+        try harness.registry.register(docType)
+
+        var document = TestHarness.makeDocumentWithLinkField()
+        try harness.engine.save(document)
+
+        let binding = Binding<Document>(get: { document }, set: { document = $0 })
+
+        let form = GenericFormView(
+            docType: docType,
+            document: binding,
+            linkSearchProvider: nil
+        )
+        XCTAssertNotNil(form)
+    }
+
+    /// GenericFormView with a link field and a wired provider compiles and
+    /// instantiates. The provider closure is the same shape Hub will use:
+    /// `engine.list(docType:)` wrapped in a try?.
+    func testLinkFieldRendersWithWiredProvider() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        // Register the target DocType (CustomerGroup) so the provider can list it.
+        let groupDocType = TestHarness.makeCustomerGroupDocType()
+        try harness.registry.register(groupDocType)
+        let groupDoc = TestHarness.makeCustomerGroupDocument(id: "CG-001")
+        try harness.engine.save(groupDoc)
+
+        let docType = TestHarness.makeDocTypeWithLinkField()
+        try harness.registry.register(docType)
+
+        var document = TestHarness.makeDocumentWithLinkField(linkedId: "CG-001")
+        try harness.engine.save(document)
+
+        let binding = Binding<Document>(get: { document }, set: { document = $0 })
+
+        let form = GenericFormView(
+            docType: docType,
+            document: binding,
+            linkSearchProvider: { targetDocType, _ in
+                (try? harness.engine.list(docType: targetDocType)) ?? []
+            }
+        )
+        XCTAssertNotNil(form)
+    }
+
+    /// The save-time link validation rejects a reference to a non-existent document.
+    func testLinkValidationRejectsUnknownTarget() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        let docType = TestHarness.makeDocTypeWithLinkField()
+        try harness.registry.register(docType)
+
+        let document = TestHarness.makeDocumentWithLinkField(linkedId: "DOES-NOT-EXIST")
+        XCTAssertThrowsError(try harness.engine.save(document)) { error in
+            guard case DocumentEngine.DocumentEngineError.validationFailed(let errors) = error else {
+                XCTFail("Expected validationFailed, got \(error)"); return
+            }
+            XCTAssertTrue(errors.contains { $0.stage == "LinkValidation" })
+        }
+    }
+
+    /// The save-time link validation passes when the referenced document exists.
+    func testLinkValidationPassesWithKnownTarget() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        let groupDocType = TestHarness.makeCustomerGroupDocType()
+        try harness.registry.register(groupDocType)
+        let groupDoc = TestHarness.makeCustomerGroupDocument(id: "CG-002")
+        try harness.engine.save(groupDoc)
+
+        let docType = TestHarness.makeDocTypeWithLinkField()
+        try harness.registry.register(docType)
+
+        let document = TestHarness.makeDocumentWithLinkField(linkedId: "CG-002")
+        XCTAssertNoThrow(try harness.engine.save(document))
+    }
+
     func testGenericListViewInstantiatesAgainstInMemoryDocumentEngine() throws {
         let harness = try TestHarness.make()
         defer { harness.cleanUp() }
@@ -162,6 +252,118 @@ private enum TestHarness {
                 "customer_name": .string("Acme Co"),
                 "email": .string("info@acme.example")
             ],
+            children: [:]
+        )
+    }
+
+    // MARK: - W4 fixtures
+
+    /// A DocType that contains a `customer_group` link field targeting "CustomerGroup".
+    static func makeDocTypeWithLinkField() -> DocType {
+        DocType(
+            id: "Contact",
+            name: "Contact",
+            module: "CRM",
+            appId: "app.mercantis.test",
+            isChildTable: false,
+            fields: [
+                FieldDefinition(
+                    key: "full_name",
+                    label: "Full Name",
+                    type: .text,
+                    required: true
+                ),
+                FieldDefinition(
+                    key: "customer_group",
+                    label: "Customer Group",
+                    type: .link,
+                    required: false,
+                    linkedDocType: "CustomerGroup"
+                )
+            ],
+            permissions: [
+                PermissionRule(
+                    role: "System Manager",
+                    canRead: true,
+                    canWrite: true,
+                    canCreate: true,
+                    canDelete: true,
+                    canSubmit: true,
+                    canAmend: true
+                )
+            ],
+            syncPolicy: SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false),
+            indexes: [],
+            searchFields: ["full_name"],
+            titleField: "full_name"
+        )
+    }
+
+    static func makeDocumentWithLinkField(linkedId: String = "") -> Document {
+        let now = Date()
+        var fields: [String: FieldValue] = ["full_name": .string("Jane Smith")]
+        if !linkedId.isEmpty {
+            fields["customer_group"] = .string(linkedId)
+        }
+        return Document(
+            id: UUID().uuidString,
+            docType: "Contact",
+            company: "",
+            status: "",
+            createdAt: now,
+            updatedAt: now,
+            syncVersion: 0,
+            syncState: .local,
+            fields: fields,
+            children: [:]
+        )
+    }
+
+    static func makeCustomerGroupDocType() -> DocType {
+        DocType(
+            id: "CustomerGroup",
+            name: "Customer Group",
+            module: "Setup",
+            appId: "app.mercantis.test",
+            isChildTable: false,
+            fields: [
+                FieldDefinition(
+                    key: "group_name",
+                    label: "Group Name",
+                    type: .text,
+                    required: true
+                )
+            ],
+            permissions: [
+                PermissionRule(
+                    role: "System Manager",
+                    canRead: true,
+                    canWrite: true,
+                    canCreate: true,
+                    canDelete: true,
+                    canSubmit: true,
+                    canAmend: true
+                )
+            ],
+            syncPolicy: SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false),
+            indexes: [],
+            searchFields: ["group_name"],
+            titleField: "group_name"
+        )
+    }
+
+    static func makeCustomerGroupDocument(id: String) -> Document {
+        let now = Date()
+        return Document(
+            id: id,
+            docType: "CustomerGroup",
+            company: "",
+            status: "",
+            createdAt: now,
+            updatedAt: now,
+            syncVersion: 0,
+            syncState: .local,
+            fields: ["group_name": .string("Commercial")],
             children: [:]
         )
     }

--- a/mercantis core/UIShell/GenericFormView.swift
+++ b/mercantis core/UIShell/GenericFormView.swift
@@ -11,23 +11,32 @@ import MercantisCore
 #endif
 
 /// A SwiftUI view that renders a form dynamically from a `DocType` and a `Document`.
+///
+/// Pass `linkSearchProvider` to enable search-and-pick for `FieldType.link` fields.
+/// The closure receives `(targetDocType, query)` and returns matching documents;
+/// it typically wraps `engine.list(docType:whereExpression:)`. When `nil` (the
+/// default), link fields fall back to plain text entry so existing callers are
+/// unaffected. (W4 / ADR-030)
 public struct GenericFormView: View {
 
     let docType: DocType
     @Binding var document: Document
     let userRoles: Set<String>
     let expressionEvaluator: ExpressionEvaluator
+    let linkSearchProvider: ((String, String) -> [Document])?
 
     public init(
         docType: DocType,
         document: Binding<Document>,
         userRoles: Set<String> = [],
-        expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator()
+        expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator(),
+        linkSearchProvider: ((String, String) -> [Document])? = nil
     ) {
         self.docType = docType
         self._document = document
         self.userRoles = userRoles
         self.expressionEvaluator = expressionEvaluator
+        self.linkSearchProvider = linkSearchProvider
     }
 
     public var body: some View {
@@ -237,19 +246,18 @@ public struct GenericFormView: View {
     }
 
     private func linkField(field: FieldDefinition, isReadOnly: Bool) -> some View {
-        let strBinding = stringBinding(for: field)
-        return Group {
-            if isReadOnly {
-                Text(strBinding.wrappedValue).foregroundStyle(.secondary)
-            } else {
-                HStack {
-                    TextField(field.linkedDocType ?? "Link", text: strBinding)
-                        .mercantisInput()
-                    Image(systemName: "arrow.up.right.square")
-                        .foregroundStyle(.secondary)
-                }
-            }
+        // W4: delegate to LinkPickerField. When linkSearchProvider is nil the
+        // picker falls back to plain text entry (no behaviour change for callers
+        // that haven't wired a provider yet).
+        let provider: ((String, String) -> [Document])? = linkSearchProvider.map { base in
+            { query in base(field.linkedDocType ?? "", query) }
         }
+        return LinkPickerField(
+            targetDocType: field.linkedDocType ?? "Link",
+            value: stringBinding(for: field),
+            isReadOnly: isReadOnly,
+            searchProvider: provider
+        )
     }
 
     private func tableField(field: FieldDefinition) -> some View {

--- a/mercantis core/UIShell/LinkPickerField.swift
+++ b/mercantis core/UIShell/LinkPickerField.swift
@@ -1,0 +1,167 @@
+//
+//  LinkPickerField.swift
+//  mercantis core
+//
+//  W4: search-and-pick UI for FieldType.link fields. (ADR-030)
+//
+//  Callers inject a `searchProvider` closure so this view stays independent
+//  of `DocumentEngine`. When `searchProvider` is nil the field degrades to a
+//  plain TextField — existing code that hasn't wired a provider yet continues
+//  to compile and run unchanged.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+/// A form field that lets the user search for and select a linked document.
+///
+/// - `targetDocType`: display label for the target type (e.g. "Customer").
+/// - `value`: binding to the persisted link value — the target document's ID string.
+/// - `isReadOnly`: when true the field renders as plain text.
+/// - `searchProvider`: given a (targetDocType, query) pair, returns matching
+///   `Document` rows. Typically wraps `engine.list(docType:whereExpression:)`.
+///   Pass `nil` to fall back to plain-text entry.
+public struct LinkPickerField: View {
+
+    let targetDocType: String
+    @Binding var value: String
+    let isReadOnly: Bool
+    let searchProvider: ((String, String) -> [Document])?
+
+    @State private var isPickerPresented = false
+    @State private var searchQuery = ""
+    @State private var searchResults: [Document] = []
+
+    public init(
+        targetDocType: String,
+        value: Binding<String>,
+        isReadOnly: Bool,
+        searchProvider: ((String, String) -> [Document])?
+    ) {
+        self.targetDocType = targetDocType
+        self._value = value
+        self.isReadOnly = isReadOnly
+        self.searchProvider = searchProvider
+    }
+
+    public var body: some View {
+        if isReadOnly {
+            Text(value.isEmpty ? "—" : value)
+                .foregroundStyle(.secondary)
+        } else if searchProvider == nil {
+            // No provider: plain text entry (backwards-compatible fallback).
+            HStack {
+                TextField(targetDocType, text: $value)
+                    .mercantisInput()
+                Image(systemName: "arrow.up.right.square")
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            pickerButton
+                .sheet(isPresented: $isPickerPresented, onDismiss: { searchQuery = "" }) {
+                    pickerSheet
+                }
+        }
+    }
+
+    // MARK: - Picker button (idle state)
+
+    private var pickerButton: some View {
+        Button {
+            searchResults = runSearch(query: "")
+            isPickerPresented = true
+        } label: {
+            HStack {
+                Text(value.isEmpty ? "Select \(targetDocType)…" : value)
+                    .foregroundStyle(value.isEmpty ? .tertiary : .primary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Image(systemName: "chevron.up.chevron.down")
+                    .foregroundStyle(.secondary)
+                    .imageScale(.small)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(MercantisTheme.surface)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Picker sheet
+
+    private var pickerSheet: some View {
+        NavigationStack {
+            List {
+                if searchResults.isEmpty {
+                    ContentUnavailableView(
+                        searchQuery.isEmpty ? "No \(targetDocType) records" : "No results for \"\(searchQuery)\"",
+                        systemImage: "magnifyingglass"
+                    )
+                    .listRowBackground(Color.clear)
+                } else {
+                    ForEach(searchResults, id: \.id) { doc in
+                        Button {
+                            value = doc.id
+                            isPickerPresented = false
+                        } label: {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(doc.id)
+                                    .font(.body)
+                                if let subtitle = firstStringFieldValue(doc) {
+                                    Text(subtitle)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .searchable(text: $searchQuery, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search \(targetDocType)")
+            .onChange(of: searchQuery) { _, query in
+                searchResults = runSearch(query: query)
+            }
+            .navigationTitle("Select \(targetDocType)")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { isPickerPresented = false }
+                }
+                // Allow clearing the current selection.
+                if !value.isEmpty {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Clear") {
+                            value = ""
+                            isPickerPresented = false
+                        }
+                        .foregroundStyle(.red)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func runSearch(query: String) -> [Document] {
+        searchProvider?(targetDocType, query) ?? []
+    }
+
+    /// Returns the first non-empty string field value from a document, used as
+    /// a human-readable subtitle in the picker list alongside the raw ID.
+    private func firstStringFieldValue(_ doc: Document) -> String? {
+        for (key, value) in doc.fields {
+            guard key != "name" else { continue }
+            if case .string(let s) = value, !s.isEmpty, s != doc.id {
+                return s
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary
Implements search-and-pick functionality for `FieldType.link` fields in forms, with full backwards compatibility for existing callers. When no search provider is wired, link fields gracefully degrade to plain text entry.

## Key Changes
- **New `LinkPickerField` component**: A reusable SwiftUI view that renders link fields with three modes:
  - Search-and-pick UI when a `searchProvider` closure is supplied
  - Plain text entry when `searchProvider` is `nil` (backwards-compatible fallback)
  - Read-only text display when the field is read-only
  
- **Updated `GenericFormView`**: 
  - Added optional `linkSearchProvider` parameter (defaults to `nil`)
  - Delegates link field rendering to `LinkPickerField`
  - Maintains full backwards compatibility—existing code continues to work unchanged

- **Comprehensive test coverage**:
  - Smoke tests for link field rendering with and without a provider
  - Save-time validation tests confirming that references to non-existent documents are rejected
  - Validation tests confirming that references to existing documents are accepted
  - Test fixtures for Contact (with link field) and CustomerGroup (target type) DocTypes

## Implementation Details
- The `searchProvider` closure receives `(targetDocType, query)` and returns matching `[Document]` rows, allowing callers to wrap `engine.list(docType:whereExpression:)` or similar
- Link picker sheet includes search functionality, result display with ID and subtitle, and ability to clear the selection
- Follows ADR-030 for backwards-compatible feature introduction
- No breaking changes to existing APIs

https://claude.ai/code/session_01EF6P9gV8oBWKCAgTadJZnd