### PR TITLE
Fix W4 macOS build: guard iOS-only searchable placement and title dis…

### DIFF
--- a/mercantis core/UIShell/LinkPickerField.swift
+++ b/mercantis core/UIShell/LinkPickerField.swift
@@ -123,12 +123,14 @@ public struct LinkPickerField: View {
                 }
             }
             .listStyle(.plain)
-            .searchable(text: $searchQuery, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search \(targetDocType)")
+            .searchable(text: $searchQuery, placement: .automatic, prompt: "Search \(targetDocType)")
             .onChange(of: searchQuery) { _, query in
                 searchResults = runSearch(query: query)
             }
             .navigationTitle("Select \(targetDocType)")
+#if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+#endif
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { isPickerPresented = false }


### PR DESCRIPTION
…play mode

.navigationBarDrawer and .navigationBarTitleDisplayMode are unavailable on macOS. Use .automatic placement (cross-platform) and wrap the title display mode modifier in #if os(iOS).

https://claude.ai/code/session_01EF6P9gV8oBWKCAgTadJZnd