### PR TITLE
Close P0.7 — reconcile ARCHITECTURE.md drift with shipped state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,8 +32,9 @@ Core is deliberately domain-agnostic. It knows about *documents*, *DocTypes*, *w
 │                                                                             │
 │   ┌───────────┐   ┌─────────────┐   ┌────────────────────┐                 │
 │   │  UIShell  │   │ AppRuntime  │   │  ExpressionEngine  │                 │
-│   │ (planned) │   │  (manifest  │   │  (AST-based eval)  │                 │
-│   │           │   │  installer) │   │                    │                 │
+│   │ (Generic  │   │  (manifest  │   │  (AST-based eval,  │                 │
+│   │  Form/    │   │  installer) │   │   lookup() P2.2)   │                 │
+│   │  List)    │   │             │   │                    │                 │
 │   └─────┬─────┘   └──────┬──────┘   └─────────┬──────────┘                 │
 │         │                │                    │                             │
 │   ┌─────▼────────────────▼────────────────────▼────────────────────────┐   │
@@ -51,7 +52,7 @@ Core is deliberately domain-agnostic. It knows about *documents*, *DocTypes*, *w
 │         │                 │                                                 │
 │   ┌─────▼─────────────────▼──────────────────────────────────────────┐     │
 │   │                   Storage (GRDB / SQLite)                         │     │
-│   │   MercantisDatabase · MigrationRunner · CacheManager              │     │
+│   │   MercantisDatabase · MigrationRunner                             │     │
 │   └────────────────────────────┬─────────────────────────────────────┘     │
 │                                │                                            │
 │   ┌────────────────────────────▼─────────────────────────────────────┐     │
@@ -62,14 +63,14 @@ Core is deliberately domain-agnostic. It knows about *documents*, *DocTypes*, *w
 │                                                                             │
 │   ┌────────────────────┐  ┌──────────────┐  ┌────────────┐  ┌──────────┐  │
 │   │  MetadataRegistry  │  │ ReportEngine │  │FileManager │  │PrintEngine│  │
-│   │  + MetaComposer    │  │  (planned)   │  │            │  │(planned) │  │
+│   │  + MetaComposer    │  │              │  │ (planned)  │  │(planned) │  │
 │   │  → ResolvedMeta    │  └──────────────┘  └────────────┘  └──────────┘  │
 │   └────────────────────┘                                                   │
 │                                                                             │
 │   ┌────────────────────────┐  ┌───────────────────────┐                   │
 │   │  CustomizationEngine   │  │    ImportExport        │                   │
 │   │  (Custom Fields, Props,│  │  (CSV/JSON import/     │                   │
-│   │   Client Scripts)      │  │   export, fixtures)    │                   │
+│   │   Client Scripts)      │  │   export — planned)    │                   │
 │   └────────────────────────┘  └───────────────────────┘                   │
 │                                                                             │
 │   ┌────────────────────────┐  ┌───────────────────────┐                   │
@@ -398,14 +399,15 @@ See [ADR-010](Docs/ADR/ADR-010-pure-client-side-architecture.md).
 
 ### 4.14 Caching Layer
 
-**Location:** `mercantis core/Cache/`
+**Location:** `mercantis core/Cache/` *(planned — not on disk; tracked as P3.4)*
 
-The Caching Layer minimises repeated database reads for hot data.
+A standalone `CacheManager` subsystem has been described historically but is not implemented. What ships today is per-subsystem caching where it matters:
 
-- **MetadataRegistry cache** — All DocType definitions are cached in-memory on first access. The cache is invalidated when a DocType is installed, updated, or uninstalled via `AppInstaller`.
-- **Document cache** — Frequently accessed single-instance documents (e.g. system settings) can be cached using `getOrCache(docType:id:)`. The cache is invalidated on any write to that document.
-- **Query result cache** — List queries are not cached by default (SQLite is fast enough for on-device data volumes). Apps can opt in to result caching for expensive computed reports.
-- **Cache invalidation** — All caches use a generation counter. Any schema change increments the generation, forcing a full reload.
+- **MetadataRegistry cache (shipped)** — All DocType definitions are cached in-memory on first access; the cache is invalidated when a DocType is installed, updated, or uninstalled via `AppInstaller`.
+- **MetaComposer `ResolvedMeta` cache (shipped)** — The composed runtime schema is memoised per DocType and invalidated when base / custom-field / property-setter inputs change (§4.1, ADR-021).
+- **ExpressionEvaluator parse cache (shipped)** — Bounded LRU of recently-parsed source strings (default 256 entries, thread-safe via `NSLock`); see §4.7 / P2.1.
+- **CachingDocumentLookupResolver (shipped)** — Read-through cache for cross-document `lookup(...)` calls with per-save invalidation via the typed event bus (§4.7 / ADR-029 / P2.2).
+- **Document / query-result caches (planned)** — A general-purpose `getOrCache(...)` API and opt-in result caching for expensive reports are not implemented. Defer until a profiling pass identifies a hot path that the existing caches don't cover (P3.4).
 
 ---
 
@@ -427,7 +429,10 @@ Key API points:
 - `DocumentLookupResolver` — `lookup(docType:name:field:)` protocol; `CachingDocumentLookupResolver` is the read-through cache with per-save invalidation. (P2.2 / ADR-029)
 - `EventEmitter` — `subscribe(_:handler:)` → `SubscriptionToken`, `publish(_:)`
 - `AppInstaller` — `install(_:)`, `install(manifestData:)`, `validate(manifestData:)`, `uninstall(appId:)`, `decodeManifest(from:)` (P2.3)
-- *`AutomationActionRegistry` is planned (ADR-025) — not yet implemented.*
+- `AutomationActionRegistry` — `register(_:)`, `unregister(actionType:)`, `handler(for:)`, `execute(actionType:document:parameters:context:)` (P1.2 / ADR-025)
+- `AutomationRunner` — Subscribes to `DocumentSavedEvent` / `DocumentSubmittedEvent` / `DocumentCancelledEvent` and dispatches matching `AppManifest.automationRules` through the registry (P1.2)
+- `SchedulerService` — `register(_:)` / `unregister(appId:)`, `start()` / `tick()`; `ExtensionSchedulerRegistrar` conformance (P1.4)
+- `NamingService` — `resolve(...)` plus pluggable `NamingStrategy` registry (P1.1 / ADR-014)
 
 See [ADR-007](Docs/ADR/ADR-007-hub-on-core-public-apis.md).
 

--- a/Docs/ENHANCEMENT-PROPOSAL.md
+++ b/Docs/ENHANCEMENT-PROPOSAL.md
@@ -98,13 +98,17 @@ Until then, §4.4 / ADR-011 accurately document what ships.
 
 `EventBus.swift` is gone; `EventEmitter(legacyBus:)` and the bridge are gone; `DocumentEngine.init` / `WorkflowEngine.init` no longer take an `eventBus` parameter. ADR-012's "superseded" status now matches the code.
 
-### P0.7 — Update ARCHITECTURE.md §7 directory tree [S, zero risk] — doc hygiene
+### P0.7 — Update ARCHITECTURE.md §7 directory tree [S, zero risk] — doc hygiene *(done — 2026-04-26)*
 
-- Remove directories that don't exist (`Automation/`, `Cache/`, `Files/`, `ImportExport/`, `Printing/`, `Scheduling/`) or clearly mark them "(planned — not on disk)". (`Naming/` now exists — see P1.1.)
-- Add `Views/DesignSystem/` to the tree with its "demo-only" caveat.
-- Correct the `DocumentEngine.list` signature in §4.15 to `list(docType:filters:)`.
-- Correct the `PermissionEngine.canPerform` signature in §4.15 to `canPerform(operation:on:userRoles:)`.
-- (Already done in this changeset: ADR-027 added to §8.)
+The §7 directory tree is now an accurate reflection of disk: `Automation/`, `Naming/`, and `Scheduling/` (all shipped via P1.1 / P1.2 / P1.4) are listed as on-disk subsystems; `Cache/`, `Files/`, `ImportExport/`, and `Printing/` (P3.1 / P3.2 / P3.3 / P3.4) are listed in the trailing "Planned, not on disk" block with their ADR / proposal references; `Views/DesignSystem/` is in the tree with its "demo-only" caveat. The `DocumentEngine.list` and `PermissionEngine.canPerform` signatures in §4.15 were already updated through P2.5 / P0.5 — `list(docType:filters:whereExpression:sortBy:limit:offset:)` and `canPerform(operation:on:userRoles:)` are now the canonical forms quoted there.
+
+Three additional drift fixes landed in the same pass:
+
+- **§3 architecture diagram** — UIShell is no longer marked `(planned)` (it ships); `ReportEngine (planned)` is no longer marked planned (it ships); `CacheManager` was removed from the Storage box (no `Cache/` subsystem on disk); `FileManager` and `ImportExport` are now explicitly marked `(planned)`.
+- **§4.14 Caching Layer** — Reframed to show the `Cache/` location as planned (P3.4) and to enumerate the per-subsystem caches that actually ship today: `MetadataRegistry`'s in-memory cache, `MetaComposer`'s `ResolvedMeta` cache (ADR-021), the `ExpressionEvaluator` parse-cache LRU (P2.1), and `CachingDocumentLookupResolver` (P2.2 / ADR-029). The standalone `CacheManager` API (`getOrCache(...)`, opt-in result caching) is correctly marked deferred until profiling identifies a hot path.
+- **§4.15 Public API Surface** — Removed the stale "AutomationActionRegistry is planned" line; added the `AutomationActionRegistry` (P1.2 / ADR-025), `AutomationRunner` (P1.2), `SchedulerService` (P1.4), and `NamingService` (P1.1 / ADR-014) entries that were missing.
+
+(Already done in earlier changesets: ADR-027 added to §8.)
 
 ### P0.8 — `DocumentVersion` stores the full old/new not just a diff summary [S, low risk] — ADR-024 *(done — 2026-04-23)*
 


### PR DESCRIPTION
- §3 diagram: drop stale "(planned)" labels from UIShell and ReportEngine (both ship); remove the non-existent CacheManager from the Storage box; mark FileManager and ImportExport as "(planned)" so the diagram doesn't imply they're on disk.
- §4.14 Caching Layer: mark the standalone Cache/ subsystem as planned (P3.4) and enumerate the per-subsystem caches that actually ship today (MetadataRegistry, MetaComposer ResolvedMeta cache, ExpressionEvaluator parse cache, CachingDocumentLookupResolver).
- §4.15 Public API Surface: remove the stale "AutomationActionRegistry is planned" line (P1.2 shipped 2026-04-24) and add the missing entries for AutomationActionRegistry, AutomationRunner, SchedulerService, and NamingService.

§7 directory tree and §4.15 list/canPerform signatures were already accurate (closed by P1.x and P2.5 along the way); P0.7 itself is marked done in ENHANCEMENT-PROPOSAL.md with a summary of what landed in this pass.

https://claude.ai/code/session_01M4TJfuZ8ZLveDgN9afpHVr