### PR TITLE
W5: inline child-table field — ChildTableField view + GenericFormView…

### DIFF
--- a/Tests/MercantisCoreUITests/GenericFormViewSmokeTests.swift
+++ b/Tests/MercantisCoreUITests/GenericFormViewSmokeTests.swift
@@ -135,6 +135,107 @@ final class GenericFormViewSmokeTests: XCTestCase {
         XCTAssertNoThrow(try harness.engine.save(document))
     }
 
+    // MARK: - W5: child table field smoke tests
+
+    /// GenericFormView with a .table field and no provider compiles and
+    /// instantiates — degrades to the static count label, no crash.
+    func testChildTableFieldRendersWithNilProvider() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        let docType = TestHarness.makeSalesOrderDocType()
+        try harness.registry.register(docType)
+
+        var document = TestHarness.makeSalesOrderDocument(items: [])
+        try harness.engine.save(document)
+
+        let binding = Binding<Document>(get: { document }, set: { document = $0 })
+
+        let form = GenericFormView(
+            docType: docType,
+            document: binding,
+            childDocTypeProvider: nil
+        )
+        XCTAssertNotNil(form)
+    }
+
+    /// GenericFormView with a .table field and a wired provider compiles and
+    /// instantiates with the child DocType resolved.
+    func testChildTableFieldRendersWithWiredProvider() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        let itemDocType = TestHarness.makeSalesOrderItemDocType()
+        try harness.registry.register(itemDocType)
+
+        let docType = TestHarness.makeSalesOrderDocType()
+        try harness.registry.register(docType)
+
+        var document = TestHarness.makeSalesOrderDocument(items: [
+            TestHarness.makeChildRow(itemCode: "ITEM-001", qty: 2, rate: 50.0)
+        ])
+        try harness.engine.save(document)
+
+        let binding = Binding<Document>(get: { document }, set: { document = $0 })
+
+        let form = GenericFormView(
+            docType: docType,
+            document: binding,
+            childDocTypeProvider: { id in id == itemDocType.id ? itemDocType : nil }
+        )
+        XCTAssertNotNil(form)
+    }
+
+    /// Saving a parent with children and fetching it back preserves the children dict.
+    func testSaveRoundTripPropagatesChildren() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        let itemDocType = TestHarness.makeSalesOrderItemDocType()
+        try harness.registry.register(itemDocType)
+
+        let docType = TestHarness.makeSalesOrderDocType()
+        try harness.registry.register(docType)
+
+        let rows = [
+            TestHarness.makeChildRow(itemCode: "A", qty: 1, rate: 10.0),
+            TestHarness.makeChildRow(itemCode: "B", qty: 3, rate: 25.0)
+        ]
+        let document = TestHarness.makeSalesOrderDocument(items: rows)
+        try harness.engine.save(document)
+
+        let fetched = try harness.engine.fetch(id: document.id, docType: docType.id)
+        XCTAssertEqual(fetched.children["items"]?.count, 2)
+    }
+
+    /// Programmatically appending and removing from the rows binding updates the count.
+    func testAddAndRemoveChildRowUpdatesBinding() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        let itemDocType = TestHarness.makeSalesOrderItemDocType()
+        try harness.registry.register(itemDocType)
+
+        let docType = TestHarness.makeSalesOrderDocType()
+        try harness.registry.register(docType)
+
+        var document = TestHarness.makeSalesOrderDocument(items: [])
+        try harness.engine.save(document)
+
+        var rows: [ChildRow] = document.children["items", default: []]
+        XCTAssertEqual(rows.count, 0)
+
+        rows.append(TestHarness.makeChildRow(itemCode: "X", qty: 5, rate: 100.0))
+        XCTAssertEqual(rows.count, 1)
+
+        rows.append(TestHarness.makeChildRow(itemCode: "Y", qty: 2, rate: 30.0))
+        XCTAssertEqual(rows.count, 2)
+
+        rows.remove(at: 0)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].fields["item_code"], .string("Y"))
+    }
+
     func testGenericListViewInstantiatesAgainstInMemoryDocumentEngine() throws {
         let harness = try TestHarness.make()
         defer { harness.cleanUp() }
@@ -365,6 +466,108 @@ private enum TestHarness {
             syncState: .local,
             fields: ["group_name": .string("Commercial")],
             children: [:]
+        )
+    }
+
+    // MARK: - W5 fixtures
+
+    /// Parent DocType with a `.table` field pointing to "SalesOrderItem".
+    static func makeSalesOrderDocType() -> DocType {
+        DocType(
+            id: "SalesOrder",
+            name: "Sales Order",
+            module: "Sales",
+            appId: "app.mercantis.test",
+            isChildTable: false,
+            fields: [
+                FieldDefinition(
+                    key: "customer",
+                    label: "Customer",
+                    type: .text,
+                    required: true
+                ),
+                FieldDefinition(
+                    key: "items",
+                    label: "Items",
+                    type: .table,
+                    required: false,
+                    childDocType: "SalesOrderItem"
+                )
+            ],
+            permissions: [
+                PermissionRule(
+                    role: "System Manager",
+                    canRead: true,
+                    canWrite: true,
+                    canCreate: true,
+                    canDelete: true,
+                    canSubmit: true,
+                    canAmend: true
+                )
+            ],
+            syncPolicy: SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false),
+            indexes: [],
+            searchFields: ["customer"],
+            titleField: "customer"
+        )
+    }
+
+    /// Child DocType with `isChildTable: true`.
+    static func makeSalesOrderItemDocType() -> DocType {
+        DocType(
+            id: "SalesOrderItem",
+            name: "Sales Order Item",
+            module: "Sales",
+            appId: "app.mercantis.test",
+            isChildTable: true,
+            fields: [
+                FieldDefinition(key: "item_code", label: "Item Code", type: .text, required: true),
+                FieldDefinition(key: "qty", label: "Qty", type: .number, required: true),
+                FieldDefinition(key: "rate", label: "Rate", type: .currency, required: false)
+            ],
+            permissions: [
+                PermissionRule(
+                    role: "System Manager",
+                    canRead: true,
+                    canWrite: true,
+                    canCreate: true,
+                    canDelete: true,
+                    canSubmit: true,
+                    canAmend: true
+                )
+            ],
+            syncPolicy: SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false),
+            indexes: [],
+            searchFields: ["item_code"],
+            titleField: "item_code"
+        )
+    }
+
+    static func makeSalesOrderDocument(items: [ChildRow]) -> Document {
+        let now = Date()
+        return Document(
+            id: UUID().uuidString,
+            docType: "SalesOrder",
+            company: "",
+            status: "",
+            createdAt: now,
+            updatedAt: now,
+            syncVersion: 0,
+            syncState: .local,
+            fields: ["customer": .string("Test Customer")],
+            children: ["items": items]
+        )
+    }
+
+    static func makeChildRow(itemCode: String, qty: Int, rate: Double) -> ChildRow {
+        ChildRow(
+            id: UUID().uuidString,
+            rowIndex: 0,
+            fields: [
+                "item_code": .string(itemCode),
+                "qty": .int(qty),
+                "rate": .double(rate)
+            ]
         )
     }
 }

--- a/mercantis core/UIShell/ChildTableField.swift
+++ b/mercantis core/UIShell/ChildTableField.swift
@@ -1,0 +1,216 @@
+//
+//  ChildTableField.swift
+//  mercantis core
+//
+//  W5: inline editable child-table grid for GenericFormView table fields.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+/// Inline editable grid for a `.table` field.
+///
+/// When `childDocType` is nil (provider not wired) the view degrades to the
+/// static row-count label so existing callers see no crash. (W5 / ADR-031)
+public struct ChildTableField: View {
+
+    let field: FieldDefinition
+    let childDocType: DocType?
+    @Binding var rows: [ChildRow]
+    let isReadOnly: Bool
+
+    public init(
+        field: FieldDefinition,
+        childDocType: DocType?,
+        rows: Binding<[ChildRow]>,
+        isReadOnly: Bool
+    ) {
+        self.field = field
+        self.childDocType = childDocType
+        self._rows = rows
+        self.isReadOnly = isReadOnly
+    }
+
+    public var body: some View {
+        if let docType = childDocType {
+            wiredGrid(docType: docType)
+        } else {
+            fallbackLabel
+        }
+    }
+
+    // MARK: - Wired grid (child DocType resolved)
+
+    @ViewBuilder
+    private func wiredGrid(docType: DocType) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Column headers
+            if !docType.fields.isEmpty {
+                headerRow(docType: docType)
+            }
+
+            // Data rows
+            ForEach(rows.indices, id: \.self) { idx in
+                dataRow(docType: docType, idx: idx)
+            }
+
+            // Add-row button
+            if !isReadOnly {
+                Button {
+                    let newRow = blankRow(for: docType, index: rows.count)
+                    rows.append(newRow)
+                } label: {
+                    Label("Add Row", systemImage: "plus.circle")
+                        .font(.caption)
+                }
+                .padding(.top, 4)
+            }
+        }
+    }
+
+    private func headerRow(docType: DocType) -> some View {
+        HStack(spacing: 8) {
+            ForEach(docType.fields) { f in
+                Text(f.label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            // Spacer for the delete button column
+            if !isReadOnly {
+                Spacer().frame(width: 28)
+            }
+        }
+    }
+
+    private func dataRow(docType: DocType, idx: Int) -> some View {
+        HStack(spacing: 8) {
+            ForEach(docType.fields) { f in
+                childFieldCell(field: f, rowIdx: idx)
+            }
+            if !isReadOnly {
+                Button(role: .destructive) {
+                    rows.remove(at: idx)
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.caption)
+                }
+                .frame(width: 28)
+            }
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+        .background(MercantisTheme.surfaceMuted)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    @ViewBuilder
+    private func childFieldCell(field f: FieldDefinition, rowIdx: Int) -> some View {
+        switch f.type {
+        case .number, .decimal, .currency:
+            TextField(f.label, text: numberCellBinding(field: f, idx: rowIdx))
+                .mercantisInput()
+#if os(iOS)
+                .keyboardType(.decimalPad)
+#endif
+                .disabled(isReadOnly)
+                .frame(maxWidth: .infinity)
+        case .boolean:
+            Toggle("", isOn: boolCellBinding(field: f, idx: rowIdx))
+                .labelsHidden()
+                .disabled(isReadOnly)
+                .frame(maxWidth: .infinity)
+        default:
+            TextField(f.label, text: stringCellBinding(field: f, idx: rowIdx))
+                .mercantisInput()
+                .disabled(isReadOnly)
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: - Fallback (no provider wired)
+
+    private var fallbackLabel: some View {
+        HStack {
+            Text("\(rows.count) row\(rows.count == 1 ? "" : "s")")
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text("Table")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Cell bindings
+
+    private func stringCellBinding(field f: FieldDefinition, idx: Int) -> Binding<String> {
+        Binding<String>(
+            get: {
+                guard idx < rows.count else { return "" }
+                switch rows[idx].fields[f.key] {
+                case .string(let s): return s
+                case .int(let i): return "\(i)"
+                case .double(let d): return "\(d)"
+                case .bool(let b): return b ? "true" : "false"
+                default: return ""
+                }
+            },
+            set: { newValue in
+                guard idx < rows.count else { return }
+                rows[idx].fields[f.key] = .string(newValue)
+            }
+        )
+    }
+
+    private func numberCellBinding(field f: FieldDefinition, idx: Int) -> Binding<String> {
+        Binding<String>(
+            get: {
+                guard idx < rows.count else { return "" }
+                switch rows[idx].fields[f.key] {
+                case .int(let i): return "\(i)"
+                case .double(let d): return "\(d)"
+                case .string(let s): return s
+                default: return ""
+                }
+            },
+            set: { newValue in
+                guard idx < rows.count else { return }
+                if f.type == .number, let i = Int(newValue) {
+                    rows[idx].fields[f.key] = .int(i)
+                } else if let d = Double(newValue) {
+                    rows[idx].fields[f.key] = .double(d)
+                } else {
+                    rows[idx].fields[f.key] = .string(newValue)
+                }
+            }
+        )
+    }
+
+    private func boolCellBinding(field f: FieldDefinition, idx: Int) -> Binding<Bool> {
+        Binding<Bool>(
+            get: {
+                guard idx < rows.count else { return false }
+                if case .bool(let b) = rows[idx].fields[f.key] { return b }
+                return false
+            },
+            set: { newValue in
+                guard idx < rows.count else { return }
+                rows[idx].fields[f.key] = .bool(newValue)
+            }
+        )
+    }
+
+    // MARK: - Blank row factory
+
+    private func blankRow(for docType: DocType, index: Int) -> ChildRow {
+        ChildRow(
+            id: UUID().uuidString,
+            rowIndex: index,
+            fields: Dictionary(uniqueKeysWithValues: docType.fields.compactMap { f in
+                f.defaultValue.map { (f.key, $0) }
+            })
+        )
+    }
+}

--- a/mercantis core/UIShell/GenericFormView.swift
+++ b/mercantis core/UIShell/GenericFormView.swift
@@ -17,6 +17,11 @@ import MercantisCore
 /// it typically wraps `engine.list(docType:whereExpression:)`. When `nil` (the
 /// default), link fields fall back to plain text entry so existing callers are
 /// unaffected. (W4 / ADR-030)
+///
+/// Pass `childDocTypeProvider` to enable inline editing of `.table` fields. The
+/// closure receives a child DocType id and returns the resolved `DocType`. When
+/// `nil` (the default), table fields degrade to the static row-count label so
+/// existing callers are unaffected. (W5 / ADR-031)
 public struct GenericFormView: View {
 
     let docType: DocType
@@ -24,19 +29,22 @@ public struct GenericFormView: View {
     let userRoles: Set<String>
     let expressionEvaluator: ExpressionEvaluator
     let linkSearchProvider: ((String, String) -> [Document])?
+    let childDocTypeProvider: ((String) -> DocType?)?
 
     public init(
         docType: DocType,
         document: Binding<Document>,
         userRoles: Set<String> = [],
         expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator(),
-        linkSearchProvider: ((String, String) -> [Document])? = nil
+        linkSearchProvider: ((String, String) -> [Document])? = nil,
+        childDocTypeProvider: ((String) -> DocType?)? = nil
     ) {
         self.docType = docType
         self._document = document
         self.userRoles = userRoles
         self.expressionEvaluator = expressionEvaluator
         self.linkSearchProvider = linkSearchProvider
+        self.childDocTypeProvider = childDocTypeProvider
     }
 
     public var body: some View {
@@ -261,15 +269,16 @@ public struct GenericFormView: View {
     }
 
     private func tableField(field: FieldDefinition) -> some View {
-        let rows = document.children[field.key, default: []]
-        return HStack {
-            Text("\(rows.count) row\(rows.count == 1 ? "" : "s")")
-                .foregroundStyle(.secondary)
-            Spacer()
-            Text("Table")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-        }
+        let childDocType = field.childDocType.flatMap { childDocTypeProvider?($0) }
+        return ChildTableField(
+            field: field,
+            childDocType: childDocType,
+            rows: Binding(
+                get: { document.children[field.key, default: []] },
+                set: { document.children[field.key] = $0 }
+            ),
+            isReadOnly: false
+        )
     }
 
     private func attachmentField(field: FieldDefinition, isReadOnly: Bool) -> some View {


### PR DESCRIPTION
… wiring

• UIShell/ChildTableField.swift (new): SwiftUI view that renders a table field
  as an inline editable grid. Column order follows childDocType.fields; add-row
  button appends a blank ChildRow; each row has a delete button. Degrades to
  the static count label when childDocType is nil so no existing caller breaks.

• UIShell/GenericFormView.swift: adds `childDocTypeProvider: ((String) -> DocType?)?`
  parameter (default nil — zero breaking changes). Replaces the static tableField
  stub with a ChildTableField that resolves the child DocType via the provider.

• Tests/MercantisCoreUITests/GenericFormViewSmokeTests.swift: 4 new W5 smoke
  tests (nil-provider fallback, wired-provider instantiation, save round-trip
  propagates children, add/remove binding updates count) plus harness factories
  makeSalesOrderDocType, makeSalesOrderItemDocType, makeSalesOrderDocument,
  makeChildRow.

Persistence layer (Document, ChildRow, DocumentEngine) unchanged — children were already persisted and fetched atomically by the engine.

https://claude.ai/code/session_018hBn28PkqvbR8i4J7zqDqi