### PR TITLE
Fix build errors surfaced under Swift 6 strict concurrency

### DIFF
--- a/mercantis core/AppRuntime/ExtensionPointResolver.swift
+++ b/mercantis core/AppRuntime/ExtensionPointResolver.swift
@@ -118,6 +118,13 @@ public final class RecordingExtensionSchedulerRegistrar: ExtensionSchedulerRegis
     public struct Entry: Sendable, Equatable {
         public let appId: String
         public let declarationId: String
+
+        // Explicit nonisolated `==` so the synthesized Equatable conformance
+        // doesn't pick up actor isolation from the enclosing context under
+        // Swift 6 strict concurrency.
+        nonisolated public static func == (lhs: Entry, rhs: Entry) -> Bool {
+            lhs.appId == rhs.appId && lhs.declarationId == rhs.declarationId
+        }
     }
 
     private let lock = NSLock()

--- a/mercantis core/SyncEngine/SyncEngine.swift
+++ b/mercantis core/SyncEngine/SyncEngine.swift
@@ -119,7 +119,8 @@ public final class SyncEngine {
         }
 
         // Opportunistic, throttled prune of acknowledged rows. (ADR-028 / P0.4)
-        try? pruneSyncQueue(force: false)
+        // Result intentionally discarded — pruning is best-effort.
+        _ = try? pruneSyncQueue(force: false)
     }
 
     // MARK: - Receive & Apply
@@ -141,7 +142,8 @@ public final class SyncEngine {
         }
 
         // Opportunistic, throttled prune of acknowledged rows. (ADR-028 / P0.4)
-        try? pruneSyncQueue(force: false)
+        // Result intentionally discarded — pruning is best-effort.
+        _ = try? pruneSyncQueue(force: false)
     }
 
     /// Receive and apply remote mutations from the cloud adapter.

--- a/mercantis core/UIShell/GenericFormView.swift
+++ b/mercantis core/UIShell/GenericFormView.swift
@@ -258,7 +258,7 @@ public struct GenericFormView: View {
         // picker falls back to plain text entry (no behaviour change for callers
         // that haven't wired a provider yet).
         let provider: ((String, String) -> [Document])? = linkSearchProvider.map { base in
-            { query in base(field.linkedDocType ?? "", query) }
+            { _, query in base(field.linkedDocType ?? "", query) }
         }
         return LinkPickerField(
             targetDocType: field.linkedDocType ?? "Link",


### PR DESCRIPTION
• GenericFormView.swift: link-field provider closure now takes 2 args
  (`{ _, query in ... }`) to match the declared
  `((String, String) -> [Document])?` type. The first arg (target DocType
  passed by LinkPickerField) is intentionally ignored — the W4 wrapper
  uses `field.linkedDocType` directly.

• ExtensionPointResolver.swift: add an explicit `nonisolated public static
  func ==` to `RecordingExtensionSchedulerRegistrar.Entry` so the
  synthesized Equatable conformance isn't inferred as main-actor isolated
  under Swift 6.

• SyncEngine.swift: silence "Result of 'try?' is unused" by binding the
  best-effort `pruneSyncQueue` result to `_`.

https://claude.ai/code/session_018hBn28PkqvbR8i4J7zqDqi