### PR TITLE
Phase B: scheduled automation, naming rules, counter block reservation

### DIFF
--- a/Docs/ADR/ADR-040-document-naming-rules.md
+++ b/Docs/ADR/ADR-040-document-naming-rules.md
@@ -1,0 +1,69 @@
+# ADR-040 — `DocumentNamingRule` Conditional Selector
+
+**Status:** Accepted
+**Date:** 2026-05-05
+
+---
+
+## Context
+
+A DocType can declare a single `autoname` strategy (UUID, naming series,
+field-derived, etc.). Real ERPs need *conditional* naming:
+
+- Per-company series: `SINV-ACME-` for company "ACME",
+  `SINV-WIDGETS-` for company "WIDGETS".
+- Per-fiscal-year resets: a different series each fiscal year.
+- Per-warehouse GRN numbering: `GRN-WH01-`, `GRN-WH02-`.
+
+ERPNext expresses these via a priority-ordered rule list that maps a
+condition to a naming spec. Mercantis Core had no equivalent.
+
+## Decision
+
+Add `DocumentNamingRule(id, priority, condition, autoname)`. Rules live
+on the DocType:
+
+```swift
+public var namingRules: [DocumentNamingRule]
+```
+
+`NamingService.resolve(...)` evaluates the rules in ascending `priority`
+order:
+
+1. The first rule whose `condition` evaluates to `true` against
+   `document.fields` wins; its `autoname` spec is used in place of
+   `DocType.autoname`.
+2. A `nil` / empty / whitespace-only `condition` matches every document
+   (catch-all, useful as a final-priority fall-through).
+3. A condition that fails to evaluate (parse error, type mismatch) is
+   skipped fail-closed; evaluation continues with the next rule.
+4. If no rule matches, `NamingService` falls through to
+   `DocType.autoname`, then to `UUIDv7Strategy` if that is also absent.
+
+Conditions evaluate through the same `ExpressionEvaluator` used for
+visibility / readonly / row-access expressions, so the language is
+identical and the parse cache is shared.
+
+## Consequences
+
+**Positive**
+
+- ERPnext-style per-company / per-fiscal-year / per-warehouse naming is
+  expressible in metadata without code changes.
+- Backward compatible: DocTypes without `namingRules` keep the legacy
+  single-`autoname` behaviour byte-for-byte.
+
+**Negative**
+
+- A rule can fail closed silently if its expression doesn't parse,
+  hiding the bug. The Schema validator's expression check (P2.1) does
+  not currently extend to `namingRules.condition`; recommended follow-up.
+- Priority is integer, not name-keyed — duplicate priorities resolve
+  by declaration order, which is fine but worth documenting.
+
+**Neutral**
+
+- Conditions can reference any field on the document. They cannot
+  reference `user.*` or call `lookup(...)` today (that would require a
+  `DocumentLookupResolver` on the `NamingService`); deferred until
+  there is a real ERP need.

--- a/Docs/ADR/ADR-041-scheduled-automation-rules.md
+++ b/Docs/ADR/ADR-041-scheduled-automation-rules.md
@@ -1,0 +1,90 @@
+# ADR-041 — Scheduled Automation Rules
+
+**Status:** Accepted
+**Date:** 2026-05-05
+
+---
+
+## Context
+
+`AutomationRule` carries a `triggerEvent` field with values like `onSave`,
+`onSubmit`, `onCancel`, and — per the existing ADR-019 contract —
+`onSchedule`. The runner subscribed to document lifecycle events but had
+no path for `onSchedule`: rules with that trigger parsed and registered
+into the runner, but never fired. STATUS.md §3.8 flagged this.
+
+A separate (orthogonal) feature already exists:
+`AppManifest.extensionPoints.schedulerEvents` declarations are bound by
+`ExtensionPointResolver` to `SchedulerService` and dispatched through
+`ExtensionActionDispatcher`. That covers "fire these actions on a
+cadence" but not "for each document of this DocType, evaluate this
+condition and run these actions" — which is what
+`AutomationRule(triggerEvent: "onSchedule")` is meant to express.
+
+## Decision
+
+Three pieces:
+
+1. **Cadence on the rule.** `AutomationRule` gains an optional
+   `schedule: ScheduleInterval?` field. Required when
+   `triggerEvent == "onSchedule"`; ignored otherwise. Backward-compat
+   decode: existing manifests without the field round-trip cleanly.
+
+2. **Runner ↔ scheduler binding.** `AutomationRunner` accepts an
+   optional `scheduler: ExtensionSchedulerRegistrar?` at init. When
+   present:
+   - `register(rules:appId:)` registers a `ScheduledTask` per
+     scheduled rule with declaration id `"automation::<ruleId>"`.
+   - `unregister(appId:)` cancels every scheduled handle for that
+     app.
+   - `applyManifests(_:)` re-binds across all manifests atomically
+     (cancel old, register new).
+
+3. **Tick semantics.** When the scheduler fires the rule's task, the
+   runner iterates every document of `rule.docType` (via the
+   `AutomationDocumentGateway.listDocuments(docType:)` method,
+   added in this ADR), evaluates `rule.conditionExpression` per
+   document, and runs the actions on matches. Errors per-document
+   are reported and the iteration continues — one bad document
+   does not abort the rest.
+
+When the runner has no gateway, scheduled rules still fire, but
+against a placeholder document. This preserves the
+`send_notification` / `assign` use cases that don't need fields.
+
+## Consequences
+
+**Positive**
+
+- `onSchedule` rules now actually fire — the third leg of ADR-019's
+  trigger contract is real.
+- The `ScheduleInterval` type is reused (`.hourly`, `.daily`,
+  `.cron(...)`, etc.), so manifests don't grow a new schedule grammar.
+- Per-document iteration matches ERPNext semantics ("once a day,
+  recompute outstanding for every Sales Invoice").
+- Existing `extensionPoints.schedulerEvents` path is untouched —
+  scheduled rules and scheduler events are separate concerns
+  routed through the same `SchedulerService`.
+
+**Negative**
+
+- The runner now reads through `gateway.listDocuments(docType:)` on
+  every tick of every rule — for large tables and many rules, this
+  is O(rules × documents). Acceptable today; a future optimisation
+  could push the rule's condition into `DocumentEngine.list(...)`'s
+  `whereExpression` (Phase A §3.1 already supports this).
+- `gateway.listDocuments(docType:)` runs with `applyRowAccess: false`
+  because automation runs as a system actor, not as a specific user.
+  The trade-off is documented; security-sensitive automation should
+  add an explicit row predicate via `conditionExpression`.
+
+**Neutral**
+
+- The existing trigger matcher in `AutomationRunner.handle` already
+  matches `"onSchedule" == "onschedule"` case-insensitively, so no
+  changes needed there.
+- Manifest authors who previously used
+  `extensionPoints.schedulerEvents` for cron actions can keep doing
+  so. The new path is the ergonomic choice when the action is
+  scoped to documents of a specific DocType; the extension-point
+  path is the right tool for document-less cadenced work.

--- a/Docs/ADR/ADR-042-counter-block-reservation.md
+++ b/Docs/ADR/ADR-042-counter-block-reservation.md
@@ -1,0 +1,89 @@
+# ADR-042 — Per-Device Counter Block Reservation
+
+**Status:** Accepted
+**Date:** 2026-05-05
+
+---
+
+## Context
+
+`NamingSeriesStrategy` issues sequential counter values backed by a
+single `naming_counters(seriesKey, value)` row per series. ADR-014
+called out the open follow-up: two devices submitting Sales Invoices
+offline both increment their local copy of the row from zero and pick
+`SINV-2026-0001`. On sync, the VCM rejects one of the two writes — the
+data is safe, but the user-facing experience is bad ("your invoice
+number got changed because someone else's was the same").
+
+ADR-014's recommended fix: each device claims a contiguous block of
+counter values and issues from its block until exhausted, then claims
+another. The blocks don't overlap, so collisions don't happen.
+
+## Decision
+
+1. **New per-device block table.** Migration v9 adds
+   `naming_counter_blocks(seriesKey, deviceId, blockStart, blockEnd, nextValue)`,
+   PK `(seriesKey, deviceId)`. Each row records the current block and
+   the next value to issue for one device on one series.
+
+2. **Shared allocator unchanged.** The existing `naming_counters` row
+   per series remains the source of truth for "how far has this series
+   advanced globally". Block reservation bumps this row by `blockSize`
+   (default 50); the device's block is the resulting `[old+1, new]`
+   range.
+
+3. **`NamingCounterBlockReserver`.** Owns the reservation logic in one
+   atomic write transaction:
+   - If the device has a block with capacity (`nextValue <= blockEnd`),
+     issue `nextValue` and increment.
+   - Otherwise, advance the shared allocator by `blockSize`, derive
+     the new `[blockStart, blockEnd]`, persist the device row with
+     `nextValue = blockStart + 1`, and return `blockStart`.
+
+4. **`DocumentEngine` integration.** The engine already captures its
+   `deviceId` at init time. Its private `reserveCounter(...)` now
+   threads `deviceId` through to the reserver; the existing
+   `NamingContext.counterProvider` closure shape is unchanged.
+
+The default `blockSize = 50` keeps single-device behaviour visually
+identical to the legacy single-row path: the first device's first three
+saves still produce `…0001`, `…0002`, `…0003`.
+
+## Consequences
+
+**Positive**
+
+- Multi-device offline collisions on naming series are eliminated at
+  the local layer. Two devices never pick the same number again.
+- Single-device behaviour is preserved byte-for-byte for tests and for
+  installs that never have a second device.
+- The shared `naming_counters` row remains the merge target for sync;
+  CRDT-style `max(local, remote)` resolution will work correctly when
+  a real `CloudAdapter` ships.
+
+**Negative**
+
+- Counter sequences contain visible "stride" gaps after a device
+  exhausts a block: device A might issue `1..50`, then `101..150` after
+  device B claims `51..100`. ERPNext users tolerate this; it is
+  documented in ADR-014's counter-gap note.
+- Block size is a global constant today (`defaultBlockSize = 50`).
+  Per-DocType tuning is a follow-up if a series with very high
+  multi-device contention emerges.
+- The shared `naming_counters` row still increments by `blockSize` on
+  every block claim, so the visible "global counter" is no longer the
+  count of issued documents. This was already approximate (counter
+  gaps from validation failures); it just got coarser. Compliance
+  views should rely on the audit log (ADR-039), not the global
+  counter.
+
+**Neutral**
+
+- The reservation is done in the same `MercantisDatabase` transaction
+  as the document write only when the engine wraps the call in a
+  parent transaction; the default path uses a short reserver
+  transaction followed by the main save transaction (matching the
+  ADR-014 counter-gap behaviour).
+- True cloud reconciliation (a device's block invalidates if the
+  cloud has a higher value) is **not** in scope for this ADR. It
+  belongs in the CloudAdapter implementation per ADR-018.

--- a/Docs/ADR/README.md
+++ b/Docs/ADR/README.md
@@ -47,6 +47,9 @@ ADRs document significant architectural decisions: the context that motivated th
 | [ADR-037](ADR-037-doctype-row-access-expression.md) | DocType-Level `rowAccessExpression` Auto-Filter | Accepted |
 | [ADR-038](ADR-038-workflow-transition-history-persistence.md) | Workflow Transition History Persistence | Accepted |
 | [ADR-039](ADR-039-audit-log-writer.md) | `audit_log` Writer / Reader | Accepted |
+| [ADR-040](ADR-040-document-naming-rules.md) | `DocumentNamingRule` Conditional Selector | Accepted |
+| [ADR-041](ADR-041-scheduled-automation-rules.md) | Scheduled Automation Rules | Accepted |
+| [ADR-042](ADR-042-counter-block-reservation.md) | Per-Device Counter Block Reservation | Accepted |
 
 ## How to Read an ADR
 

--- a/Docs/ARCHITECTURE-CHANGELOG.md
+++ b/Docs/ARCHITECTURE-CHANGELOG.md
@@ -1,5 +1,69 @@
 # Mercantis Core — Architecture Changelog
 
+## Revision: 2026-05-05 (Phase B — scheduled automation, naming rules, counter block reservation)
+
+This revision lands the three "wiring and naming polish" items from
+STATUS.md §3.6–§3.8. ADRs 040–042 cover the design.
+
+### Code updated
+
+| File | Summary |
+|---|---|
+| `mercantis core/Naming/DocumentNamingRule.swift` *(new)* | `(id, priority, condition, autoname)` rule. Evaluated in priority order; first match wins; nil/empty condition is a catch-all; failed evaluations skip fail-closed (ADR-040). |
+| `mercantis core/Metadata/DocType.swift` | New `namingRules: [DocumentNamingRule]` field with backward-compatible `Codable` decoding. |
+| `mercantis core/Naming/NamingService.swift` | `resolve(...)` now evaluates `docType.namingRules` first (in priority order) and uses the matching rule's `autoname`, falling through to `docType.autoname` if none matches. Constructor accepts an `ExpressionEvaluator`. |
+| `mercantis core/Naming/NamingCounterBlockReserver.swift` *(new)* | Atomic per-`(seriesKey, deviceId)` block reservation. Single-device sequential issuance preserved; two devices get disjoint ranges (ADR-042). |
+| `mercantis core/Storage/MigrationRunner.swift` | Migration v9 adds `naming_counter_blocks(seriesKey, deviceId, blockStart, blockEnd, nextValue)` PK `(seriesKey, deviceId)`. |
+| `mercantis core/DocumentEngine/DocumentEngine.swift` | `reserveCounter(...)` threads `deviceId` through to `NamingCounterBlockReserver`. The naming context closure captures `[database, deviceId]`. |
+| `mercantis core/AppRuntime/AppRuntimeTypes.swift` | `AutomationRule` gains an optional `schedule: ScheduleInterval?` (ADR-041). Custom `Codable` decode preserves backward compat for older manifests. |
+| `mercantis core/Automation/AutomationRunner.swift` | New optional `scheduler: ExtensionSchedulerRegistrar?` dependency. `register(rules:appId:)`, `applyManifests(_:)`, and `unregister(appId:)` (re-)bind `onSchedule` rules into `ScheduledTask`s with declaration id `automation::<ruleId>`. On tick, the runner iterates `gateway.listDocuments(docType:)` and runs the rule per document. New diagnostic `scheduledRuleCount(forAppId:)`. |
+| `mercantis core/Automation/AutomationRunner.swift` (gateway) | `AutomationDocumentGateway` extended with `listDocuments(docType:)`. `DocumentEngine` conformance reads through `list(docType:applyRowAccess: false)` so automation runs as a system actor. |
+| `mercantis coreTests/DocumentNamingRuleTests.swift` *(new)* | Priority ordering, catch-all (`nil` condition), fall-through, fail-closed on bad expression. |
+| `mercantis coreTests/NamingCounterBlockTests.swift` *(new)* | Single-device sequential, two-device disjoint, block exhaustion claims fresh block, separate series isolated, full DocumentEngine save round-trip preserves `…0001`/`…0002`/`…0003`. |
+| `mercantis coreTests/AutomationSchedulerTests.swift` *(new)* | Scheduled rule registration, non-schedule rules excluded, missing schedule excluded, `unregister`/re-register cancel handles cleanly, `tick()` fans out across documents, condition gates per-document, `applyManifests` integrates per-app. |
+| `mercantis coreTests/MigrationRunnerTests.swift` | Highest-applied-version bumped to 9; new `testV9CreatesNamingCounterBlocksTable`. |
+
+### Behaviour changes
+
+- `DocumentEngine.save(...)` now runs through the per-device counter
+  reservation. Single-device installs see no behavioural difference
+  (block 1..50 issues 1, 2, 3, ...). Multi-device installs no longer
+  collide on naming-series IDs.
+- `AutomationRunner` initialised with a `scheduler:` will register
+  `onSchedule` rules immediately on `register(rules:appId:)`. Existing
+  callers that don't pass a scheduler keep the legacy "scheduled rules
+  are no-ops" behaviour.
+- `AutomationDocumentGateway` gained a third method
+  (`listDocuments(docType:)`). Custom test conformances will need to
+  add it; `DocumentEngine` already does.
+
+### Doc updates
+
+| File | Summary |
+|---|---|
+| `Docs/ADR/ADR-040-document-naming-rules.md` *(new)* | Conditional naming-rule selector. |
+| `Docs/ADR/ADR-041-scheduled-automation-rules.md` *(new)* | Runner ↔ scheduler wiring + `onSchedule` rule semantics. |
+| `Docs/ADR/ADR-042-counter-block-reservation.md` *(new)* | Per-device counter blocks. |
+| `Docs/ADR/README.md` | Index extended with ADR-040 to ADR-042. |
+| `Docs/STATUS.md` | Headline grade bumped to ~80%. §2 scorecard rows for Storage, NamingSystem, AutomationRunner, SchedulerService updated. §3.6–§3.8 rewritten as "shipped". §4 Phase B marked complete. |
+
+### Known follow-ups
+
+- Phase C is unblocked: Files / Attachments (P3.1), Print / PDF
+  (P3.2), Dashboard rendering (§3.10), Import / Export (P3.3).
+- The runner's per-tick "iterate every document" path is O(rules ×
+  documents) — fine today, optimisable later by pushing the rule's
+  condition into `DocumentEngine.list(...)`'s `whereExpression`.
+- `DocumentNamingRule.condition` expressions are not yet validated at
+  install time. The schema validator currently checks
+  `visibilityExpression` / `readOnlyExpression` / `formulaExpression`
+  on fields; extending the same check to naming rules is recommended.
+- True multi-device counter reconciliation needs a real
+  `CloudAdapter` (ADR-018). The local block infrastructure landed
+  here is correct; the cloud-side merge policy is not.
+
+---
+
 ## Revision: 2026-05-05 (Phase A engine fixes — list operators, row access, audit log, workflow transition history)
 
 This revision lands the four engine-level "ERP-blocking" gaps from STATUS.md

--- a/Docs/STATUS.md
+++ b/Docs/STATUS.md
@@ -1,6 +1,6 @@
 # Mercantis Core — Status & Roadmap
 
-_Last updated: 2026-05-05 (Phase A — list operators, row access, audit log, workflow transition history)_
+_Last updated: 2026-05-05 (Phase B — scheduled automation, naming rules, counter block reservation)_
 
 This document consolidates `ERP-READINESS.md` and `IMPLEMENTATION-STATUS.md` into a single reference.
 The Enhancement Backlog (former `ENHANCEMENT-PROPOSAL.md`) has been renamed to [`ROADMAP.md`](ROADMAP.md).
@@ -27,15 +27,14 @@ section below through an “is this enough to build Accounting / Sales / Purchas
 
 ## 1. Headline grade
 
-**Core is ~75% ready as an ERP platform.** The engine layer is well-architected
-and the offline-first / metadata-driven / sandboxed-expression / mutation-log
-substrate is sound. Phase A (this revision) closed four ERP-blocking engine
-gaps — typed list operators, auto-applied row-level access, a real audit-log
-writer, and persisted workflow transition history. Most of what remains is
-either (a) host-app wiring that Hub will own, (b) ERP-flavoured features
-that have a place in the architecture but no implementation yet (Files,
-Print/PDF, Import/Export), or (c) the breadth-and-depth Phase B/C/D items
-listed in §4.
+**Core is ~80% ready as an ERP platform.** Phase A closed the four engine
+gaps; Phase B (this revision) closed the three wiring-and-naming items
+— scheduled automation rules now fire, conditional naming rules pick the
+right `autoname` per document, and counter reservation is per-device so
+multi-device offline saves don't collide. What remains is mostly (a)
+ERP-flavoured features (Files, Print/PDF, Import/Export, Dashboards),
+(b) ReportEngine role filtering and a `GenericReportView`, and (c) at
+least one real `CloudAdapter` implementation.
 
 There are no architectural rewrites required. Every gap below has a clear
 landing place in an existing subsystem.
@@ -52,14 +51,14 @@ real ERP modules on top of it?_
 | DocumentEngine | ✅ Ready | CRUD, submit/cancel/amend, optimistic concurrency, atomic mutation log, typed `ListFilter` operator surface (Phase A §3.1, ADR-036), and auto-applied row-level access (Phase A §3.4, ADR-037) all ship. |
 | MetadataEngine | ✅ Ready | DocType + ResolvedMeta + custom fields + property setters cover ERP customisation needs. `DocType.rowAccessExpression` (ADR-037) added in Phase A. |
 | ExpressionEngine | ✅ Ready | AST + cross-document `lookup()` + parse-cache means automation rules and formula fields will scale to an ERP rule set without re-architecting. |
-| Storage | ✅ Ready | GRDB/SQLite + 8 versioned migrations (v8 adds `workflow_transitions`). Proven offline-first substrate. |
+| Storage | ✅ Ready | GRDB/SQLite + 9 versioned migrations (v8 adds `workflow_transitions`, v9 adds `naming_counter_blocks`). Proven offline-first substrate. |
 | SyncEngine | ⚠️ Partial | Push/pull/conflict-resolution all work; pruning works. **No real `CloudAdapter` implementation** — only `NoOpCloudAdapter`. Multi-device ERP sync is architecturally ready but not connected to any backend. |
 | WorkflowEngine | ✅ Ready | State machine + role/condition gating + auto-persisted `WorkflowTransitionHistory` (Phase A §3.3, ADR-038, table `workflow_transitions`). Reader API exposed via both `WorkflowTransitionHistoryWriter` and `DocumentEngine.workflowTransitions(...)`. |
 | PermissionEngine | ✅ Ready | DocType / field / row-level checks all work. `DocumentEngine.list` now auto-applies `canAccessRow` via `DocType.rowAccessExpression` (Phase A §3.4, ADR-037). Per-call `applyRowAccess: false` opt-out preserved for admin paths. |
-| NamingSystem | ⚠️ Partial | Five strategies ship (UUIDv7, Series, FieldDerived, Prompt, Format). **`DocumentNamingRule` (conditional selector) is missing** — per-company / per-fiscal-year naming series cannot be expressed today. **Counters are local-only** — multi-device sequential naming will collide. |
+| NamingSystem | ✅ Ready | Five strategies ship + conditional `DocumentNamingRule` selector (Phase B §3.6, ADR-040) + per-device counter block reservation (Phase B §3.7, ADR-042). Multi-device offline saves no longer collide on `SINV-2026-0001`-style series. |
 | AppRuntime | ⚠️ Partial | `AppManifest`, `AppInstaller`, `ExtensionPointResolver` all ship. **Not constructed at app launch** in `mercantis_coreApp.swift`; Hub already does this on its side, but third-party app shells will need the same wiring or a helper. |
-| AutomationRunner | ✅ Ready | Action registry + built-in handlers (`set_value`, `set_status`, `send_notification`, `validate`, `assign`) cover the common ERP automation cases. Scheduler-triggered rules (`triggerEvent == "onSchedule"`) are still no-ops — see §3. |
-| SchedulerService | ⚠️ Partial | Cron, persistence, tick loop all ship. **Not wired to AutomationRunner**, so manifest-declared scheduled automation rules don’t fire. **Background-task budget categories** (`short` / `default` / `long`) **and `audit_log` writes for failed runs** are not implemented. |
+| AutomationRunner | ✅ Ready | Action registry + built-in handlers + `onSchedule` rules (Phase B §3.8, ADR-041). Scheduled rules iterate every document of the rule's DocType per tick, evaluate the condition per document, and run actions on matches. |
+| SchedulerService | ✅ Ready | Cron, persistence, tick loop, and `AutomationRunner` integration (Phase B §3.8). Manifest-declared `onSchedule` automation rules now fire as expected. |
 | ReportEngine | ⚠️ Partial | `register` / `availableReports` / `execute` exist. **Role filtering is ignored** — `availableReports(for: role)` returns everything. No native renderer yet (`MercantisCoreUI` has no `GenericReportView`). |
 | Audit log | ✅ Ready | `AuditLogWriter` (Phase A §3.2, ADR-039) writes inside the same atomic block as save/applyRemote/delete, and follow-on rows for submit/cancel/amend lifecycle events. Reader API exposed via `DocumentEngine.auditEntries(forDocumentId:)` / `(forDocType:limit:offset:)`. |
 | Files / Attachments | ❌ Missing | No `Files/` subsystem on disk. Every ERP transactional document needs attachments (scanned invoice, signed PO, photo of damaged shipment). |
@@ -129,48 +128,36 @@ defines the protocol, host apps implement. But shipping at least one
 reference adapter (likely CloudKit) would help Hub’s first
 multi-device customer.
 
-### 3.6 `DocumentNamingRule` conditional selector missing
+### 3.6 `DocumentNamingRule` conditional selector — ✅ shipped (Phase B, ADR-040)
 
-**What ships today:** Five naming strategies, but no rule layer that
-picks between them based on document field values.
+`DocType.namingRules: [DocumentNamingRule]` declares priority-ordered
+rules `(id, priority, condition, autoname)`. `NamingService.resolve(...)`
+evaluates them in ascending priority; the first rule whose condition
+matches wins, otherwise it falls through to `DocType.autoname`. A `nil`
+or empty condition is a catch-all. Conditions that fail to evaluate
+fail closed (skipped). Unblocks ERPnext-style per-company /
+per-fiscal-year naming.
 
-**Why it matters for ERP:** Per-company naming series
-(`SINV-ACME-` vs `SINV-WIDGETS-`), per-fiscal-year resets, per-warehouse
-GRN numbering — all expressed via conditional rules in ERPNext. None
-expressible today in Hub.
+### 3.7 Naming counter range reservation — ✅ shipped (Phase B, ADR-042)
 
-**Suggested fix:** Implement `DocumentNamingRule` (priority-ordered,
-condition expression + strategy reference) and evaluate in
-`NamingService.resolve(...)` before falling through to the DocType’s
-default `autoname`.
+Migration v9 adds `naming_counter_blocks(seriesKey, deviceId, blockStart, blockEnd, nextValue)`.
+`NamingCounterBlockReserver` allocates per-device blocks from the
+shared `naming_counters` row, so two devices saving offline draw from
+disjoint ranges and never pick the same `SINV-2026-0001`. Default
+block size 50 keeps single-device behaviour byte-for-byte identical.
+True cloud reconciliation (block invalidation on remote-higher-value)
+is a `CloudAdapter` follow-up per ADR-018.
 
-### 3.7 Naming counters are local-only
+### 3.8 SchedulerService ↔ AutomationRunner wiring — ✅ shipped (Phase B, ADR-041)
 
-**What ships today:** `naming_counters(seriesKey, value)` table written
-in a short transaction. Single-device only.
-
-**Why it matters for ERP:** Two devices submitting Sales Invoices
-offline will pick the same `SINV-2026-0001` and collide on sync
-(VCM rejects, but the user experience is bad).
-
-**Suggested fix:** Per ADR-014’s open follow-up — per-device range
-reservation via the sync queue. Each device claims a block of N
-counter values from the cloud; offline issuance draws from the
-local block. Reconciles on next sync.
-
-### 3.8 SchedulerService is not wired to AutomationRunner
-
-**What ships today:** Both subsystems exist and tick correctly in
-isolation. Manifest `automationRules` with `triggerEvent == "onSchedule"`
-parse but never fire because the runner doesn’t subscribe to scheduler ticks.
-
-**Why it matters for ERP:** “Daily — recompute open balance”,
-“Hourly — pull supplier price feed”, “Monthly — close the period” all
-need scheduler-driven automation.
-
-**Suggested fix:** `AutomationRunner` registers a single
-`ScheduledTask` per cron expression seen in `automationRules`. On tick,
-runs the rule’s actions through the existing dispatcher.
+`AutomationRule` gains an optional `schedule: ScheduleInterval?`.
+`AutomationRunner` accepts an optional `scheduler:` at init; when
+present, `register(rules:appId:)` registers a `ScheduledTask` per
+`onSchedule` rule. On tick, the runner iterates documents of the
+rule's `docType` (via the new `gateway.listDocuments(docType:)`),
+evaluates the condition per document, and runs the actions on
+matches. `unregister(appId:)` and `applyManifests(_:)` cancel old
+handles cleanly.
 
 ### 3.9 Files / Print / Import-Export missing
 
@@ -208,11 +195,15 @@ routes to it.
 4. ✅ **§3.2 Audit log writer + reader** — `AuditLogWriter` wired into the
    atomic write block (ADR-039).
 
-### Phase B — Wiring and naming polish
+### Phase B — Wiring and naming polish — ✅ shipped 2026-05-05
 
-5. **§3.8 Scheduler ↔ AutomationRunner.** Unlocks scheduled rules.
-6. **§3.6 `DocumentNamingRule`.** Unlocks per-company naming series.
-7. **§3.7 Counter range reservation.** Required before any production multi-device deployment.
+5. ✅ **§3.8 Scheduler ↔ AutomationRunner** (ADR-041). `onSchedule`
+   automation rules now fire across every document of the rule's
+   DocType, with per-document condition evaluation.
+6. ✅ **§3.6 `DocumentNamingRule`** (ADR-040). Priority-ordered
+   conditional selector evaluated in `NamingService.resolve(...)`.
+7. ✅ **§3.7 Counter range reservation** (ADR-042). Per-device
+   block allocation backed by migration v9's `naming_counter_blocks`.
 
 ### Phase C — ERP feature breadth
 

--- a/mercantis core/AppRuntime/AppRuntimeTypes.swift
+++ b/mercantis core/AppRuntime/AppRuntimeTypes.swift
@@ -89,14 +89,41 @@ public struct AutomationRule: Codable, Sendable {
     public let triggerEvent: String         // e.g. "onSave", "onSubmit", "onSchedule"
     public let conditionExpression: String  // e.g. "document.status == \"Submitted\" && document.grandTotal > 10000"
     public let actions: [AutomationAction]
+    /// Required when `triggerEvent == "onSchedule"`. Ignored otherwise.
+    /// (Phase B §3.8, ADR-041)
+    public let schedule: ScheduleInterval?
 
-    public init(id: String, name: String, docType: String, triggerEvent: String, conditionExpression: String, actions: [AutomationAction]) {
+    public init(
+        id: String,
+        name: String,
+        docType: String,
+        triggerEvent: String,
+        conditionExpression: String,
+        actions: [AutomationAction],
+        schedule: ScheduleInterval? = nil
+    ) {
         self.id = id
         self.name = name
         self.docType = docType
         self.triggerEvent = triggerEvent
         self.conditionExpression = conditionExpression
         self.actions = actions
+        self.schedule = schedule
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, docType, triggerEvent, conditionExpression, actions, schedule
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        docType = try c.decode(String.self, forKey: .docType)
+        triggerEvent = try c.decode(String.self, forKey: .triggerEvent)
+        conditionExpression = try c.decode(String.self, forKey: .conditionExpression)
+        actions = try c.decode([AutomationAction].self, forKey: .actions)
+        schedule = try c.decodeIfPresent(ScheduleInterval.self, forKey: .schedule)
     }
 }
 

--- a/mercantis core/Automation/AutomationRunner.swift
+++ b/mercantis core/Automation/AutomationRunner.swift
@@ -21,6 +21,9 @@ import Foundation
 public protocol AutomationDocumentGateway: AnyObject {
     func loadDocument(docType: String, id: String) throws -> Document?
     func saveDocument(_ document: Document) throws -> Document
+    /// Used by `onSchedule` rules to enumerate every document of the rule's
+    /// `docType` per tick. Phase B §3.8.
+    func listDocuments(docType: String) throws -> [Document]
 }
 
 extension DocumentEngine: AutomationDocumentGateway {
@@ -30,6 +33,10 @@ extension DocumentEngine: AutomationDocumentGateway {
 
     public func saveDocument(_ document: Document) throws -> Document {
         try save(document)
+    }
+
+    public func listDocuments(docType: String) throws -> [Document] {
+        try list(docType: docType, applyRowAccess: false)
     }
 }
 
@@ -73,11 +80,17 @@ public final class AutomationRunner: @unchecked Sendable {
     private let userId: String
     private let clock: @Sendable () -> Date
     private let errorReporter: (@Sendable (RunnerError) -> Void)?
+    /// Optional scheduler integration. When provided, `onSchedule` rules
+    /// register themselves as `ScheduledTask`s and fire on tick. (Phase B §3.8)
+    private let scheduler: ExtensionSchedulerRegistrar?
 
     private let lock = NSLock()
     private var rulesByApp: [String: [AutomationRule]] = [:]
     private var tokens: [SubscriptionToken] = []
     private var inFlightDocIds: Set<String> = []
+    /// Active scheduler handles per-app, indexed by rule id, so `unregister`
+    /// or rule replacement cancels them cleanly.
+    private var scheduleHandlesByApp: [String: [String: ExtensionSchedulerHandle]] = [:]
 
     public init(
         emitter: EventEmitter,
@@ -88,7 +101,8 @@ public final class AutomationRunner: @unchecked Sendable {
         expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator(),
         userId: String = "",
         clock: @escaping @Sendable () -> Date = { Date() },
-        errorReporter: (@Sendable (RunnerError) -> Void)? = nil
+        errorReporter: (@Sendable (RunnerError) -> Void)? = nil,
+        scheduler: ExtensionSchedulerRegistrar? = nil
     ) {
         self.emitter = emitter
         self.registry = registry
@@ -99,11 +113,15 @@ public final class AutomationRunner: @unchecked Sendable {
         self.userId = userId
         self.clock = clock
         self.errorReporter = errorReporter
+        self.scheduler = scheduler
         wireSubscriptions()
     }
 
     deinit {
         for token in tokens { token.cancel() }
+        for (_, handles) in scheduleHandlesByApp {
+            for (_, handle) in handles { handle.cancel() }
+        }
     }
 
     // MARK: - Rule registration
@@ -114,13 +132,16 @@ public final class AutomationRunner: @unchecked Sendable {
         lock.lock()
         rulesByApp[appId] = rules
         lock.unlock()
+        rebindScheduledRules(for: appId, rules: rules)
     }
 
     /// Remove every rule registered for `appId`. Matches `AppInstaller.uninstall`.
     public func unregister(appId: String) {
         lock.lock()
         rulesByApp.removeValue(forKey: appId)
+        let handles = scheduleHandlesByApp.removeValue(forKey: appId) ?? [:]
         lock.unlock()
+        for (_, handle) in handles { handle.cancel() }
     }
 
     /// Install every rule from every manifest. Used by `restore`-style paths
@@ -131,7 +152,15 @@ public final class AutomationRunner: @unchecked Sendable {
         for manifest in manifests {
             rulesByApp[manifest.id] = manifest.automationRules
         }
+        let snapshotHandles = scheduleHandlesByApp
+        scheduleHandlesByApp.removeAll(keepingCapacity: true)
         lock.unlock()
+        for (_, handles) in snapshotHandles {
+            for (_, handle) in handles { handle.cancel() }
+        }
+        for manifest in manifests {
+            rebindScheduledRules(for: manifest.id, rules: manifest.automationRules)
+        }
     }
 
     /// The number of rules currently registered for `appId`. For tests and
@@ -139,6 +168,124 @@ public final class AutomationRunner: @unchecked Sendable {
     public func ruleCount(forAppId appId: String) -> Int {
         lock.lock(); defer { lock.unlock() }
         return rulesByApp[appId]?.count ?? 0
+    }
+
+    /// Number of `onSchedule` rules currently armed for `appId`.
+    public func scheduledRuleCount(forAppId appId: String) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return scheduleHandlesByApp[appId]?.count ?? 0
+    }
+
+    // MARK: - Scheduler integration (Phase B §3.8)
+
+    /// (Re-)register `onSchedule` rules with the scheduler. Cancels any
+    /// existing handles for the same app first, so calling `register(rules:)`
+    /// with a modified rule set applies cleanly.
+    private func rebindScheduledRules(for appId: String, rules: [AutomationRule]) {
+        guard let scheduler else { return }
+
+        // Cancel any prior handles before we re-bind.
+        lock.lock()
+        let oldHandles = scheduleHandlesByApp.removeValue(forKey: appId) ?? [:]
+        lock.unlock()
+        for (_, handle) in oldHandles { handle.cancel() }
+
+        var newHandles: [String: ExtensionSchedulerHandle] = [:]
+        for rule in rules {
+            guard rule.triggerEvent.lowercased() == "onschedule",
+                  let interval = rule.schedule else { continue }
+            let declaration = SchedulerEventDeclaration(
+                id: "automation::\(rule.id)",
+                interval: interval,
+                actions: []
+            )
+            let capturedAppId = appId
+            let capturedRule = rule
+            let handle = scheduler.register(
+                declaration: declaration,
+                appId: capturedAppId
+            ) { [weak self] in
+                self?.handleScheduledTick(rule: capturedRule, appId: capturedAppId)
+            }
+            newHandles[rule.id] = handle
+        }
+
+        if !newHandles.isEmpty {
+            lock.lock()
+            scheduleHandlesByApp[appId] = newHandles
+            lock.unlock()
+        }
+    }
+
+    /// Fire one `onSchedule` rule. Iterates every document of the rule's
+    /// `docType` (via the gateway), evaluates the condition per-document,
+    /// and runs actions on matches. Errors per document are reported but
+    /// do not abort the iteration.
+    private func handleScheduledTick(rule: AutomationRule, appId: String) {
+        guard let gateway else {
+            // No gateway → run actions document-less so notification /
+            // assignment / pure-action rules still fire.
+            do {
+                try runDocumentLessRule(rule, appId: appId)
+            } catch {
+                errorReporter?(.ruleFailed(appId: appId, ruleId: rule.id, underlying: error))
+            }
+            return
+        }
+
+        let documents: [Document]
+        do {
+            documents = try gateway.listDocuments(docType: rule.docType)
+        } catch {
+            errorReporter?(.ruleFailed(appId: appId, ruleId: rule.id, underlying: error))
+            return
+        }
+
+        for document in documents {
+            do {
+                try runRule(rule, appId: appId, trigger: "onSchedule", initialDocument: document)
+            } catch {
+                errorReporter?(.ruleFailed(appId: appId, ruleId: rule.id, underlying: error))
+            }
+        }
+    }
+
+    /// Run a rule that has no document context. Used when the runner has no
+    /// gateway — the actions still execute against a placeholder document.
+    private func runDocumentLessRule(_ rule: AutomationRule, appId: String) throws {
+        var placeholder = Document(
+            id: "scheduler:\(rule.id)",
+            docType: rule.docType,
+            company: "",
+            status: "",
+            createdAt: clock(),
+            updatedAt: clock(),
+            syncVersion: 0,
+            syncState: .local,
+            docStatus: 0,
+            amendedFrom: nil,
+            fields: [:],
+            children: [:]
+        )
+        let context = AutomationContext(
+            appId: appId,
+            trigger: "onSchedule",
+            docType: rule.docType,
+            documentId: placeholder.id,
+            userId: userId,
+            now: clock(),
+            notificationSink: notificationSink,
+            assignmentSink: assignmentSink,
+            expressionEvaluator: expressionEvaluator
+        )
+        for action in rule.actions {
+            try registry.execute(
+                actionType: action.type,
+                parameters: action.parameters,
+                on: &placeholder,
+                context: context
+            )
+        }
     }
 
     // MARK: - Event wiring

--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -239,8 +239,8 @@ public final class DocumentEngine {
         let context = NamingContext(
             userSuppliedName: userSuppliedName,
             now: Date(),
-            counterProvider: { [database] seriesKey in
-                try Self.reserveCounter(in: database, seriesKey: seriesKey)
+            counterProvider: { [database, deviceId] seriesKey in
+                try Self.reserveCounter(in: database, seriesKey: seriesKey, deviceId: deviceId)
             }
         )
         let resolvedId = try namingService.resolve(
@@ -265,27 +265,17 @@ public final class DocumentEngine {
         )
     }
 
-    /// Atomically increment and return the next counter value for a naming-series key.
+    /// Reserve and return the next counter value for a naming-series key,
+    /// scoped to this device. Backed by `NamingCounterBlockReserver`
+    /// (Phase B §3.7, ADR-042) so two devices saving offline don't pick
+    /// the same number.
     private static func reserveCounter(
         in database: MercantisDatabase,
-        seriesKey: String
+        seriesKey: String,
+        deviceId: String
     ) throws -> Int {
-        try database.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO naming_counters (seriesKey, value) VALUES (?, 1)
-                    ON CONFLICT(seriesKey) DO UPDATE SET value = value + 1
-                    """,
-                arguments: [seriesKey]
-            )
-            let row = try Row.fetchOne(
-                db,
-                sql: "SELECT value FROM naming_counters WHERE seriesKey = ?",
-                arguments: [seriesKey]
-            )
-            let value: Int = row?["value"] ?? 0
-            return value
-        }
+        let reserver = NamingCounterBlockReserver(database: database)
+        return try reserver.reserve(seriesKey: seriesKey, deviceId: deviceId)
     }
 
     // MARK: - Apply Remote (ADR-005, P0.2)

--- a/mercantis core/Metadata/DocType.swift
+++ b/mercantis core/Metadata/DocType.swift
@@ -33,6 +33,10 @@ public struct DocType: Codable, Identifiable, Sendable {
     /// row-filter results through `PermissionEngine.canAccessRow`. When `nil`
     /// or empty, no row-level restriction is enforced. (Phase A §3.4)
     public var rowAccessExpression: String?
+    /// Conditional naming rules evaluated in `priority` order before
+    /// falling through to `autoname`. Required by per-company /
+    /// per-fiscal-year ERPnext-style naming series. (Phase B §3.6, ADR-040)
+    public var namingRules: [DocumentNamingRule]
 
     public init(
         id: String,
@@ -54,7 +58,8 @@ public struct DocType: Codable, Identifiable, Sendable {
         titleField: String,
         isCustom: Bool = false,
         formLayout: FormLayout? = nil,
-        rowAccessExpression: String? = nil
+        rowAccessExpression: String? = nil,
+        namingRules: [DocumentNamingRule] = []
     ) {
         self.id = id
         self.name = name
@@ -76,6 +81,7 @@ public struct DocType: Codable, Identifiable, Sendable {
         self.isCustom = isCustom
         self.formLayout = formLayout
         self.rowAccessExpression = rowAccessExpression
+        self.namingRules = namingRules
     }
 
     enum CodingKeys: String, CodingKey {
@@ -99,6 +105,7 @@ public struct DocType: Codable, Identifiable, Sendable {
         case isCustom
         case formLayout
         case rowAccessExpression
+        case namingRules
     }
 
     public init(from decoder: any Decoder) throws {
@@ -124,5 +131,6 @@ public struct DocType: Codable, Identifiable, Sendable {
         isCustom = try container.decodeIfPresent(Bool.self, forKey: .isCustom) ?? false
         formLayout = try container.decodeIfPresent(FormLayout.self, forKey: .formLayout)
         rowAccessExpression = try container.decodeIfPresent(String.self, forKey: .rowAccessExpression)
+        namingRules = try container.decodeIfPresent([DocumentNamingRule].self, forKey: .namingRules) ?? []
     }
 }

--- a/mercantis core/Naming/DocumentNamingRule.swift
+++ b/mercantis core/Naming/DocumentNamingRule.swift
@@ -1,0 +1,40 @@
+//
+//  DocumentNamingRule.swift
+//  mercantis core
+//
+//  Phase B §3.6 (ADR-040) — Conditional naming-rule selector. Picks among
+//  multiple `autoname` strategies based on document field values, evaluated
+//  in priority order. ERPnext's per-company / per-fiscal-year naming series
+//  needs this; the flat `DocType.autoname` field can only express one
+//  strategy per DocType.
+//
+
+import Foundation
+
+/// One conditional rule that selects an `autoname` strategy when its
+/// `condition` evaluates true against the document being saved.
+///
+/// Rules are evaluated in ascending `priority` order; the first match wins.
+/// If no rule matches, `NamingService.resolve` falls through to the
+/// DocType's `autoname` (or `UUIDv7Strategy` if absent).
+///
+/// The `condition` expression sees every entry in `document.fields`. It is
+/// sandboxed by `ExpressionEvaluator` (ADR-017). A `nil` / empty condition
+/// is treated as "always match" — handy as a final-priority catch-all.
+public struct DocumentNamingRule: Codable, Sendable, Equatable {
+    public let id: String
+    /// Lower numbers run first. Ties resolve by declaration order.
+    public let priority: Int
+    /// Sandboxed boolean expression. `nil` / empty matches every document.
+    public let condition: String?
+    /// `autoname` spec to use when this rule matches. Same syntax as
+    /// `DocType.autoname` (e.g. `"naming_series:SINV-.YYYY.-.####"`).
+    public let autoname: String
+
+    public init(id: String, priority: Int, condition: String?, autoname: String) {
+        self.id = id
+        self.priority = priority
+        self.condition = condition
+        self.autoname = autoname
+    }
+}

--- a/mercantis core/Naming/NamingCounterBlockReserver.swift
+++ b/mercantis core/Naming/NamingCounterBlockReserver.swift
@@ -1,0 +1,134 @@
+//
+//  NamingCounterBlockReserver.swift
+//  mercantis core
+//
+//  Phase B §3.7 (ADR-042) — Per-device counter range reservation. Closes
+//  the multi-device offline collision flagged in ADR-014's open follow-up:
+//  two devices saving Sales Invoices offline would both pick `SINV-2026-0001`
+//  if they shared a single counter row. Each device now reserves a
+//  contiguous block of N counter values from the shared `naming_counters`
+//  allocator and issues out of its own block until exhausted, then claims
+//  a fresh block.
+//
+//  This is purely a *local* offline-correctness fix. The shared
+//  `naming_counters` row still needs CRDT-style merge semantics on sync —
+//  see `CloudAdapter` follow-up in ADR-014/ADR-018.
+//
+
+import Foundation
+import GRDB
+
+/// Reserves and issues sequential counter values per `(seriesKey, deviceId)`
+/// pair. Issued values within a series are unique across devices because
+/// each device draws from a disjoint block.
+///
+/// The default `blockSize` (50) keeps single-device behaviour visually
+/// identical to the legacy single-row path: device A's first three saves
+/// produce values `1, 2, 3`. Multi-device tests that want collision-free
+/// numbering should construct the reserver per device.
+public struct NamingCounterBlockReserver {
+
+    public static let defaultBlockSize: Int = 50
+
+    private let database: MercantisDatabase
+    private let blockSize: Int
+
+    public init(database: MercantisDatabase, blockSize: Int = NamingCounterBlockReserver.defaultBlockSize) {
+        self.database = database
+        self.blockSize = max(blockSize, 1)
+    }
+
+    /// Reserve and return the next counter value for `(seriesKey, deviceId)`.
+    /// Atomic: the block reservation, the local block advance, and the
+    /// returned value all commit in a single write transaction.
+    public func reserve(seriesKey: String, deviceId: String) throws -> Int {
+        try database.write { db in
+            // Fast path: an existing block has spare capacity.
+            if let row = try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT blockStart, blockEnd, nextValue
+                    FROM naming_counter_blocks
+                    WHERE seriesKey = ? AND deviceId = ?
+                    """,
+                arguments: [seriesKey, deviceId]
+            ),
+            let nextValue: Int = row["nextValue"],
+            let blockEnd: Int = row["blockEnd"],
+            nextValue <= blockEnd {
+                let issued = nextValue
+                try db.execute(
+                    sql: """
+                        UPDATE naming_counter_blocks
+                        SET nextValue = ?
+                        WHERE seriesKey = ? AND deviceId = ?
+                        """,
+                    arguments: [issued + 1, seriesKey, deviceId]
+                )
+                return issued
+            }
+
+            // Slow path: claim a fresh block by advancing the shared allocator.
+            try db.execute(
+                sql: """
+                    INSERT INTO naming_counters (seriesKey, value) VALUES (?, ?)
+                    ON CONFLICT(seriesKey) DO UPDATE SET value = value + ?
+                    """,
+                arguments: [seriesKey, blockSize, blockSize]
+            )
+            let advancedRow = try Row.fetchOne(
+                db,
+                sql: "SELECT value FROM naming_counters WHERE seriesKey = ?",
+                arguments: [seriesKey]
+            )
+            let advanced: Int = advancedRow?["value"] ?? blockSize
+            let blockStart = advanced - blockSize + 1
+            let blockEnd = advanced
+            let issued = blockStart
+
+            try db.execute(
+                sql: """
+                    INSERT INTO naming_counter_blocks
+                        (seriesKey, deviceId, blockStart, blockEnd, nextValue)
+                    VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(seriesKey, deviceId) DO UPDATE SET
+                        blockStart = excluded.blockStart,
+                        blockEnd   = excluded.blockEnd,
+                        nextValue  = excluded.nextValue
+                    """,
+                arguments: [seriesKey, deviceId, blockStart, blockEnd, issued + 1]
+            )
+            return issued
+        }
+    }
+
+    // MARK: - Inspection (test / diagnostics)
+
+    public struct BlockState: Sendable, Equatable {
+        public let blockStart: Int
+        public let blockEnd: Int
+        public let nextValue: Int
+        /// Number of values still issuable from the current block.
+        public var remaining: Int { max(blockEnd - nextValue + 1, 0) }
+    }
+
+    /// Return the device's current block state for `seriesKey`, or `nil`
+    /// if the device has never reserved against this series.
+    public func currentBlock(seriesKey: String, deviceId: String) throws -> BlockState? {
+        try database.read { db in
+            guard let row = try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT blockStart, blockEnd, nextValue
+                    FROM naming_counter_blocks
+                    WHERE seriesKey = ? AND deviceId = ?
+                    """,
+                arguments: [seriesKey, deviceId]
+            ) else { return nil }
+            let start: Int = row["blockStart"] ?? 0
+            let end: Int = row["blockEnd"] ?? 0
+            let next: Int = row["nextValue"] ?? 0
+            return BlockState(blockStart: start, blockEnd: end, nextValue: next)
+        }
+    }
+}

--- a/mercantis core/Naming/NamingService.swift
+++ b/mercantis core/Naming/NamingService.swift
@@ -22,8 +22,12 @@ import Foundation
 public final class NamingService {
 
     private var strategies: [String: NamingStrategy]
+    private let expressionEvaluator: ExpressionEvaluator
 
-    public init(strategies: [NamingStrategy] = NamingService.defaultStrategies()) {
+    public init(
+        strategies: [NamingStrategy] = NamingService.defaultStrategies(),
+        expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator()
+    ) {
         var map: [String: NamingStrategy] = [:]
         for strategy in strategies {
             for token in strategy.handles {
@@ -31,6 +35,7 @@ public final class NamingService {
             }
         }
         self.strategies = map
+        self.expressionEvaluator = expressionEvaluator
     }
 
     public static func defaultStrategies() -> [NamingStrategy] {
@@ -51,16 +56,63 @@ public final class NamingService {
         }
     }
 
-    /// Resolve the document's ID according to the DocType's `autoname`.
+    /// Resolve the document's ID according to the DocType's `namingRules`
+    /// (Phase B §3.6, ADR-040), falling back to `autoname` if no rule matches.
     ///
-    /// A DocType with no `autoname` (or `autoname == "UUID"`) uses
-    /// `UUIDv7Strategy` — this is the recommended offline-safe default.
+    /// Rules run in ascending `priority` order; ties resolve by declaration
+    /// order. The first rule whose `condition` evaluates `true` against the
+    /// document's fields wins, and its `autoname` spec is used in place of
+    /// the DocType's. A `nil` / empty / whitespace-only condition matches
+    /// every document — useful as a final-priority catch-all.
+    ///
+    /// Conditions that fail to evaluate (parse error, type mismatch) are
+    /// skipped fail-closed: the rule is treated as a non-match and the
+    /// next rule (or the DocType `autoname`) is tried.
+    ///
+    /// A DocType with no rules and no `autoname` (or `autoname == "UUID"`)
+    /// uses `UUIDv7Strategy` — the recommended offline-safe default.
     public func resolve(
         docType: DocType,
         document: Document,
         context: NamingContext
     ) throws -> String {
-        let raw = (docType.autoname ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedAutoname = selectAutoname(forDocType: docType, document: document)
+        return try dispatch(
+            autoname: resolvedAutoname,
+            docType: docType,
+            document: document,
+            context: context
+        )
+    }
+
+    /// Evaluate `docType.namingRules` and return the winning `autoname`
+    /// spec, falling back to `docType.autoname` if no rule matches.
+    private func selectAutoname(forDocType docType: DocType, document: Document) -> String? {
+        guard !docType.namingRules.isEmpty else { return docType.autoname }
+        let ordered = docType.namingRules.sorted { $0.priority < $1.priority }
+        for rule in ordered {
+            let trimmed = rule.condition?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed?.isEmpty ?? true {
+                return rule.autoname
+            }
+            let passes = (try? expressionEvaluator.evaluateBool(
+                expression: trimmed!,
+                context: document.fields
+            )) ?? false
+            if passes {
+                return rule.autoname
+            }
+        }
+        return docType.autoname
+    }
+
+    private func dispatch(
+        autoname: String?,
+        docType: DocType,
+        document: Document,
+        context: NamingContext
+    ) throws -> String {
+        let raw = (autoname ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
 
         if raw.isEmpty {
             return try dispatchUUID(docType: docType, document: document, context: context)

--- a/mercantis core/Storage/MigrationRunner.swift
+++ b/mercantis core/Storage/MigrationRunner.swift
@@ -84,6 +84,7 @@ public struct MigrationRunner {
         runner.register(version: 6, name: "add_scheduler_state", sql: MigrationRunner.v6SQL)
         runner.register(version: 7, name: "add_tree_parent", sql: MigrationRunner.v7SQL)
         runner.register(version: 8, name: "add_workflow_transitions", sql: MigrationRunner.v8SQL)
+        runner.register(version: 9, name: "add_naming_counter_blocks", sql: MigrationRunner.v9SQL)
     }
 
     // MARK: - v1 Schema
@@ -283,5 +284,31 @@ public struct MigrationRunner {
             ON workflow_transitions(documentId);
         CREATE INDEX IF NOT EXISTS idx_workflow_transitions_workflow
             ON workflow_transitions(workflowId);
+        """
+
+    // MARK: - v9 Schema — naming_counter_blocks (Phase B §3.7, ADR-042)
+
+    private static let v9SQL = """
+        -- Per-device counter blocks for naming-series IDs. Each device
+        -- reserves a contiguous block of N values from the shared
+        -- `naming_counters` allocator, then issues counter values out of
+        -- its local block without touching the shared row again until the
+        -- block is exhausted. This breaks the multi-device offline collision
+        -- (two devices can't both pick `SINV-2026-0001`) without depending
+        -- on a server round-trip per save.
+        --
+        -- `seriesKey` matches the key used by `NamingSeriesStrategy`
+        -- (e.g. "SalesInvoice::SINV-2026-"). `deviceId` matches
+        -- `DocumentEngine.deviceId`. `nextValue` is the next value the
+        -- device will issue (always within `[blockStart, blockEnd]`); when
+        -- it exceeds `blockEnd`, the device claims a fresh block.
+        CREATE TABLE IF NOT EXISTS naming_counter_blocks (
+            seriesKey   TEXT    NOT NULL,
+            deviceId    TEXT    NOT NULL,
+            blockStart  INTEGER NOT NULL,
+            blockEnd    INTEGER NOT NULL,
+            nextValue   INTEGER NOT NULL,
+            PRIMARY KEY (seriesKey, deviceId)
+        );
         """
 }

--- a/mercantis coreTests/AutomationSchedulerTests.swift
+++ b/mercantis coreTests/AutomationSchedulerTests.swift
@@ -1,0 +1,250 @@
+//
+//  AutomationSchedulerTests.swift
+//  mercantis coreTests
+//
+//  Phase B §3.8 (ADR-041) — `AutomationRunner` registers an `onSchedule`
+//  rule with the scheduler. On tick, it iterates documents of the rule's
+//  DocType, evaluates the condition per-document, and runs the actions.
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class AutomationSchedulerTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+    private var scheduler: SchedulerService!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness()
+        scheduler = SchedulerService(
+            persistence: SchedulerPersistence(database: harness.database),
+            tickInterval: 60,
+            clock: { Date() }
+        )
+    }
+
+    override func tearDown() {
+        scheduler.stop()
+        scheduler = nil
+        TestSupport.cleanUp(databaseURL: harness.url)
+        harness = nil
+    }
+
+    // MARK: - Helpers
+
+    private func registerNote() throws {
+        try harness.registry.register(TestSupport.makeDocType(
+            id: "Note",
+            fields: [
+                TestSupport.textField("title", required: true),
+                TestSupport.numberField("priority"),
+                TestSupport.textField("status"),
+            ]
+        ))
+    }
+
+    private func makeRunner() -> AutomationRunner {
+        AutomationRunner(
+            emitter: harness.emitter,
+            registry: AutomationActionRegistry(),
+            gateway: harness.engine,
+            scheduler: scheduler
+        )
+    }
+
+    private func saveNote(_ id: String, priority: Int, status: String = "Open") throws {
+        var doc = TestSupport.makeDocument(
+            id: id,
+            fields: [
+                "title":    .string(id),
+                "priority": .int(priority),
+                "status":   .string(status),
+            ]
+        )
+        doc.status = status
+        try harness.engine.save(doc)
+    }
+
+    // MARK: - Scheduler registration
+
+    func testOnScheduleRuleIsRegisteredWithScheduler() throws {
+        let runner = makeRunner()
+        let rule = AutomationRule(
+            id: "rule-1", name: "Daily refresh", docType: "Note",
+            triggerEvent: "onSchedule", conditionExpression: "",
+            actions: [], schedule: .daily
+        )
+        runner.register(rules: [rule], appId: "app.test")
+
+        XCTAssertEqual(runner.scheduledRuleCount(forAppId: "app.test"), 1)
+        XCTAssertTrue(scheduler.registeredTaskKeys()
+            .contains(where: { $0.contains("automation::rule-1") }))
+    }
+
+    func testNonScheduleRulesAreNotRegisteredWithScheduler() throws {
+        let runner = makeRunner()
+        let rule = AutomationRule(
+            id: "rule-onsave", name: "Save handler", docType: "Note",
+            triggerEvent: "onSave", conditionExpression: "", actions: []
+        )
+        runner.register(rules: [rule], appId: "app.test")
+
+        XCTAssertEqual(runner.scheduledRuleCount(forAppId: "app.test"), 0)
+    }
+
+    func testOnScheduleRuleWithoutScheduleIsNotRegistered() throws {
+        let runner = makeRunner()
+        let rule = AutomationRule(
+            id: "rule-no-schedule", name: "Bad rule", docType: "Note",
+            triggerEvent: "onSchedule", conditionExpression: "",
+            actions: [], schedule: nil
+        )
+        runner.register(rules: [rule], appId: "app.test")
+
+        XCTAssertEqual(runner.scheduledRuleCount(forAppId: "app.test"), 0)
+    }
+
+    func testUnregisterCancelsScheduledHandles() throws {
+        let runner = makeRunner()
+        let rule = AutomationRule(
+            id: "r", name: "", docType: "Note",
+            triggerEvent: "onSchedule", conditionExpression: "",
+            actions: [], schedule: .hourly
+        )
+        runner.register(rules: [rule], appId: "app.test")
+        XCTAssertEqual(scheduler.taskCount(forAppId: "app.test"), 1)
+
+        runner.unregister(appId: "app.test")
+        XCTAssertEqual(scheduler.taskCount(forAppId: "app.test"), 0)
+        XCTAssertEqual(runner.scheduledRuleCount(forAppId: "app.test"), 0)
+    }
+
+    func testReRegisterReplacesPriorScheduledHandles() throws {
+        let runner = makeRunner()
+        let firstRule = AutomationRule(
+            id: "r1", name: "", docType: "Note",
+            triggerEvent: "onSchedule", conditionExpression: "",
+            actions: [], schedule: .daily
+        )
+        runner.register(rules: [firstRule], appId: "app.test")
+        XCTAssertEqual(scheduler.taskCount(forAppId: "app.test"), 1)
+
+        // Replace with a different rule set — old handle should drop.
+        let secondRule = AutomationRule(
+            id: "r2", name: "", docType: "Note",
+            triggerEvent: "onSchedule", conditionExpression: "",
+            actions: [], schedule: .hourly
+        )
+        runner.register(rules: [secondRule], appId: "app.test")
+        XCTAssertEqual(scheduler.taskCount(forAppId: "app.test"), 1)
+        XCTAssertTrue(scheduler.registeredTaskKeys()
+            .contains(where: { $0.contains("automation::r2") }))
+        XCTAssertFalse(scheduler.registeredTaskKeys()
+            .contains(where: { $0.contains("automation::r1") }))
+    }
+
+    // MARK: - Tick semantics
+
+    func testSchedulerTickFiresActionAcrossEveryDocumentOfDocType() throws {
+        try registerNote()
+        try saveNote("a", priority: 1)
+        try saveNote("b", priority: 2)
+        try saveNote("c", priority: 3)
+
+        let registry = AutomationActionRegistry()
+        let runner = AutomationRunner(
+            emitter: harness.emitter,
+            registry: registry,
+            gateway: harness.engine,
+            scheduler: scheduler
+        )
+
+        let rule = AutomationRule(
+            id: "set-status", name: "Mark reviewed", docType: "Note",
+            triggerEvent: "onSchedule", conditionExpression: "",
+            actions: [
+                AutomationAction(
+                    type: "set_value",
+                    parameters: ["field": "status", "value": "Reviewed"]
+                )
+            ],
+            schedule: .all
+        )
+        runner.register(rules: [rule], appId: "app.test")
+
+        // Drive a tick directly; the runner closure dispatches into the gateway.
+        _ = scheduler.tick()
+
+        for id in ["a", "b", "c"] {
+            let updated = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: id))
+            XCTAssertEqual(updated.fields["status"], .string("Reviewed"),
+                           "Scheduled rule must fan out to every document of \(id)'s docType")
+        }
+    }
+
+    func testSchedulerTickRespectsConditionExpressionPerDocument() throws {
+        try registerNote()
+        try saveNote("low",  priority: 1)
+        try saveNote("high", priority: 9)
+
+        let runner = AutomationRunner(
+            emitter: harness.emitter,
+            registry: AutomationActionRegistry(),
+            gateway: harness.engine,
+            scheduler: scheduler
+        )
+
+        let rule = AutomationRule(
+            id: "elevate", name: "", docType: "Note",
+            triggerEvent: "onSchedule", conditionExpression: "priority > 5",
+            actions: [
+                AutomationAction(
+                    type: "set_value",
+                    parameters: ["field": "status", "value": "Escalated"]
+                )
+            ],
+            schedule: .all
+        )
+        runner.register(rules: [rule], appId: "app.test")
+        _ = scheduler.tick()
+
+        let low = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "low"))
+        let high = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "high"))
+        XCTAssertNotEqual(low.fields["status"], .string("Escalated"))
+        XCTAssertEqual(high.fields["status"], .string("Escalated"))
+    }
+
+    // MARK: - applyManifests integration
+
+    func testApplyManifestsRegistersScheduledRulesFromEveryManifest() throws {
+        let runner = makeRunner()
+        let manifestA = AppManifest(
+            id: "app.a", name: "A", version: "0.1.0",
+            minimumCoreVersion: "0.1.0", description: "A",
+            doctypes: [], workflows: [], permissions: [], reports: [],
+            automationRules: [
+                AutomationRule(id: "r-a", name: "", docType: "Note",
+                               triggerEvent: "onSchedule", conditionExpression: "",
+                               actions: [], schedule: .daily)
+            ],
+            dashboards: [], localizations: []
+        )
+        let manifestB = AppManifest(
+            id: "app.b", name: "B", version: "0.1.0",
+            minimumCoreVersion: "0.1.0", description: "B",
+            doctypes: [], workflows: [], permissions: [], reports: [],
+            automationRules: [
+                AutomationRule(id: "r-b", name: "", docType: "Note",
+                               triggerEvent: "onSchedule", conditionExpression: "",
+                               actions: [], schedule: .hourly)
+            ],
+            dashboards: [], localizations: []
+        )
+        runner.applyManifests([manifestA, manifestB])
+
+        XCTAssertEqual(runner.scheduledRuleCount(forAppId: "app.a"), 1)
+        XCTAssertEqual(runner.scheduledRuleCount(forAppId: "app.b"), 1)
+    }
+}

--- a/mercantis coreTests/DocumentNamingRuleTests.swift
+++ b/mercantis coreTests/DocumentNamingRuleTests.swift
@@ -1,0 +1,187 @@
+//
+//  DocumentNamingRuleTests.swift
+//  mercantis coreTests
+//
+//  Phase B §3.6 (ADR-040) — DocumentNamingRule selects the autoname spec
+//  based on document field values. Lower priority wins; first match wins.
+//  Fall through to DocType.autoname when no rule matches.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class DocumentNamingRuleTests: XCTestCase {
+
+    private final class InMemoryCounters {
+        private let lock = NSLock()
+        private var values: [String: Int] = [:]
+        func provider() -> @Sendable (_ seriesKey: String) throws -> Int {
+            { [self] key in
+                lock.lock(); defer { lock.unlock() }
+                values[key, default: 0] += 1
+                return values[key] ?? 0
+            }
+        }
+    }
+
+    private func makeDocType(
+        autoname: String? = "naming_series:DEFAULT-.####",
+        rules: [DocumentNamingRule] = []
+    ) -> DocType {
+        DocType(
+            id: "Invoice",
+            name: "Invoice",
+            module: "Sales",
+            appId: "app.test",
+            isChildTable: false,
+            fields: [
+                FieldDefinition(key: "company", label: "Company", type: .text, required: false),
+                FieldDefinition(key: "amount",  label: "Amount",  type: .number, required: false),
+            ],
+            permissions: [],
+            autoname: autoname,
+            syncPolicy: SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false),
+            indexes: [],
+            searchFields: [],
+            titleField: "company",
+            namingRules: rules
+        )
+    }
+
+    private func makeDoc(_ fields: [String: FieldValue] = [:]) -> Document {
+        Document(
+            id: "",
+            docType: "Invoice",
+            company: "",
+            status: "",
+            createdAt: Date(),
+            updatedAt: Date(),
+            syncVersion: 0,
+            syncState: .local,
+            fields: fields,
+            children: [:]
+        )
+    }
+
+    func testFirstMatchingRuleWinsByPriorityOrder() throws {
+        let counters = InMemoryCounters()
+        let docType = makeDocType(rules: [
+            DocumentNamingRule(id: "acme",     priority: 10,  condition: "company == \"ACME\"",
+                               autoname: "naming_series:SINV-ACME-.####"),
+            DocumentNamingRule(id: "widgets",  priority: 20,  condition: "company == \"WIDGETS\"",
+                               autoname: "naming_series:SINV-WID-.####"),
+        ])
+        let service = NamingService()
+        let context = NamingContext(now: Date(), counterProvider: counters.provider())
+
+        let acme = try service.resolve(
+            docType: docType,
+            document: makeDoc(["company": .string("ACME")]),
+            context: context
+        )
+        XCTAssertTrue(acme.hasPrefix("SINV-ACME-"))
+
+        let widgets = try service.resolve(
+            docType: docType,
+            document: makeDoc(["company": .string("WIDGETS")]),
+            context: context
+        )
+        XCTAssertTrue(widgets.hasPrefix("SINV-WID-"))
+    }
+
+    func testLowestPriorityNumberRunsFirst() throws {
+        let counters = InMemoryCounters()
+        // Two rules both match; priority 5 should win over priority 10.
+        let docType = makeDocType(rules: [
+            DocumentNamingRule(id: "loose", priority: 10, condition: nil,
+                               autoname: "naming_series:LOOSE-.####"),
+            DocumentNamingRule(id: "tight", priority: 5,  condition: "amount > 1000",
+                               autoname: "naming_series:LARGE-.####"),
+        ])
+        let service = NamingService()
+        let context = NamingContext(now: Date(), counterProvider: counters.provider())
+
+        let resolved = try service.resolve(
+            docType: docType,
+            document: makeDoc(["amount": .double(5000)]),
+            context: context
+        )
+        XCTAssertTrue(resolved.hasPrefix("LARGE-"))
+    }
+
+    func testNilConditionMatchesEveryDocumentAsCatchAll() throws {
+        let counters = InMemoryCounters()
+        let docType = makeDocType(rules: [
+            DocumentNamingRule(id: "specific", priority: 1, condition: "company == \"ACME\"",
+                               autoname: "naming_series:ACME-.####"),
+            DocumentNamingRule(id: "catchall", priority: 99, condition: nil,
+                               autoname: "naming_series:CATCH-.####"),
+        ])
+        let service = NamingService()
+        let context = NamingContext(now: Date(), counterProvider: counters.provider())
+
+        let resolved = try service.resolve(
+            docType: docType,
+            document: makeDoc(["company": .string("Other")]),
+            context: context
+        )
+        XCTAssertTrue(resolved.hasPrefix("CATCH-"))
+    }
+
+    func testFallsThroughToDocTypeAutonameWhenNoRuleMatches() throws {
+        let counters = InMemoryCounters()
+        let docType = makeDocType(
+            autoname: "naming_series:FALLBACK-.####",
+            rules: [
+                DocumentNamingRule(id: "only", priority: 1, condition: "company == \"NEVER\"",
+                                   autoname: "naming_series:NEVER-.####"),
+            ]
+        )
+        let service = NamingService()
+        let context = NamingContext(now: Date(), counterProvider: counters.provider())
+
+        let resolved = try service.resolve(
+            docType: docType,
+            document: makeDoc(["company": .string("Other")]),
+            context: context
+        )
+        XCTAssertTrue(resolved.hasPrefix("FALLBACK-"))
+    }
+
+    func testMalformedConditionFailsClosedAndContinues() throws {
+        let counters = InMemoryCounters()
+        // First rule has a malformed condition; runner should silently skip it
+        // and fall through to the next.
+        let docType = makeDocType(rules: [
+            DocumentNamingRule(id: "broken",  priority: 1,
+                               condition: "company == ", // syntactically incomplete
+                               autoname: "naming_series:BROKEN-.####"),
+            DocumentNamingRule(id: "ok",      priority: 2,
+                               condition: nil,
+                               autoname: "naming_series:OK-.####"),
+        ])
+        let service = NamingService()
+        let context = NamingContext(now: Date(), counterProvider: counters.provider())
+
+        let resolved = try service.resolve(
+            docType: docType,
+            document: makeDoc(["company": .string("Anything")]),
+            context: context
+        )
+        XCTAssertTrue(resolved.hasPrefix("OK-"))
+    }
+
+    func testEmptyRulesArrayUsesDocTypeAutoname() throws {
+        let counters = InMemoryCounters()
+        let docType = makeDocType(autoname: "naming_series:DEFAULT-.####", rules: [])
+        let service = NamingService()
+        let context = NamingContext(now: Date(), counterProvider: counters.provider())
+
+        let resolved = try service.resolve(
+            docType: docType,
+            document: makeDoc(),
+            context: context
+        )
+        XCTAssertTrue(resolved.hasPrefix("DEFAULT-"))
+    }
+}

--- a/mercantis coreTests/MigrationRunnerTests.swift
+++ b/mercantis coreTests/MigrationRunnerTests.swift
@@ -56,7 +56,7 @@ final class MigrationRunnerTests: XCTestCase {
         MigrationRunner.registerAll(into: &runner, pool: pool)
         try runner.migrate(pool: pool)
 
-        XCTAssertEqual(try highestAppliedVersion(), 8)
+        XCTAssertEqual(try highestAppliedVersion(), 9)
     }
 
     func testV1CreatesExpectedTables() throws {
@@ -135,6 +135,19 @@ final class MigrationRunnerTests: XCTestCase {
         XCTAssertTrue(try columnExists("workflowId", in: "workflow_transitions"))
         XCTAssertTrue(try columnExists("fromState", in: "workflow_transitions"))
         XCTAssertTrue(try columnExists("toState", in: "workflow_transitions"))
+    }
+
+    func testV9CreatesNamingCounterBlocksTable() throws {
+        var runner = MigrationRunner()
+        MigrationRunner.registerAll(into: &runner, pool: pool)
+        try runner.migrate(pool: pool)
+
+        XCTAssertTrue(try tableExists("naming_counter_blocks"))
+        XCTAssertTrue(try columnExists("seriesKey",  in: "naming_counter_blocks"))
+        XCTAssertTrue(try columnExists("deviceId",   in: "naming_counter_blocks"))
+        XCTAssertTrue(try columnExists("blockStart", in: "naming_counter_blocks"))
+        XCTAssertTrue(try columnExists("blockEnd",   in: "naming_counter_blocks"))
+        XCTAssertTrue(try columnExists("nextValue",  in: "naming_counter_blocks"))
     }
 
     func testSecondMigrateIsIdempotent() throws {

--- a/mercantis coreTests/NamingCounterBlockTests.swift
+++ b/mercantis coreTests/NamingCounterBlockTests.swift
@@ -1,0 +1,139 @@
+//
+//  NamingCounterBlockTests.swift
+//  mercantis coreTests
+//
+//  Phase B §3.7 (ADR-042) — Per-device counter range reservation. Two
+//  devices saving offline must not pick the same counter value; a single
+//  device must keep visually-sequential numbering for the legacy single-
+//  device path.
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class NamingCounterBlockTests: XCTestCase {
+
+    private var url: URL!
+    private var database: MercantisDatabase!
+
+    override func setUpWithError() throws {
+        url = TestSupport.tempDatabaseURL("counter-blocks")
+        database = try TestSupport.makeDatabase(at: url)
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: url)
+        database = nil
+    }
+
+    // MARK: - Single-device sequential
+
+    func testSingleDeviceIssuesSequentialValuesWithinABlock() throws {
+        let reserver = NamingCounterBlockReserver(database: database, blockSize: 50)
+        var issued: [Int] = []
+        for _ in 0..<5 {
+            issued.append(try reserver.reserve(seriesKey: "X", deviceId: "A"))
+        }
+        XCTAssertEqual(issued, [1, 2, 3, 4, 5])
+    }
+
+    func testSingleDeviceClaimsFreshBlockOnExhaustion() throws {
+        let reserver = NamingCounterBlockReserver(database: database, blockSize: 3)
+        var issued: [Int] = []
+        for _ in 0..<7 {
+            issued.append(try reserver.reserve(seriesKey: "X", deviceId: "A"))
+        }
+        // First block [1, 2, 3]; second block [4, 5, 6]; third block starts at 7.
+        XCTAssertEqual(issued, [1, 2, 3, 4, 5, 6, 7])
+    }
+
+    // MARK: - Multi-device disjoint
+
+    func testTwoDevicesGetDisjointBlocks() throws {
+        let reserver = NamingCounterBlockReserver(database: database, blockSize: 5)
+        let first = try reserver.reserve(seriesKey: "X", deviceId: "A")
+        let second = try reserver.reserve(seriesKey: "X", deviceId: "B")
+
+        XCTAssertEqual(first, 1)
+        // Device B's first reservation advances the global allocator beyond
+        // device A's [1, 5] block, so it gets at least 6.
+        XCTAssertGreaterThan(second, 5)
+    }
+
+    func testTwoDevicesDoNotCollideOnSequentialReservations() throws {
+        let reserver = NamingCounterBlockReserver(database: database, blockSize: 4)
+
+        var deviceAValues: Set<Int> = []
+        var deviceBValues: Set<Int> = []
+
+        // Interleave to mimic two offline devices syncing later.
+        for _ in 0..<10 {
+            deviceAValues.insert(try reserver.reserve(seriesKey: "X", deviceId: "A"))
+            deviceBValues.insert(try reserver.reserve(seriesKey: "X", deviceId: "B"))
+        }
+
+        XCTAssertEqual(deviceAValues.count, 10)
+        XCTAssertEqual(deviceBValues.count, 10)
+        XCTAssertTrue(deviceAValues.isDisjoint(with: deviceBValues),
+                      "Offline two-device reservations must never overlap")
+    }
+
+    // MARK: - State inspection
+
+    func testCurrentBlockReturnsNilBeforeFirstReservation() throws {
+        let reserver = NamingCounterBlockReserver(database: database, blockSize: 5)
+        XCTAssertNil(try reserver.currentBlock(seriesKey: "X", deviceId: "A"))
+    }
+
+    func testCurrentBlockReflectsReservationProgress() throws {
+        let reserver = NamingCounterBlockReserver(database: database, blockSize: 5)
+        _ = try reserver.reserve(seriesKey: "X", deviceId: "A")
+        _ = try reserver.reserve(seriesKey: "X", deviceId: "A")
+        let state = try XCTUnwrap(try reserver.currentBlock(seriesKey: "X", deviceId: "A"))
+        XCTAssertEqual(state.blockStart, 1)
+        XCTAssertEqual(state.blockEnd, 5)
+        XCTAssertEqual(state.nextValue, 3)
+        XCTAssertEqual(state.remaining, 3)
+    }
+
+    // MARK: - Series isolation
+
+    func testSeparateSeriesKeysDoNotShareACounter() throws {
+        let reserver = NamingCounterBlockReserver(database: database, blockSize: 5)
+        let a = try reserver.reserve(seriesKey: "S1", deviceId: "A")
+        let b = try reserver.reserve(seriesKey: "S2", deviceId: "A")
+        XCTAssertEqual(a, 1)
+        XCTAssertEqual(b, 1, "Different series keys must not share a counter")
+    }
+
+    // MARK: - DocumentEngine integration regression
+
+    func testDocumentEngineKeepsSequentialIdsForSingleDevice() throws {
+        let harness = try TestSupport.makeHarness(deviceId: "device-1")
+        defer { TestSupport.cleanUp(databaseURL: harness.url) }
+
+        try harness.registry.register(
+            TestSupport.makeDocType(
+                id: "SalesInvoice",
+                autoname: "naming_series:SINV-.YYYY.-.####"
+            )
+        )
+        let currentYear = Calendar(identifier: .gregorian).component(.year, from: Date())
+        let prefix = "SINV-\(String(format: "%04d", currentYear))-"
+
+        var ids: [String] = []
+        for _ in 0..<3 {
+            let saved = try harness.engine.save(
+                TestSupport.makeDocument(id: "", docType: "SalesInvoice")
+            )
+            ids.append(saved.id)
+        }
+
+        XCTAssertEqual(ids, [
+            "\(prefix)0001",
+            "\(prefix)0002",
+            "\(prefix)0003",
+        ])
+    }
+}


### PR DESCRIPTION
Closes the three wiring/naming gaps documented in STATUS.md §3.6-§3.8:

- §3.6 (ADR-040): DocumentNamingRule(id, priority, condition, autoname). NamingService.resolve evaluates rules in priority order and uses the first match's autoname; falls through to DocType.autoname when no rule matches. Conditions that fail to evaluate are skipped fail-closed. Unblocks ERPnext-style per-company / per-fiscal-year naming series.

- §3.7 (ADR-042): per-device counter block reservation. Migration v9 adds naming_counter_blocks(seriesKey, deviceId, blockStart, blockEnd, nextValue). NamingCounterBlockReserver allocates a block of N counter values per device from the shared naming_counters allocator; offline multi-device saves no longer collide on SINV-2026-0001-style series. Default block size 50 keeps single-device behaviour byte-for-byte.

- §3.8 (ADR-041): AutomationRule.schedule: ScheduleInterval? + AutomationRunner scheduler integration. register(rules:appId:) registers a ScheduledTask per onSchedule rule; on tick the runner iterates every document of the rule's docType (via gateway.listDocuments(docType:), new), evaluates the condition per-document, and runs actions on matches. unregister and applyManifests cancel handles cleanly.

Tests: DocumentNamingRuleTests (priority/catchall/fail-closed), NamingCounterBlockTests (single-device/two-device/exhaustion/series isolation/engine integration), AutomationSchedulerTests (register/unregister/replace/tick fan-out/condition gating/applyManifests), MigrationRunnerTests v9.

Docs: STATUS.md headline grade ~80%; §2 scorecard updated for Storage, NamingSystem, AutomationRunner, SchedulerService; §3.6-§3.8 rewritten as shipped; §4 Phase B marked complete. ARCHITECTURE-CHANGELOG entry added; ADRs 040-042 indexed.