### PR TITLE
Phase C: files/attachments, print/PDF, dashboards, import/export

### DIFF
--- a/Docs/ADR/ADR-043-attachments-subsystem.md
+++ b/Docs/ADR/ADR-043-attachments-subsystem.md
@@ -1,0 +1,82 @@
+# ADR-043 — Files / Attachments Subsystem
+
+**Status:** Accepted
+**Date:** 2026-05-05
+
+---
+
+## Context
+
+Every transactional ERP DocType eventually grows attachments: scanned
+invoices on Sales Invoice, signed POs on Purchase Order, photos on
+Stock Entry, employee CVs on Employee. STATUS.md §3.9 listed the Files
+subsystem as planned but missing — `FieldType.attachment` already
+existed in the metadata layer, but there was no place to actually
+store the bytes.
+
+## Decision
+
+Three-piece subsystem under `mercantis core/Files/`:
+
+1. **`AttachmentStore`** — filesystem byte store. Files live under
+   `<rootURL>/<documentId>/<attachmentId>` so per-document deletion is
+   one directory removal. SHA-256 hashing is provided as a static
+   helper for content integrity / (future) dedup.
+2. **`Attachment`** — typed metadata struct mirroring one row of the
+   new `attachments` table.
+3. **`AttachmentManager`** — public API (attach / read / list /
+   delete). Holds a `MercantisDatabase` for metadata, an
+   `AttachmentStore` for bytes, and an optional `AuditLogWriter` for
+   compliance. Every byte write commits with the metadata row in one
+   atomic write transaction; if the metadata insert fails the
+   on-disk file is deleted to avoid orphans.
+
+Migration v10 adds the `attachments` table:
+
+```
+attachments(id PK, documentId, docType, fieldKey?, fileName, mimeType,
+            byteSize, storagePath, uploadedAt, uploadedBy, sha256)
+```
+
+`fieldKey` is nullable: `nil` means a general document-level
+attachment, non-`nil` binds the file to a specific
+`FieldType.attachment` field for typed UI rendering.
+
+`DocumentEngine` accepts an optional `attachmentManager:` at init.
+When supplied, `delete(_:)` cascades and removes every attachment
+metadata row + on-disk file for the deleted document. The cascade
+runs outside the document write transaction (the
+`AttachmentManager` already provides its own atomic boundary), with
+failures swallowed via `try?` — the document deletion is durable
+and an orphan file is recoverable, while a cascade failure that
+aborted the delete would leave a deleted-row-but-live-children
+state that's harder to reason about.
+
+## Consequences
+
+**Positive**
+
+- Hub gets a working attachments API on day one of the dependency
+  bump. No bespoke per-Hub storage layer needed.
+- Bytes and metadata commit atomically; integrity is verified on
+  every read via SHA-256 comparison.
+- The cascade-on-delete keeps the on-disk store in sync with the
+  document table without bookkeeping in the caller.
+
+**Negative**
+
+- Attachments do not currently flow through the sync queue. Two
+  devices with different attachment sets won't reconcile until a
+  real `CloudAdapter` extends to attachment metadata + byte upload.
+  Local-only attachments are useful immediately; multi-device
+  attachment sync is a separate ADR-018 follow-up.
+- Hashing every read is O(file size). For very large files this is
+  measurable; a future optimisation could verify only the first /
+  last N KB or move to a Merkle-style chunked hash.
+
+**Neutral**
+
+- Attachments are not subject to the document mutation log. The
+  audit log (ADR-039) is the canonical compliance trail for attach
+  / detach actions when an `AuditLogWriter` is supplied to the
+  manager.

--- a/Docs/ADR/ADR-044-print-formats-and-pdf.md
+++ b/Docs/ADR/ADR-044-print-formats-and-pdf.md
@@ -1,0 +1,88 @@
+# ADR-044 — Print Formats and PDF Rendering
+
+**Status:** Accepted
+**Date:** 2026-05-05
+
+---
+
+## Context
+
+Sales Invoice, Purchase Order, Delivery Note, Quotation — every
+ERP-flavoured DocType eventually needs printable output. STATUS.md §3.9
+listed Print / PDF as missing; the architecture had no place for either
+the declarative format or the byte-producing renderer.
+
+The decision needed to satisfy three constraints:
+
+1. **Declarative.** Print formats live in app manifests, not code, so
+   end-users / system administrators can customise without rebuilding
+   the host app.
+2. **Multi-format.** Plain text (CLI export, scripting) and PDF
+   (customer-facing invoices) are the obvious first two; the
+   architecture should not foreclose HTML / DOCX later.
+3. **Cross-platform.** The same renderer code should compile on iOS,
+   macOS, and (for headless tests) Linux. UI-tier dependencies belong
+   in `MercantisCoreUI`, not in the engine library.
+
+## Decision
+
+Subsystem under `mercantis core/Printing/`:
+
+1. **`PrintFormat`** — declarative manifest type. Carries an ordered
+   list of `PrintSection` cases (heading / paragraph / fields-grid /
+   child-table grid / key-value). Each section is self-describing
+   structured data, not a markup string, so renderers can lay it out
+   per output kind without parsing.
+2. **`LetterHead`** — reusable header / footer chrome. Referenced by
+   `PrintFormat.letterHeadId`.
+3. **`PrintTemplate`** — shared helpers for `{field}` placeholder
+   substitution and default `FieldValue → String` formatting. Every
+   renderer uses these to keep behaviour consistent.
+4. **`PrintRenderer`** protocol — one renderer per `PrintOutputKind`.
+5. **`PlainTextPrintRenderer`** — pure-Swift, deterministic, always
+   available. Doubles as the test oracle and the CLI fallback.
+6. **`PDFPrintRenderer`** — Core Graphics-backed PDF renderer.
+   `CoreGraphics` is available on every Apple platform and avoids
+   pulling in PDFKit / SwiftUI / UIKit / AppKit. On Linux the file
+   compiles to a stub that throws `backendUnavailable`.
+7. **`PrintService`** — public coordinator. Holds the format / letter
+   head registries and dispatches to the right renderer by output
+   kind.
+
+## Consequences
+
+**Positive**
+
+- Hub gets a working print path immediately for both plain text and
+  PDF, declared via metadata. Sales Invoice / PO PDFs are no longer
+  blocked on a UI rewrite.
+- The renderer protocol cleanly separates output kind from format
+  declaration; an HTML / DOCX renderer is a single new file.
+- PDF rendering ships in `MercantisCore` (no UI dependency) because
+  `CoreGraphics` is a low-level Apple framework, not a UI framework.
+
+**Negative**
+
+- The PDF renderer is text-only (mono-spaced visual style derived
+  from the plain-text layout). Pixel-accurate invoice templates with
+  logos, tables with vertical rules, and CSS-grade typography are
+  not in scope. A future "rich" renderer could be added as a third
+  `PrintRenderer` implementation behind the same protocol.
+- Page break logic is naive: lines that overflow the page boundary
+  push to a new page; tables don't repeat their headers on
+  subsequent pages. Sufficient for a single-page invoice; revisit
+  when multi-page tables become real.
+- `CoreGraphics` adds an implicit Apple-platform-only contract for
+  the PDF path. The `#if canImport(CoreGraphics)` guard documents
+  this; downstream Linux consumers get a typed `backendUnavailable`
+  error rather than a link failure.
+
+**Neutral**
+
+- `PrintFormat` and `LetterHead` aren't yet attached to
+  `AppManifest`. Adding them is a one-line struct change once Hub
+  starts shipping print formats; deferred to keep this ADR focused.
+- Placeholder substitution is `{field}`-only. We deliberately avoid
+  full templating syntax (loops, conditionals) to keep the surface
+  manageable; complex formats should compose multiple `PrintSection`
+  cases instead.

--- a/Docs/ADR/ADR-045-dashboard-runtime.md
+++ b/Docs/ADR/ADR-045-dashboard-runtime.md
@@ -1,0 +1,86 @@
+# ADR-045 — Dashboard Runtime
+
+**Status:** Accepted
+**Date:** 2026-05-05
+
+---
+
+## Context
+
+`DashboardDefinition` and `DashboardWidget` have decoded from app
+manifests since ADR-004, but no runtime evaluated them. STATUS.md §3.10
+flagged this: Hub already declares dashboards in
+`HubDashboards.swift`, and the declarations have nowhere to render.
+
+Three concerns to separate:
+
+1. **Data resolution.** Walk the widget list, run each widget's
+   underlying query (count / list / chart / shortcut), produce
+   a typed result.
+2. **Rendering.** Turn the typed result into pixels. SwiftUI is the
+   right home for this — but it lives in `MercantisCoreUI`, not the
+   engine library.
+3. **Error handling.** A broken widget should not blank the entire
+   dashboard.
+
+## Decision
+
+`DashboardEngine` lives under `mercantis core/Reporting/` (alongside
+`ReportEngine`, since chart widgets defer to it). It owns:
+
+- A registry of `DashboardDefinition`s.
+- The `resolve(dashboardId:userRoles:)` method that walks the
+  declaration's widgets and produces a `DashboardResult`.
+- A typed `DashboardWidgetResult` enum mirroring the four widget
+  kinds plus an `error` case carrying a human-readable reason.
+
+Widget resolution rules:
+
+- **count** — calls `DocumentEngine.list(...)` with optional
+  parameter-derived predicates and returns the row count.
+- **list** — same, with explicit `columns` / `limit` parameters and
+  per-column value extraction via `PrintTemplate.lookup`.
+- **chart** — defers to `ReportEngine.execute(report:)` so charts
+  share their data path with reports.
+- **shortcut** — returns the navigation target straight from the
+  declaration (no DB hit).
+
+Widget parameter syntax (CSV-style; kept manifest-friendly):
+
+- `status=Open` ⇒ equality predicate.
+- `where.<field>__<op>=<value>` ⇒ typed operator predicate
+  (`eq`/`neq`/`gt`/`gte`/`lt`/`lte`/`like`/`isnull`/`notnull`).
+  Reuses Phase A's `ListFilter` predicates (ADR-036).
+
+## Consequences
+
+**Positive**
+
+- Hub's `HubDashboards.swift` declarations now have a real runtime to
+  consume. Pixel rendering still belongs to `MercantisCoreUI`, but the
+  engine no longer leaves declared dashboards as dead weight.
+- Per-widget error isolation: one bad widget shows an error tile, the
+  rest of the dashboard renders.
+- Charts share the `ReportEngine` execution path, so their data
+  semantics are identical to running the same report on its own.
+
+**Negative**
+
+- The widget parameter grammar is intentionally narrow. Anything
+  beyond simple operator predicates needs a richer schema (or a
+  `whereExpression` parameter). Deferred until ERP module rules
+  demand it.
+- `applyRowAccess: false` is hard-coded for the `list`/`count`
+  widget queries. Dashboards run as a system actor so the count
+  matches reality; per-user "what I can see" dashboards need an
+  explicit user-roles override path. Acceptable for now; documented
+  as a follow-up.
+- The `widget.parameters` dictionary is `[String: String]` per
+  ADR-004's manifest contract. Numeric / typed parameters get
+  coerced inside `DashboardEngine` rather than at decode time.
+
+**Neutral**
+
+- `GenericDashboardView` (the SwiftUI consumer of `DashboardResult`)
+  ships with `MercantisCoreUI` in a follow-up; the engine library
+  contract is the typed result.

--- a/Docs/ADR/ADR-046-import-export-subsystem.md
+++ b/Docs/ADR/ADR-046-import-export-subsystem.md
@@ -1,0 +1,86 @@
+# ADR-046 — Import / Export Subsystem
+
+**Status:** Accepted
+**Date:** 2026-05-05
+
+---
+
+## Context
+
+Every real ERP deployment starts with bulk import (data migration from
+the legacy system, opening balances, supplier price lists, customer
+master data) and grows into export (period reports, accountant
+hand-offs). STATUS.md §3.9 listed the subsystem as missing.
+
+## Decision
+
+Subsystem under `mercantis core/ImportExport/`:
+
+1. **`ImportExportFormat`** — `csv` and `json`, with shared error /
+   outcome types (`ImportRowOutcome`, `ImportReport`,
+   `ImportConflictPolicy`).
+2. **`CSVCodec`** — RFC-4180-ish encoder/decoder. Handles quoted
+   cells with embedded commas, newlines, and escaped quotes;
+   rejects unterminated quoted cells with a typed error.
+3. **`DataExporter`** — writes every document of a DocType (or a
+   subset matching `[ListFilter]` predicates) to CSV (flat,
+   children-omitted) or JSON (full envelope including children).
+4. **`DataImporter`** — reads CSV / JSON and routes every row
+   through `DocumentEngine.save(...)`. The validation pipeline,
+   naming service, audit log, and per-device counter blocks all
+   fire identically to interactive saves. Per-row failures are
+   recorded in the report rather than aborting the batch.
+
+Conflict policy on id collision:
+
+- `.overwrite` (default) — re-save the row with the imported
+  fields, preserving the existing `createdAt`, `syncVersion`, and
+  `updatedAt` so optimistic concurrency passes.
+- `.skipExisting` — keep the on-disk document, record the row as
+  `skipped`.
+- `.fail` — record the row as `failed`.
+
+Field-level coercion (CSV): primitives are typed by the DocType's
+`FieldDefinition.type`. Strings stay strings; numbers / booleans /
+dates parse through their ISO / decimal representations; child
+tables and formula fields are skipped (CSV cannot losslessly carry
+them). JSON imports use `Document`'s existing `Codable` so the typed
+`FieldValue` envelope (ADR-032) round-trips losslessly, including
+children.
+
+## Consequences
+
+**Positive**
+
+- Bulk migration paths (CSV from spreadsheet exports, JSON from
+  prior backups) work without per-DocType code.
+- Imports use the same write path as interactive saves, so all
+  ADR-022 validation rules, ADR-039 audit entries, and ADR-038
+  workflow transitions still apply. There is no "back door" that
+  bypasses business logic.
+- The `ImportReport` carries a per-row outcome list; admin UIs can
+  show "47 inserted, 2 updated, 3 failed" with individual reasons
+  without bespoke aggregation.
+
+**Negative**
+
+- CSV cannot losslessly express child tables. The exporter omits
+  them; the importer skips child cells. JSON is the right format
+  for round-trips that need to preserve full document shape.
+- Imports do not currently run inside a single transaction.
+  Per-row save means a partially-imported batch is durable when
+  the import is interrupted. This matches ERPNext's behaviour and
+  keeps memory pressure bounded for large files; the
+  `ImportReport` lets the caller resume by id.
+- The CSV decoder is intentionally minimal (no
+  alternative-separator support, no automatic encoding detection).
+  Extend per-call if needed; we won't grow the surface
+  speculatively.
+
+**Neutral**
+
+- Legacy import-error UIs in ERPNext show line numbers from the
+  CSV; we provide the row index post-decode. Mapping back to
+  source lines is a UI concern.
+- Round-trip JSON exports are pretty-printed with sorted keys, so
+  diffs against version control are stable.

--- a/Docs/ADR/README.md
+++ b/Docs/ADR/README.md
@@ -50,6 +50,10 @@ ADRs document significant architectural decisions: the context that motivated th
 | [ADR-040](ADR-040-document-naming-rules.md) | `DocumentNamingRule` Conditional Selector | Accepted |
 | [ADR-041](ADR-041-scheduled-automation-rules.md) | Scheduled Automation Rules | Accepted |
 | [ADR-042](ADR-042-counter-block-reservation.md) | Per-Device Counter Block Reservation | Accepted |
+| [ADR-043](ADR-043-attachments-subsystem.md) | Files / Attachments Subsystem | Accepted |
+| [ADR-044](ADR-044-print-formats-and-pdf.md) | Print Formats and PDF Rendering | Accepted |
+| [ADR-045](ADR-045-dashboard-runtime.md) | Dashboard Runtime | Accepted |
+| [ADR-046](ADR-046-import-export-subsystem.md) | Import / Export Subsystem | Accepted |
 
 ## How to Read an ADR
 

--- a/Docs/ARCHITECTURE-CHANGELOG.md
+++ b/Docs/ARCHITECTURE-CHANGELOG.md
@@ -1,5 +1,73 @@
 # Mercantis Core — Architecture Changelog
 
+## Revision: 2026-05-05 (Phase C — files/attachments, print/PDF, dashboards, import/export)
+
+This revision lands the four ERP-feature-breadth items from STATUS.md
+§3.9 + §3.10. ADRs 043–046 cover the design.
+
+### Code updated
+
+| File | Summary |
+|---|---|
+| `mercantis core/Files/Attachment.swift` *(new)* | Typed metadata struct + `AttachmentError`. (ADR-043) |
+| `mercantis core/Files/AttachmentStore.swift` *(new)* | Filesystem byte store rooted at `<dbDir>/attachments/`. SHA-256 helper for integrity. |
+| `mercantis core/Files/AttachmentManager.swift` *(new)* | Public attach / read / list / delete API. Atomic metadata + audit-log writes; rolls back the on-disk file if metadata persistence fails. |
+| `mercantis core/Storage/MigrationRunner.swift` | Migration v10 adds `attachments(id PK, documentId, docType, fieldKey, fileName, mimeType, byteSize, storagePath, uploadedAt, uploadedBy, sha256)` + indices. |
+| `mercantis core/DocumentEngine/DocumentEngine.swift` | Optional `attachmentManager:` init dependency. `delete(_:)` cascades and removes every attachment metadata row + on-disk file for the deleted document. |
+| `mercantis core/Printing/PrintFormat.swift` *(new)* | `PrintFormat` + `LetterHead` + structured `PrintSection` enum (heading / paragraph / fields / table / keyValue). (ADR-044) |
+| `mercantis core/Printing/PrintRenderer.swift` *(new)* | `PrintRenderer` protocol + `PrintRenderContext` / `PrintRenderResult` / `PrintOutputKind`. Shared `PrintTemplate` helpers (`{field}` substitution, `FieldValue` formatting, label humanisation). |
+| `mercantis core/Printing/PlainTextPrintRenderer.swift` *(new)* | Cross-platform plain-text renderer. Test oracle and CLI fallback. |
+| `mercantis core/Printing/PDFPrintRenderer.swift` *(new)* | CoreGraphics-backed PDF renderer with `#if canImport(CoreGraphics)` guard so non-Apple builds throw `backendUnavailable` instead of failing to link. |
+| `mercantis core/Printing/PrintService.swift` *(new)* | Public coordinator: format + letter-head registries, dispatches to renderer by `PrintOutputKind`. |
+| `mercantis core/Reporting/DashboardEngine.swift` *(new)* | Resolves `DashboardDefinition`s into typed `DashboardResult` (count / list / chart / shortcut / error). Widget-parameter mini-grammar (`where.<field>__<op>=<value>`) reuses `ListFilter` predicates from Phase A. (ADR-045) |
+| `mercantis core/ImportExport/ImportExportFormat.swift` *(new)* | `ImportExportFormat`, `ImportRowOutcome`, `ImportReport`, `ImportConflictPolicy`, `ImportExportError`. (ADR-046) |
+| `mercantis core/ImportExport/CSVCodec.swift` *(new)* | RFC-4180-ish encoder + decoder. Handles embedded commas/quotes/newlines; rejects unterminated quoted cells. |
+| `mercantis core/ImportExport/DataExporter.swift` *(new)* | CSV (flat) + JSON (envelope including children) export. Optional `[ListFilter]` subset. |
+| `mercantis core/ImportExport/DataImporter.swift` *(new)* | CSV + JSON import. Rows route through `DocumentEngine.save(...)` so validation / naming / audit / counter blocks all run. Per-row failures aggregate into `ImportReport` rather than aborting the batch. |
+| `mercantis coreTests/AttachmentTests.swift` *(new)* | Attach/read/list/delete; integrity verification on tampered file; field-key isolation; audit-log integration; engine cascade-on-delete. |
+| `mercantis coreTests/PrintServiceTests.swift` *(new)* | Registry, plain-text rendering with letter heads and child tables, placeholder substitution, unknown-format / docType-mismatch errors, PDF magic-byte sanity, `Codable` round-trip for `PrintFormat`. |
+| `mercantis coreTests/DashboardEngineTests.swift` *(new)* | count / list / chart / shortcut resolution; equality + operator filters; missing-ReportEngine fallback; unknown widget type → error tile; unknown dashboard throws. |
+| `mercantis coreTests/ImportExportTests.swift` *(new)* | CSV codec edge cases; CSV export columns + system fields; insert / overwrite / skipExisting; per-row failure isolation; JSON round-trip preserves children + typed values; predicate-bound exports. |
+| `mercantis coreTests/MigrationRunnerTests.swift` | Highest-applied-version bumped to 10; new `testV10CreatesAttachmentsTable`. |
+
+### Behaviour changes
+
+- `DocumentEngine.delete(...)` now cascades attachments when an
+  `attachmentManager:` is wired into the engine. The cascade runs
+  outside the document write transaction (the manager has its own
+  atomic boundary), with failures swallowed via `try?` so document
+  deletion remains durable.
+- New subsystems are entirely opt-in. Existing callers that don't
+  construct `AttachmentManager` / `PrintService` / `DashboardEngine`
+  / `DataImporter` see no behavioural change.
+
+### Doc updates
+
+| File | Summary |
+|---|---|
+| `Docs/ADR/ADR-043-attachments-subsystem.md` *(new)* | `AttachmentStore` + `AttachmentManager` + cascade-on-delete contract. |
+| `Docs/ADR/ADR-044-print-formats-and-pdf.md` *(new)* | Declarative `PrintFormat` + plain-text + CoreGraphics PDF renderer architecture. |
+| `Docs/ADR/ADR-045-dashboard-runtime.md` *(new)* | Engine vs renderer split; widget parameter grammar; per-widget error isolation. |
+| `Docs/ADR/ADR-046-import-export-subsystem.md` *(new)* | CSV + JSON; per-row outcomes; conflict policies; route-through-save semantics. |
+| `Docs/ADR/README.md` | Index extended with ADR-043 to ADR-046. |
+| `Docs/STATUS.md` | Headline grade bumped to ~90%. §2 scorecard rows for Storage, Files, Print/PDF, ImportExport, Dashboards updated. §3.9 + §3.10 rewritten as "shipped". §4 Phase C marked complete. |
+
+### Known follow-ups
+
+- Phase D is unblocked: real `CloudAdapter` (§3.5), `NotificationLog`
+  + at least one channel, `ReportEngine` role filtering +
+  `GenericReportView` in `MercantisCoreUI`.
+- The PDF renderer is text-only (mono-spaced layout). Pixel-accurate
+  invoice templates with logos / styled tables would require a
+  richer renderer behind the same `PrintRenderer` protocol.
+- `DashboardEngine` runs queries with `applyRowAccess: false`. A
+  per-user "what I can see" dashboard mode is a follow-up.
+- Attachment sync across devices is not in scope. Local-only
+  attachments are useful immediately; multi-device attachment sync
+  belongs in a `CloudAdapter` follow-up tied to ADR-018.
+
+---
+
 ## Revision: 2026-05-05 (Phase B — scheduled automation, naming rules, counter block reservation)
 
 This revision lands the three "wiring and naming polish" items from

--- a/Docs/STATUS.md
+++ b/Docs/STATUS.md
@@ -1,6 +1,6 @@
 # Mercantis Core — Status & Roadmap
 
-_Last updated: 2026-05-05 (Phase B — scheduled automation, naming rules, counter block reservation)_
+_Last updated: 2026-05-05 (Phase C — files/attachments, print/PDF, dashboards, import/export)_
 
 This document consolidates `ERP-READINESS.md` and `IMPLEMENTATION-STATUS.md` into a single reference.
 The Enhancement Backlog (former `ENHANCEMENT-PROPOSAL.md`) has been renamed to [`ROADMAP.md`](ROADMAP.md).
@@ -27,14 +27,16 @@ section below through an “is this enough to build Accounting / Sales / Purchas
 
 ## 1. Headline grade
 
-**Core is ~80% ready as an ERP platform.** Phase A closed the four engine
-gaps; Phase B (this revision) closed the three wiring-and-naming items
-— scheduled automation rules now fire, conditional naming rules pick the
-right `autoname` per document, and counter reservation is per-device so
-multi-device offline saves don't collide. What remains is mostly (a)
-ERP-flavoured features (Files, Print/PDF, Import/Export, Dashboards),
-(b) ReportEngine role filtering and a `GenericReportView`, and (c) at
-least one real `CloudAdapter` implementation.
+**Core is ~90% ready as an ERP platform.** Phase A closed the four engine
+gaps; Phase B closed the three wiring-and-naming items; Phase C (this
+revision) ships the four "ERP feature breadth" items — file attachments
+with on-disk store + cascade-on-delete, declarative print formats with
+plain-text and CoreGraphics PDF renderers, a dashboard runtime that
+resolves widget declarations into typed result tiles, and a CSV/JSON
+bulk import/export subsystem routed through the document validation
+pipeline. What remains is Phase D production-readiness: at least one
+real `CloudAdapter`, `NotificationLog` channels, and `ReportEngine`
+role filtering with a `GenericReportView` in `MercantisCoreUI`.
 
 There are no architectural rewrites required. Every gap below has a clear
 landing place in an existing subsystem.
@@ -51,7 +53,7 @@ real ERP modules on top of it?_
 | DocumentEngine | ✅ Ready | CRUD, submit/cancel/amend, optimistic concurrency, atomic mutation log, typed `ListFilter` operator surface (Phase A §3.1, ADR-036), and auto-applied row-level access (Phase A §3.4, ADR-037) all ship. |
 | MetadataEngine | ✅ Ready | DocType + ResolvedMeta + custom fields + property setters cover ERP customisation needs. `DocType.rowAccessExpression` (ADR-037) added in Phase A. |
 | ExpressionEngine | ✅ Ready | AST + cross-document `lookup()` + parse-cache means automation rules and formula fields will scale to an ERP rule set without re-architecting. |
-| Storage | ✅ Ready | GRDB/SQLite + 9 versioned migrations (v8 adds `workflow_transitions`, v9 adds `naming_counter_blocks`). Proven offline-first substrate. |
+| Storage | ✅ Ready | GRDB/SQLite + 10 versioned migrations (v8 `workflow_transitions`, v9 `naming_counter_blocks`, v10 `attachments`). Proven offline-first substrate. |
 | SyncEngine | ⚠️ Partial | Push/pull/conflict-resolution all work; pruning works. **No real `CloudAdapter` implementation** — only `NoOpCloudAdapter`. Multi-device ERP sync is architecturally ready but not connected to any backend. |
 | WorkflowEngine | ✅ Ready | State machine + role/condition gating + auto-persisted `WorkflowTransitionHistory` (Phase A §3.3, ADR-038, table `workflow_transitions`). Reader API exposed via both `WorkflowTransitionHistoryWriter` and `DocumentEngine.workflowTransitions(...)`. |
 | PermissionEngine | ✅ Ready | DocType / field / row-level checks all work. `DocumentEngine.list` now auto-applies `canAccessRow` via `DocType.rowAccessExpression` (Phase A §3.4, ADR-037). Per-call `applyRowAccess: false` opt-out preserved for admin paths. |
@@ -61,11 +63,11 @@ real ERP modules on top of it?_
 | SchedulerService | ✅ Ready | Cron, persistence, tick loop, and `AutomationRunner` integration (Phase B §3.8). Manifest-declared `onSchedule` automation rules now fire as expected. |
 | ReportEngine | ⚠️ Partial | `register` / `availableReports` / `execute` exist. **Role filtering is ignored** — `availableReports(for: role)` returns everything. No native renderer yet (`MercantisCoreUI` has no `GenericReportView`). |
 | Audit log | ✅ Ready | `AuditLogWriter` (Phase A §3.2, ADR-039) writes inside the same atomic block as save/applyRemote/delete, and follow-on rows for submit/cancel/amend lifecycle events. Reader API exposed via `DocumentEngine.auditEntries(forDocumentId:)` / `(forDocType:limit:offset:)`. |
-| Files / Attachments | ❌ Missing | No `Files/` subsystem on disk. Every ERP transactional document needs attachments (scanned invoice, signed PO, photo of damaged shipment). |
-| Print / PDF | ❌ Missing | No `Printing/` subsystem. Sales invoices, purchase orders, delivery notes universally require print formats and PDF rendering. |
-| ImportExport | ❌ Missing | No `ImportExport/` subsystem. Bulk CSV/JSON import/export is essential for any real deployment (data migration, supplier price lists, opening balances). |
-| Notifications | ⚠️ Partial | Typed event bus ships and works. `NotificationLog` DocType, in-app inbox, email/SMS/webhook channels are not implemented. |
-| Dashboards | ❌ Missing-runtime | `DashboardDefinition` decodes from manifests. **No `DashboardView` exists** in `MercantisCoreUI`. ERP home screens require dashboards. |
+| Files / Attachments | ✅ Ready | `Files/` subsystem (Phase C / P3.1, ADR-043). `AttachmentStore` (filesystem) + `AttachmentManager` (atomic metadata + audit). `DocumentEngine` cascade-on-delete via optional `attachmentManager:` init dependency. SHA-256 integrity check on every read. |
+| Print / PDF | ✅ Ready | `Printing/` subsystem (Phase C / P3.2, ADR-044). Declarative `PrintFormat` + `LetterHead`, pluggable `PrintRenderer` per `PrintOutputKind`, plain-text and CoreGraphics PDF renderers, `PrintService` coordinator. UI-tier rich rendering remains a `MercantisCoreUI` follow-up. |
+| ImportExport | ✅ Ready | `ImportExport/` subsystem (Phase C / P3.3, ADR-046). RFC-4180-ish `CSVCodec`, `DataExporter` (CSV + JSON), `DataImporter` routed through `DocumentEngine.save(...)` so validation / naming / audit / counter blocks all fire. Per-row outcome aggregation in `ImportReport`. |
+| Notifications | ⚠️ Partial | Typed event bus ships and works. `NotificationLog` DocType, in-app inbox, email/SMS/webhook channels are not implemented. (Phase D) |
+| Dashboards | ✅ Ready (engine) | `DashboardEngine` (Phase C / §3.10, ADR-045) resolves `DashboardDefinition` widgets into typed `DashboardResult` tiles using `DocumentEngine` + `ReportEngine`. Per-widget error isolation. SwiftUI `GenericDashboardView` is a `MercantisCoreUI` follow-up. |
 | UIShell | ✅ Ready | `GenericFormView`, `GenericListView`, `NavigationShell`, `FormBuilderView`, link picker, inline child-table editor, rich text / image / barcode field types all ship. |
 | SwiftPM split | ✅ Ready | `MercantisCore` (headless) + `MercantisCoreUI` (SwiftUI) means Hub can depend on the right surface cleanly. |
 
@@ -159,26 +161,38 @@ evaluates the condition per document, and runs the actions on
 matches. `unregister(appId:)` and `applyManifests(_:)` cancel old
 handles cleanly.
 
-### 3.9 Files / Print / Import-Export missing
+### 3.9 Files / Print / Import-Export — ✅ shipped (Phase C, ADRs 043 / 044 / 046)
 
-These are documented as planned (P3.1 / P3.2 / P3.3) and won’t surprise
-anyone, but they are real ERP blockers:
+- **Files (P3.1, ADR-043):** `Files/` subsystem with `AttachmentStore`
+  (bytes on disk under `<dbDir>/attachments/<documentId>/`),
+  `AttachmentManager` (atomic metadata + audit), and `DocumentEngine`
+  cascade-on-delete via the optional `attachmentManager:` init
+  dependency. SHA-256 hashing on every write enables integrity
+  verification on every read.
+- **Print / PDF (P3.2, ADR-044):** `Printing/` subsystem with
+  declarative `PrintFormat` + `LetterHead`, pluggable `PrintRenderer`
+  per `PrintOutputKind`, plain-text and CoreGraphics PDF renderers,
+  and a `PrintService` coordinator. UI-tier rich rendering remains a
+  `MercantisCoreUI` follow-up.
+- **Import / Export (P3.3, ADR-046):** `ImportExport/` subsystem with
+  RFC-4180-ish `CSVCodec`, `DataExporter` (CSV + JSON envelope),
+  and `DataImporter` routed through `DocumentEngine.save(...)` so the
+  validation pipeline, naming service, audit log, and per-device
+  counter blocks all fire identically to interactive saves. Per-row
+  outcomes aggregate into `ImportReport`.
 
-- **Files:** Required by every transactional DocType. Land first.
-- **Print / PDF:** Required by Sales Invoice, Purchase Order, Delivery
-  Note, Quotation. Land before submitting Selling/Buying modules.
-- **Import / Export:** Required by every customer’s data migration. Land
-  before any production deployment.
+### 3.10 Dashboard runtime — ✅ shipped (Phase C, ADR-045)
 
-### 3.10 Dashboard rendering missing
+`DashboardEngine` lives under `mercantis core/Reporting/`. It registers
+`DashboardDefinition`s and resolves them into typed `DashboardResult`
+trees (count / list / chart / shortcut tiles, plus an `error` case for
+per-widget failure isolation). Counts and lists run through
+`DocumentEngine.list(...)` (with `ListFilter` predicates parsed from
+widget parameters); charts defer to `ReportEngine.execute(...)`.
 
-**What ships today:** `DashboardDefinition` decodes from manifests.
-`HubDashboards.swift` already declares dashboards. No view renders them.
-
-**Suggested fix:** Add `GenericDashboardView` to `MercantisCoreUI`
-backed by `ReportEngine.execute(...)` for the data tiles. Hub’s
-`HubMenuItem.dashboard` case in `Navigation/HubNavigation.swift` then
-routes to it.
+The SwiftUI `GenericDashboardView` that consumes a `DashboardResult` is
+a follow-up in `MercantisCoreUI`. The engine library contract — the
+typed result — is shipped.
 
 ---
 
@@ -205,12 +219,19 @@ routes to it.
 7. ✅ **§3.7 Counter range reservation** (ADR-042). Per-device
    block allocation backed by migration v9's `naming_counter_blocks`.
 
-### Phase C — ERP feature breadth
+### Phase C — ERP feature breadth — ✅ shipped 2026-05-05
 
-8. **Files / Attachments (P3.1).** Required by every ERP DocType with external paperwork.
-9. **Print / PDF (P3.2).** Required before Selling / Buying modules ship to a customer.
-10. **Dashboard rendering (§3.10).** Hub already declares dashboards that have nowhere to render today.
-11. **Import / Export (P3.3).** Required before any real-world deployment.
+8. ✅ **Files / Attachments (P3.1, ADR-043).** `Files/` subsystem
+   with on-disk store, atomic metadata writes, audit-log integration,
+   and `DocumentEngine` cascade-on-delete.
+9. ✅ **Print / PDF (P3.2, ADR-044).** `Printing/` subsystem with
+   declarative formats and plain-text + CoreGraphics PDF renderers.
+10. ✅ **Dashboard runtime (§3.10, ADR-045).** `DashboardEngine`
+    resolves widgets into typed result tiles. `MercantisCoreUI` view
+    is a follow-up.
+11. ✅ **Import / Export (P3.3, ADR-046).** CSV + JSON via
+    `DataExporter` / `DataImporter` routed through
+    `DocumentEngine.save(...)`.
 
 ### Phase D — Production readiness
 

--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -98,6 +98,9 @@ public final class DocumentEngine {
     private let permissionEngine: PermissionEngine
     private let auditLogWriter: AuditLogWriter
     private let workflowHistoryWriter: WorkflowTransitionHistoryWriter
+    /// Optional. When supplied, `delete(...)` cascades and removes every
+    /// attachment row + on-disk file for the deleted document. (Phase C / P3.1)
+    private let attachmentManager: AttachmentManager?
     private let deviceId: String
     private let userId: String
 
@@ -109,7 +112,8 @@ public final class DocumentEngine {
         eventEmitter: EventEmitter = EventEmitter(),
         validationPipeline: ValidationPipeline = ValidationPipeline(),
         namingService: NamingService = NamingService(),
-        permissionEngine: PermissionEngine = PermissionEngine()
+        permissionEngine: PermissionEngine = PermissionEngine(),
+        attachmentManager: AttachmentManager? = nil
     ) {
         self.database = database
         self.registry = registry
@@ -120,6 +124,7 @@ public final class DocumentEngine {
         self.permissionEngine = permissionEngine
         self.auditLogWriter = AuditLogWriter(database: database)
         self.workflowHistoryWriter = WorkflowTransitionHistoryWriter(database: database)
+        self.attachmentManager = attachmentManager
         self.deviceId = deviceId
         self.userId = userId
     }
@@ -395,6 +400,13 @@ public final class DocumentEngine {
                 after: nil,
                 in: db
             )
+        }
+
+        // Cascade attachments (Phase C / P3.1). Done outside the document-row
+        // transaction because attachment metadata + bytes have their own
+        // atomic boundary inside `AttachmentManager.deleteAll(...)`.
+        if let attachmentManager {
+            try? attachmentManager.deleteAll(forDocumentId: id, userId: userId)
         }
 
         eventEmitter.publish(DocumentDeletedEvent(

--- a/mercantis core/Files/Attachment.swift
+++ b/mercantis core/Files/Attachment.swift
@@ -1,0 +1,66 @@
+//
+//  Attachment.swift
+//  mercantis core
+//
+//  Phase C / P3.1 (ADR-043) — File attachments. Metadata for one row in
+//  the `attachments` table.
+//
+
+import Foundation
+
+/// A file attachment bound to a document (and optionally a specific field).
+///
+/// Bytes live on disk under the `AttachmentStore` root; this struct carries
+/// the metadata persisted in the `attachments` table. Use
+/// `AttachmentManager.read(_:)` to materialise the bytes.
+public struct Attachment: Identifiable, Codable, Sendable, Equatable {
+    public let id: String
+    public let documentId: String
+    public let docType: String
+    /// Bound field key. `nil` for general document attachments not tied to
+    /// a specific `FieldType.attachment` field.
+    public let fieldKey: String?
+    public let fileName: String
+    public let mimeType: String
+    public let byteSize: Int
+    /// Path under the attachment store root. Stable across moves of the
+    /// store directory as long as the store is given the new root.
+    public let storagePath: String
+    public let uploadedAt: Date
+    public let uploadedBy: String
+    /// Lower-case hex SHA-256 of the file bytes. Used for integrity
+    /// verification and (future) content-addressable dedup.
+    public let sha256: String
+
+    public init(
+        id: String,
+        documentId: String,
+        docType: String,
+        fieldKey: String?,
+        fileName: String,
+        mimeType: String,
+        byteSize: Int,
+        storagePath: String,
+        uploadedAt: Date,
+        uploadedBy: String,
+        sha256: String
+    ) {
+        self.id = id
+        self.documentId = documentId
+        self.docType = docType
+        self.fieldKey = fieldKey
+        self.fileName = fileName
+        self.mimeType = mimeType
+        self.byteSize = byteSize
+        self.storagePath = storagePath
+        self.uploadedAt = uploadedAt
+        self.uploadedBy = uploadedBy
+        self.sha256 = sha256
+    }
+}
+
+public enum AttachmentError: Error, Sendable, Equatable {
+    case notFound(id: String)
+    case integrityFailure(id: String)
+    case ioFailure(reason: String)
+}

--- a/mercantis core/Files/AttachmentManager.swift
+++ b/mercantis core/Files/AttachmentManager.swift
@@ -1,0 +1,277 @@
+//
+//  AttachmentManager.swift
+//  mercantis core
+//
+//  Phase C / P3.1 (ADR-043) — Public attachment API. Wraps the on-disk
+//  byte store with the metadata table, integrity checks, and audit-log
+//  rows.
+//
+
+import Foundation
+import GRDB
+
+/// High-level attachment API for Hub and other host apps.
+///
+/// One `AttachmentManager` owns a `MercantisDatabase` (for metadata) and
+/// an `AttachmentStore` (for bytes). `DocumentEngine` optionally holds a
+/// reference for cascade-on-delete; standalone callers can construct one
+/// directly when they need to attach / read files.
+public final class AttachmentManager: @unchecked Sendable {
+
+    private let database: MercantisDatabase
+    private let store: AttachmentStore
+    private let auditWriter: AuditLogWriter?
+
+    public init(
+        database: MercantisDatabase,
+        store: AttachmentStore,
+        auditWriter: AuditLogWriter? = nil
+    ) {
+        self.database = database
+        self.store = store
+        self.auditWriter = auditWriter
+    }
+
+    // MARK: - Attach
+
+    /// Persist `data` as an attachment on `(documentId, docType)`,
+    /// optionally bound to a `fieldKey`. Writes the bytes, the metadata
+    /// row, and an audit-log entry in one atomic write transaction.
+    @discardableResult
+    public func attach(
+        documentId: String,
+        docType: String,
+        fieldKey: String? = nil,
+        fileName: String,
+        mimeType: String = "application/octet-stream",
+        data: Data,
+        userId: String
+    ) throws -> Attachment {
+        let attachmentId = UUID().uuidString
+        let storagePath = try store.write(
+            documentId: documentId,
+            attachmentId: attachmentId,
+            data: data
+        )
+        let now = Date()
+        let attachment = Attachment(
+            id: attachmentId,
+            documentId: documentId,
+            docType: docType,
+            fieldKey: fieldKey,
+            fileName: fileName,
+            mimeType: mimeType,
+            byteSize: data.count,
+            storagePath: storagePath,
+            uploadedAt: now,
+            uploadedBy: userId,
+            sha256: AttachmentStore.sha256(data)
+        )
+        do {
+            try database.write { db in
+                try Self.insert(attachment, in: db)
+                if let auditWriter {
+                    try auditWriter.append(
+                        AuditLogEntry(
+                            documentId: documentId,
+                            docType: docType,
+                            userId: userId,
+                            action: "attach",
+                            payloadJSON: Self.attachmentSummary(attachment)
+                        ),
+                        in: db
+                    )
+                }
+            }
+        } catch {
+            // Roll back the on-disk write if metadata persistence fails.
+            try? store.delete(storagePath: storagePath)
+            throw error
+        }
+        return attachment
+    }
+
+    // MARK: - Read
+
+    public func read(_ attachment: Attachment) throws -> Data {
+        let data = try store.read(storagePath: attachment.storagePath)
+        if AttachmentStore.sha256(data) != attachment.sha256 {
+            throw AttachmentError.integrityFailure(id: attachment.id)
+        }
+        return data
+    }
+
+    public func read(id: String) throws -> Data {
+        guard let attachment = try metadata(id: id) else {
+            throw AttachmentError.notFound(id: id)
+        }
+        return try read(attachment)
+    }
+
+    // MARK: - Listing
+
+    public func attachments(forDocumentId documentId: String) throws -> [Attachment] {
+        try database.read { db in
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT id, documentId, docType, fieldKey, fileName, mimeType,
+                           byteSize, storagePath, uploadedAt, uploadedBy, sha256
+                    FROM attachments
+                    WHERE documentId = ?
+                    ORDER BY uploadedAt ASC, id ASC
+                    """,
+                arguments: [documentId]
+            )
+            return try rows.map { try Self.attachmentFromRow($0) }
+        }
+    }
+
+    public func attachments(forField fieldKey: String, on documentId: String) throws -> [Attachment] {
+        try database.read { db in
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT id, documentId, docType, fieldKey, fileName, mimeType,
+                           byteSize, storagePath, uploadedAt, uploadedBy, sha256
+                    FROM attachments
+                    WHERE documentId = ? AND fieldKey = ?
+                    ORDER BY uploadedAt ASC, id ASC
+                    """,
+                arguments: [documentId, fieldKey]
+            )
+            return try rows.map { try Self.attachmentFromRow($0) }
+        }
+    }
+
+    public func metadata(id: String) throws -> Attachment? {
+        try database.read { db in
+            guard let row = try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT id, documentId, docType, fieldKey, fileName, mimeType,
+                           byteSize, storagePath, uploadedAt, uploadedBy, sha256
+                    FROM attachments
+                    WHERE id = ?
+                    """,
+                arguments: [id]
+            ) else { return nil }
+            return try Self.attachmentFromRow(row)
+        }
+    }
+
+    // MARK: - Delete
+
+    /// Remove a single attachment by id. Best-effort: tolerates a missing
+    /// on-disk file (the metadata row is the source of truth).
+    public func delete(id: String, userId: String) throws {
+        guard let existing = try metadata(id: id) else {
+            throw AttachmentError.notFound(id: id)
+        }
+        try database.write { db in
+            try db.execute(sql: "DELETE FROM attachments WHERE id = ?", arguments: [id])
+            if let auditWriter {
+                try auditWriter.append(
+                    AuditLogEntry(
+                        documentId: existing.documentId,
+                        docType: existing.docType,
+                        userId: userId,
+                        action: "detach",
+                        payloadJSON: Self.attachmentSummary(existing)
+                    ),
+                    in: db
+                )
+            }
+        }
+        try? store.delete(storagePath: existing.storagePath)
+    }
+
+    /// Cascade: remove every attachment for `documentId`. Called by
+    /// `DocumentEngine.delete(...)` when an `AttachmentManager` is wired
+    /// into the engine.
+    public func deleteAll(forDocumentId documentId: String, userId: String) throws {
+        let existing = try attachments(forDocumentId: documentId)
+        guard !existing.isEmpty else { return }
+
+        try database.write { db in
+            try db.execute(
+                sql: "DELETE FROM attachments WHERE documentId = ?",
+                arguments: [documentId]
+            )
+            if let auditWriter {
+                try auditWriter.append(
+                    AuditLogEntry(
+                        documentId: documentId,
+                        docType: existing.first?.docType ?? "",
+                        userId: userId,
+                        action: "detachAll",
+                        payloadJSON: "{\"count\":\(existing.count)}"
+                    ),
+                    in: db
+                )
+            }
+        }
+        try? store.deleteAll(documentId: documentId)
+    }
+
+    // MARK: - Internals
+
+    private static func insert(_ attachment: Attachment, in db: Database) throws {
+        try db.execute(
+            sql: """
+                INSERT INTO attachments
+                    (id, documentId, docType, fieldKey, fileName, mimeType,
+                     byteSize, storagePath, uploadedAt, uploadedBy, sha256)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+            arguments: [
+                attachment.id,
+                attachment.documentId,
+                attachment.docType,
+                attachment.fieldKey,
+                attachment.fileName,
+                attachment.mimeType,
+                attachment.byteSize,
+                attachment.storagePath,
+                ISO8601DateFormatter().string(from: attachment.uploadedAt),
+                attachment.uploadedBy,
+                attachment.sha256,
+            ]
+        )
+    }
+
+    private static func attachmentFromRow(_ row: Row) throws -> Attachment {
+        let id: String = row["id"] ?? ""
+        let documentId: String = row["documentId"] ?? ""
+        let docType: String = row["docType"] ?? ""
+        let fieldKey: String? = row["fieldKey"]
+        let fileName: String = row["fileName"] ?? ""
+        let mimeType: String = row["mimeType"] ?? "application/octet-stream"
+        let byteSize: Int = row["byteSize"] ?? 0
+        let storagePath: String = row["storagePath"] ?? ""
+        let uploadedAtStr: String = row["uploadedAt"] ?? ""
+        let uploadedBy: String = row["uploadedBy"] ?? ""
+        let sha256: String = row["sha256"] ?? ""
+        let uploadedAt = ISO8601DateFormatter().date(from: uploadedAtStr) ?? Date(timeIntervalSince1970: 0)
+        return Attachment(
+            id: id,
+            documentId: documentId,
+            docType: docType,
+            fieldKey: fieldKey,
+            fileName: fileName,
+            mimeType: mimeType,
+            byteSize: byteSize,
+            storagePath: storagePath,
+            uploadedAt: uploadedAt,
+            uploadedBy: uploadedBy,
+            sha256: sha256
+        )
+    }
+
+    private static func attachmentSummary(_ a: Attachment) -> String {
+        // Shortened JSON suitable for an audit_log payload — full row is
+        // already in `attachments`, so we just record the identifying bits.
+        let escapedName = a.fileName.replacingOccurrences(of: "\"", with: "\\\"")
+        return "{\"attachmentId\":\"\(a.id)\",\"fileName\":\"\(escapedName)\",\"byteSize\":\(a.byteSize),\"sha256\":\"\(a.sha256)\"}"
+    }
+}

--- a/mercantis core/Files/AttachmentStore.swift
+++ b/mercantis core/Files/AttachmentStore.swift
@@ -1,0 +1,100 @@
+//
+//  AttachmentStore.swift
+//  mercantis core
+//
+//  Phase C / P3.1 (ADR-043) — Filesystem backend for attachment bytes.
+//
+
+import Foundation
+import CryptoKit
+
+/// Filesystem-backed byte store for attachments. Files are written under
+/// `<rootURL>/<documentId>/<attachmentId>` so a per-document `deleteAll`
+/// is one directory tree removal.
+///
+/// The store is intentionally dumb: it knows nothing about DocTypes,
+/// permissions, or audit. Those concerns live one layer up in
+/// `AttachmentManager`.
+public final class AttachmentStore: @unchecked Sendable {
+
+    public let rootURL: URL
+    private let fileManager: FileManager
+
+    public init(rootURL: URL, fileManager: FileManager = .default) throws {
+        self.rootURL = rootURL
+        self.fileManager = fileManager
+        try Self.ensureDirectory(rootURL, fileManager: fileManager)
+    }
+
+    /// Convenience: derive an attachment root next to a `MercantisDatabase`
+    /// file. Result: `<dbDir>/attachments/`.
+    public convenience init(beside database: MercantisDatabase) throws {
+        let dbDir = database.databaseURL.deletingLastPathComponent()
+        try self.init(rootURL: dbDir.appendingPathComponent("attachments", isDirectory: true))
+    }
+
+    // MARK: - Write
+
+    /// Write `data` for `attachmentId` under `documentId`. Returns the
+    /// relative storage path (always `"<documentId>/<attachmentId>"`),
+    /// which is what `AttachmentManager` records in the metadata row.
+    @discardableResult
+    public func write(documentId: String, attachmentId: String, data: Data) throws -> String {
+        let dir = rootURL.appendingPathComponent(documentId, isDirectory: true)
+        try Self.ensureDirectory(dir, fileManager: fileManager)
+        let target = dir.appendingPathComponent(attachmentId)
+        try data.write(to: target, options: .atomic)
+        return "\(documentId)/\(attachmentId)"
+    }
+
+    // MARK: - Read
+
+    public func read(storagePath: String) throws -> Data {
+        let url = rootURL.appendingPathComponent(storagePath)
+        guard fileManager.fileExists(atPath: url.path) else {
+            throw AttachmentError.notFound(id: storagePath)
+        }
+        return try Data(contentsOf: url)
+    }
+
+    public func exists(storagePath: String) -> Bool {
+        let url = rootURL.appendingPathComponent(storagePath)
+        return fileManager.fileExists(atPath: url.path)
+    }
+
+    // MARK: - Delete
+
+    /// Delete a single attachment file. Missing files are tolerated —
+    /// the metadata row may already have been removed independently.
+    public func delete(storagePath: String) throws {
+        let url = rootURL.appendingPathComponent(storagePath)
+        if fileManager.fileExists(atPath: url.path) {
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    /// Recursively delete every file under `<rootURL>/<documentId>/`.
+    /// Used when a document is deleted (`AttachmentManager.deleteAll(for:)`).
+    public func deleteAll(documentId: String) throws {
+        let dir = rootURL.appendingPathComponent(documentId, isDirectory: true)
+        if fileManager.fileExists(atPath: dir.path) {
+            try fileManager.removeItem(at: dir)
+        }
+    }
+
+    // MARK: - Hashing
+
+    /// Lower-case hex SHA-256 of `data`.
+    public static func sha256(_ data: Data) -> String {
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Internals
+
+    private static func ensureDirectory(_ url: URL, fileManager: FileManager) throws {
+        if !fileManager.fileExists(atPath: url.path) {
+            try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+    }
+}

--- a/mercantis core/ImportExport/CSVCodec.swift
+++ b/mercantis core/ImportExport/CSVCodec.swift
@@ -1,0 +1,138 @@
+//
+//  CSVCodec.swift
+//  mercantis core
+//
+//  Phase C / P3.3 (ADR-046) — Minimal CSV reader / writer. RFC-4180-ish:
+//  `,` separator, `"` quoting, `""` for embedded quotes, CRLF or LF line
+//  endings on read, LF on write.
+//
+//  We deliberately avoid pulling in a third-party CSV library — the
+//  surface we need (encode/decode `[String: String]` rows) is small
+//  enough that a few hundred lines of focused parsing keep our
+//  dependency graph clean.
+//
+
+import Foundation
+
+public enum CSVCodec {
+
+    // MARK: - Encode
+
+    /// Render a header + rows array as RFC-4180 CSV bytes (LF line endings).
+    /// `headers` defines column order; missing cells render empty.
+    public static func encode(headers: [String], rows: [[String: String]]) -> Data {
+        var out = ""
+        out += headers.map(escape).joined(separator: ",")
+        out += "\n"
+        for row in rows {
+            out += headers.map { escape(row[$0] ?? "") }.joined(separator: ",")
+            out += "\n"
+        }
+        return Data(out.utf8)
+    }
+
+    /// Escape one CSV cell. Quotes the value when it contains a separator,
+    /// quote, CR, or LF.
+    public static func escape(_ raw: String) -> String {
+        if raw.isEmpty { return "" }
+        let needsQuote = raw.contains(",") || raw.contains("\"") || raw.contains("\n") || raw.contains("\r")
+        if !needsQuote { return raw }
+        let inner = raw.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(inner)\""
+    }
+
+    // MARK: - Decode
+
+    public struct DecodedTable: Sendable {
+        public let headers: [String]
+        public let rows: [[String: String]]
+    }
+
+    /// Parse `bytes` as RFC-4180 CSV. Throws `ImportExportError.malformedCSV`
+    /// on quote / row mismatches (e.g. unterminated quoted cells).
+    public static func decode(_ bytes: Data) throws -> DecodedTable {
+        guard let text = String(data: bytes, encoding: .utf8) else {
+            throw ImportExportError.malformedCSV(line: 0, reason: "input is not valid UTF-8")
+        }
+        let rawRows = try parseRows(text)
+        guard let header = rawRows.first else {
+            return DecodedTable(headers: [], rows: [])
+        }
+        let dataRows = rawRows.dropFirst().map { cells -> [String: String] in
+            var row: [String: String] = [:]
+            for (i, key) in header.enumerated() where i < cells.count {
+                row[key] = cells[i]
+            }
+            return row
+        }
+        return DecodedTable(headers: header, rows: Array(dataRows))
+    }
+
+    private static func parseRows(_ text: String) throws -> [[String]] {
+        var rows: [[String]] = []
+        var currentRow: [String] = []
+        var currentCell = ""
+        var inQuotes = false
+        var line = 1
+        var iter = text.makeIterator()
+        var pending: Character? = nil
+
+        func nextChar() -> Character? {
+            if let p = pending {
+                pending = nil
+                return p
+            }
+            return iter.next()
+        }
+
+        while let ch = nextChar() {
+            if inQuotes {
+                if ch == "\"" {
+                    if let peek = iter.next() {
+                        if peek == "\"" {
+                            currentCell.append("\"")
+                        } else {
+                            inQuotes = false
+                            pending = peek
+                        }
+                    } else {
+                        inQuotes = false
+                    }
+                } else {
+                    if ch == "\n" { line += 1 }
+                    currentCell.append(ch)
+                }
+            } else {
+                switch ch {
+                case "\"":
+                    if !currentCell.isEmpty {
+                        throw ImportExportError.malformedCSV(line: line, reason: "quote inside unquoted cell")
+                    }
+                    inQuotes = true
+                case ",":
+                    currentRow.append(currentCell)
+                    currentCell = ""
+                case "\r":
+                    // Swallow; the LF will close the row.
+                    continue
+                case "\n":
+                    currentRow.append(currentCell)
+                    rows.append(currentRow)
+                    currentRow = []
+                    currentCell = ""
+                    line += 1
+                default:
+                    currentCell.append(ch)
+                }
+            }
+        }
+        if inQuotes {
+            throw ImportExportError.malformedCSV(line: line, reason: "unterminated quoted cell")
+        }
+        if !currentCell.isEmpty || !currentRow.isEmpty {
+            currentRow.append(currentCell)
+            rows.append(currentRow)
+        }
+        return rows
+    }
+}

--- a/mercantis core/ImportExport/DataExporter.swift
+++ b/mercantis core/ImportExport/DataExporter.swift
@@ -1,0 +1,110 @@
+//
+//  DataExporter.swift
+//  mercantis core
+//
+//  Phase C / P3.3 (ADR-046) — Bulk export. Walks every document of a
+//  DocType (or a caller-supplied set), serialises to CSV or JSON.
+//
+
+import Foundation
+
+public final class DataExporter: @unchecked Sendable {
+
+    private let documentEngine: DocumentEngine
+    private let registry: MetadataRegistry
+
+    public init(documentEngine: DocumentEngine, registry: MetadataRegistry) {
+        self.documentEngine = documentEngine
+        self.registry = registry
+    }
+
+    // MARK: - Public API
+
+    /// Export every document of `docType` in the requested format. Optional
+    /// `predicates` narrow the export to a subset; when nil, every document
+    /// of that DocType is included.
+    public func export(
+        docType: String,
+        format: ImportExportFormat,
+        predicates: [ListFilter]? = nil
+    ) throws -> Data {
+        guard registry.get(docType) != nil else {
+            throw ImportExportError.docTypeNotRegistered(docType)
+        }
+        let documents = try documentEngine.list(
+            docType: docType,
+            predicates: predicates,
+            sortBy: [ListSort(fieldKey: "id", direction: .ascending)],
+            applyRowAccess: false
+        )
+        switch format {
+        case .csv:  return try exportCSV(documents: documents, docType: docType)
+        case .json: return try exportJSON(documents: documents)
+        }
+    }
+
+    // MARK: - CSV
+
+    private func exportCSV(documents: [Document], docType: String) throws -> Data {
+        // Header order: id, status, docStatus, then each declared field key
+        // (in DocType declaration order). Children are not exported in CSV
+        // because they don't fit the flat-row format; callers needing those
+        // should use JSON.
+        let docTypeMeta = registry.get(docType)
+        let fieldKeys = docTypeMeta?.fields.map(\.key) ?? []
+        let headers = ["id", "status", "docStatus"] + fieldKeys
+
+        let rows: [[String: String]] = documents.map { doc in
+            var row: [String: String] = [
+                "id": doc.id,
+                "status": doc.status,
+                "docStatus": String(doc.docStatus),
+            ]
+            for key in fieldKeys {
+                if let value = doc.fields[key] {
+                    row[key] = stringify(value)
+                } else {
+                    row[key] = ""
+                }
+            }
+            return row
+        }
+        return CSVCodec.encode(headers: headers, rows: rows)
+    }
+
+    private func stringify(_ value: FieldValue) -> String {
+        switch value {
+        case .string(let s): return s
+        case .int(let i):    return String(i)
+        case .double(let d): return String(d)
+        case .bool(let b):   return b ? "true" : "false"
+        case .null:          return ""
+        case .date(let d), .dateTime(let d):
+            return ISO8601DateFormatter().string(from: d)
+        case .data(let d):   return d.base64EncodedString()
+        case .array(let xs):
+            // Best-effort flatten for CSV; JSON path keeps full structure.
+            return xs.map { stringify($0) }.joined(separator: ";")
+        }
+    }
+
+    // MARK: - JSON
+
+    /// JSON envelope: `{ "docType": "...", "documents": [Document...] }`.
+    /// `Document` already encodes via `Codable` with the typed-envelope
+    /// `FieldValue` form (ADR-032), so children round-trip correctly.
+    private func exportJSON(documents: [Document]) throws -> Data {
+        struct Envelope: Codable {
+            let docType: String?
+            let documents: [Document]
+        }
+        let envelope = Envelope(
+            docType: documents.first?.docType,
+            documents: documents
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(envelope)
+    }
+}

--- a/mercantis core/ImportExport/DataImporter.swift
+++ b/mercantis core/ImportExport/DataImporter.swift
@@ -1,0 +1,242 @@
+//
+//  DataImporter.swift
+//  mercantis core
+//
+//  Phase C / P3.3 (ADR-046) — Bulk import. Reads CSV / JSON and routes
+//  every row through `DocumentEngine.save(...)` so the validation
+//  pipeline, naming, and audit log all run identically to interactive
+//  saves.
+//
+
+import Foundation
+
+public final class DataImporter: @unchecked Sendable {
+
+    private let documentEngine: DocumentEngine
+    private let registry: MetadataRegistry
+
+    public init(documentEngine: DocumentEngine, registry: MetadataRegistry) {
+        self.documentEngine = documentEngine
+        self.registry = registry
+    }
+
+    // MARK: - Public API
+
+    /// Import bytes into `docType`. Per-row failures are recorded in the
+    /// returned `ImportReport` rather than aborting the whole batch.
+    @discardableResult
+    public func `import`(
+        docType: String,
+        data: Data,
+        format: ImportExportFormat,
+        conflictPolicy: ImportConflictPolicy = .overwrite
+    ) throws -> ImportReport {
+        guard registry.get(docType) != nil else {
+            throw ImportExportError.docTypeNotRegistered(docType)
+        }
+        switch format {
+        case .csv:  return try importCSV(docType: docType, data: data, conflictPolicy: conflictPolicy)
+        case .json: return try importJSON(docType: docType, data: data, conflictPolicy: conflictPolicy)
+        }
+    }
+
+    // MARK: - CSV path
+
+    private func importCSV(
+        docType: String,
+        data: Data,
+        conflictPolicy: ImportConflictPolicy
+    ) throws -> ImportReport {
+        let table = try CSVCodec.decode(data)
+        let docTypeMeta = registry.get(docType)
+        let fieldByKey: [String: FieldDefinition] = Dictionary(
+            uniqueKeysWithValues: (docTypeMeta?.fields ?? []).map { ($0.key, $0) }
+        )
+
+        var outcomes: [ImportRowOutcome] = []
+        for (index, row) in table.rows.enumerated() {
+            do {
+                let document = try makeDocument(
+                    docType: docType,
+                    row: row,
+                    fieldByKey: fieldByKey
+                )
+                let outcome = try saveOrSkip(document, conflictPolicy: conflictPolicy)
+                outcomes.append(outcome)
+            } catch {
+                outcomes.append(.failed(rowIndex: index, reason: "\(error)"))
+            }
+        }
+        return ImportReport(docType: docType, rowsRead: table.rows.count, outcomes: outcomes)
+    }
+
+    private func makeDocument(
+        docType: String,
+        row: [String: String],
+        fieldByKey: [String: FieldDefinition]
+    ) throws -> Document {
+        var fields: [String: FieldValue] = [:]
+        for (key, raw) in row {
+            if key == "id" || key == "status" || key == "docStatus" { continue }
+            guard let definition = fieldByKey[key] else { continue }
+            fields[key] = try coerce(raw, to: definition.type)
+        }
+
+        let id = row["id"] ?? ""
+        let status = row["status"] ?? ""
+        let docStatus = Int(row["docStatus"] ?? "") ?? 0
+        let now = Date()
+        return Document(
+            id: id,
+            docType: docType,
+            company: "",
+            status: status,
+            createdAt: now,
+            updatedAt: now,
+            syncVersion: 0,
+            syncState: .local,
+            docStatus: docStatus,
+            amendedFrom: nil,
+            fields: fields,
+            children: [:]
+        )
+    }
+
+    private func coerce(_ raw: String, to type: FieldType) throws -> FieldValue {
+        if raw.isEmpty { return .null }
+        switch type {
+        case .text, .longText, .richText, .email, .phone, .select, .multiselect,
+             .link, .status, .barcode, .image, .attachment:
+            return .string(raw)
+        case .number:
+            guard let v = Int(raw) else {
+                throw ImportExportError.malformedCSV(line: 0, reason: "expected integer for \(type.rawValue), got '\(raw)'")
+            }
+            return .int(v)
+        case .decimal, .currency:
+            guard let v = Double(raw) else {
+                throw ImportExportError.malformedCSV(line: 0, reason: "expected number for \(type.rawValue), got '\(raw)'")
+            }
+            return .double(v)
+        case .boolean:
+            switch raw.lowercased() {
+            case "true", "yes", "1":  return .bool(true)
+            case "false", "no", "0":  return .bool(false)
+            default:
+                throw ImportExportError.malformedCSV(line: 0, reason: "expected boolean, got '\(raw)'")
+            }
+        case .date:
+            guard let d = ISO8601DateFormatter().date(from: raw) else {
+                throw ImportExportError.malformedCSV(line: 0, reason: "expected ISO 8601 date, got '\(raw)'")
+            }
+            return .date(d)
+        case .datetime:
+            guard let d = ISO8601DateFormatter().date(from: raw) else {
+                throw ImportExportError.malformedCSV(line: 0, reason: "expected ISO 8601 dateTime, got '\(raw)'")
+            }
+            return .dateTime(d)
+        case .table, .formula:
+            // CSV cannot losslessly carry child tables / formula results.
+            // Skip the cell so the rest of the row still imports.
+            return .null
+        }
+    }
+
+    // MARK: - JSON path
+
+    private func importJSON(
+        docType: String,
+        data: Data,
+        conflictPolicy: ImportConflictPolicy
+    ) throws -> ImportReport {
+        struct Envelope: Codable {
+            let docType: String?
+            let documents: [Document]
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope: Envelope
+        do {
+            envelope = try decoder.decode(Envelope.self, from: data)
+        } catch {
+            throw ImportExportError.malformedJSON(reason: "\(error)")
+        }
+        var outcomes: [ImportRowOutcome] = []
+        for (index, doc) in envelope.documents.enumerated() {
+            do {
+                // Coerce docType so callers can re-target an export.
+                let retargeted = withDocType(doc, docType: docType)
+                let outcome = try saveOrSkip(retargeted, conflictPolicy: conflictPolicy)
+                outcomes.append(outcome)
+            } catch {
+                outcomes.append(.failed(rowIndex: index, reason: "\(error)"))
+            }
+        }
+        return ImportReport(
+            docType: docType,
+            rowsRead: envelope.documents.count,
+            outcomes: outcomes
+        )
+    }
+
+    private func withDocType(_ doc: Document, docType: String) -> Document {
+        Document(
+            id: doc.id,
+            docType: docType,
+            company: doc.company,
+            status: doc.status,
+            createdAt: doc.createdAt,
+            updatedAt: doc.updatedAt,
+            syncVersion: doc.syncVersion,
+            syncState: doc.syncState,
+            docStatus: doc.docStatus,
+            amendedFrom: doc.amendedFrom,
+            parentID: doc.parentID,
+            fields: doc.fields,
+            children: doc.children
+        )
+    }
+
+    // MARK: - Save dispatch
+
+    private func saveOrSkip(
+        _ document: Document,
+        conflictPolicy: ImportConflictPolicy
+    ) throws -> ImportRowOutcome {
+        let existing: Document? = (!document.id.isEmpty)
+            ? try documentEngine.fetch(docType: document.docType, id: document.id)
+            : nil
+
+        if let existing {
+            switch conflictPolicy {
+            case .skipExisting:
+                return .skipped(documentId: existing.id, reason: "id already exists")
+            case .fail:
+                return .failed(rowIndex: -1, reason: "id '\(existing.id)' already exists")
+            case .overwrite:
+                // Carry the existing updatedAt forward so the optimistic-
+                // concurrency check passes on save.
+                let merged = Document(
+                    id: existing.id,
+                    docType: existing.docType,
+                    company: document.company,
+                    status: document.status.isEmpty ? existing.status : document.status,
+                    createdAt: existing.createdAt,
+                    updatedAt: existing.updatedAt,
+                    syncVersion: existing.syncVersion,
+                    syncState: existing.syncState,
+                    docStatus: document.docStatus,
+                    amendedFrom: existing.amendedFrom,
+                    parentID: existing.parentID,
+                    fields: document.fields,
+                    children: document.children.isEmpty ? existing.children : document.children
+                )
+                let saved = try documentEngine.save(merged)
+                return .updated(documentId: saved.id)
+            }
+        } else {
+            let saved = try documentEngine.save(document)
+            return .inserted(documentId: saved.id)
+        }
+    }
+}

--- a/mercantis core/ImportExport/ImportExportFormat.swift
+++ b/mercantis core/ImportExport/ImportExportFormat.swift
@@ -1,0 +1,64 @@
+//
+//  ImportExportFormat.swift
+//  mercantis core
+//
+//  Phase C / P3.3 (ADR-046) — Common shapes for the bulk import / export
+//  subsystem.
+//
+
+import Foundation
+
+/// Wire format for bulk transfer.
+public enum ImportExportFormat: String, Sendable, Codable {
+    case csv
+    case json
+}
+
+/// Per-row outcome from an import run. Aggregated into `ImportReport`.
+public enum ImportRowOutcome: Sendable, Equatable {
+    case inserted(documentId: String)
+    case updated(documentId: String)
+    case skipped(documentId: String, reason: String)
+    case failed(rowIndex: Int, reason: String)
+}
+
+/// Aggregated outcome of an `import(...)` call. Imports never partially
+/// abort: every row is attempted, and per-row failures are recorded
+/// without rolling back successful rows.
+public struct ImportReport: Sendable, Equatable {
+    public let docType: String
+    public let rowsRead: Int
+    public let outcomes: [ImportRowOutcome]
+
+    public init(docType: String, rowsRead: Int, outcomes: [ImportRowOutcome]) {
+        self.docType = docType
+        self.rowsRead = rowsRead
+        self.outcomes = outcomes
+    }
+
+    public var insertedCount: Int { outcomes.reduce(0) { $0 + (isInserted($1) ? 1 : 0) } }
+    public var updatedCount: Int  { outcomes.reduce(0) { $0 + (isUpdated($1)  ? 1 : 0) } }
+    public var skippedCount: Int  { outcomes.reduce(0) { $0 + (isSkipped($1)  ? 1 : 0) } }
+    public var failedCount: Int   { outcomes.reduce(0) { $0 + (isFailed($1)   ? 1 : 0) } }
+
+    private func isInserted(_ o: ImportRowOutcome) -> Bool { if case .inserted = o { return true }; return false }
+    private func isUpdated(_ o: ImportRowOutcome) -> Bool { if case .updated = o { return true }; return false }
+    private func isSkipped(_ o: ImportRowOutcome) -> Bool { if case .skipped = o { return true }; return false }
+    private func isFailed(_ o: ImportRowOutcome) -> Bool { if case .failed = o { return true }; return false }
+}
+
+/// What to do when an imported row's `id` matches an existing document.
+public enum ImportConflictPolicy: String, Sendable, Codable {
+    /// Default — overwrite the existing document with the imported fields.
+    case overwrite
+    /// Keep the existing document; record the row as `skipped`.
+    case skipExisting
+    /// Treat the conflict as a per-row failure.
+    case fail
+}
+
+public enum ImportExportError: Error, Sendable, Equatable {
+    case malformedCSV(line: Int, reason: String)
+    case malformedJSON(reason: String)
+    case docTypeNotRegistered(String)
+}

--- a/mercantis core/Printing/PDFPrintRenderer.swift
+++ b/mercantis core/Printing/PDFPrintRenderer.swift
@@ -1,0 +1,172 @@
+//
+//  PDFPrintRenderer.swift
+//  mercantis core
+//
+//  Phase C / P3.2 (ADR-044) — PDF renderer backed by Core Graphics.
+//  CoreGraphics is available on iOS, macOS, tvOS, and visionOS, so this
+//  renderer ships in `MercantisCore` without a UIKit / AppKit dependency.
+//  Linux builds compile a stub that throws `backendUnavailable`.
+//
+
+import Foundation
+#if canImport(CoreGraphics)
+import CoreGraphics
+import CoreText
+#endif
+
+public struct PDFPrintRenderer: PrintRenderer {
+
+    public var outputKind: PrintOutputKind { .pdf }
+
+    /// US Letter at 72 dpi. Adjustable per call by constructing a renderer
+    /// with a different page rect.
+    public let pageRect: CGRect
+    public let margin: CGFloat
+
+    public init(
+        pageRect: CGRect = CGRect(x: 0, y: 0, width: 612, height: 792),
+        margin: CGFloat = 36
+    ) {
+        self.pageRect = pageRect
+        self.margin = margin
+    }
+
+    public func render(_ context: PrintRenderContext) throws -> PrintRenderResult {
+        #if canImport(CoreGraphics)
+        return try renderWithCoreGraphics(context)
+        #else
+        throw PrintRenderError.backendUnavailable(
+            reason: "PDFPrintRenderer requires CoreGraphics, which is not available on this platform."
+        )
+        #endif
+    }
+
+    #if canImport(CoreGraphics)
+    private func renderWithCoreGraphics(_ context: PrintRenderContext) throws -> PrintRenderResult {
+        let document = context.document
+        let lines = textLines(for: context)
+
+        let cfData = CFDataCreateMutable(nil, 0)!
+        let consumer = CGDataConsumer(data: cfData)!
+        var mediaBox = pageRect
+        guard let pdfContext = CGContext(consumer: consumer, mediaBox: &mediaBox, nil) else {
+            throw PrintRenderError.backendUnavailable(reason: "CGPDFContext creation failed")
+        }
+
+        let lineHeight: CGFloat = 14
+        let usableTop = pageRect.height - margin
+        let usableBottom = margin
+        var cursorY = usableTop
+
+        pdfContext.beginPDFPage(nil)
+
+        for line in lines {
+            if cursorY - lineHeight < usableBottom {
+                pdfContext.endPDFPage()
+                pdfContext.beginPDFPage(nil)
+                cursorY = usableTop
+            }
+            drawLine(line.text, atY: cursorY, isBold: line.isBold, in: pdfContext)
+            cursorY -= lineHeight
+        }
+
+        pdfContext.endPDFPage()
+        pdfContext.closePDF()
+
+        let data = Data(referencing: cfData as CFData as NSData)
+        let safeId = document.id.replacingOccurrences(of: "/", with: "-")
+        return PrintRenderResult(
+            data: data,
+            mimeType: "application/pdf",
+            suggestedFileName: "\(context.format.id)-\(safeId).pdf"
+        )
+    }
+
+    /// Convert the `PrintFormat` into a flat list of `(text, bold)` lines.
+    /// We delegate the heavy lifting to `PlainTextPrintRenderer` for body
+    /// generation and overlay bold formatting on heading + table-header
+    /// lines so the PDF output preserves visual hierarchy.
+    private func textLines(for context: PrintRenderContext) -> [(text: String, isBold: Bool)] {
+        var output: [(String, Bool)] = []
+        let document = context.document
+
+        if let letterHead = context.letterHead {
+            output.append((PrintTemplate.substitute(letterHead.header, in: document), true))
+            output.append(("", false))
+        }
+
+        for section in context.format.sections {
+            switch section {
+            case .heading(let text):
+                if !output.isEmpty { output.append(("", false)) }
+                output.append((PrintTemplate.substitute(text, in: document), true))
+
+            case .paragraph(let text):
+                if !output.isEmpty { output.append(("", false)) }
+                output.append((PrintTemplate.substitute(text, in: document), false))
+
+            case .fields(let keys, let labels):
+                if !output.isEmpty { output.append(("", false)) }
+                let labelWidth = keys
+                    .map { (labels[$0] ?? PrintTemplate.defaultLabel(forKey: $0)).count }
+                    .max() ?? 0
+                for key in keys {
+                    let label = labels[key] ?? PrintTemplate.defaultLabel(forKey: key)
+                    let value = PrintTemplate.lookup(key: key, in: document).map(PrintTemplate.format) ?? ""
+                    let padded = label.padding(toLength: labelWidth, withPad: " ", startingAt: 0)
+                    output.append(("\(padded)  \(value)", false))
+                }
+
+            case .table(let tableKey, let columns, let labels):
+                if !output.isEmpty { output.append(("", false)) }
+                let textRenderer = PlainTextPrintRenderer()
+                let block: String = (try? {
+                    let mini = PrintFormat(
+                        id: "_table", name: "_", docType: document.docType,
+                        sections: [.table(tableKey: tableKey, columns: columns, labels: labels)]
+                    )
+                    let result = try textRenderer.render(PrintRenderContext(
+                        format: mini, document: document, letterHead: nil, now: context.now
+                    ))
+                    return String(data: result.data, encoding: .utf8) ?? ""
+                }()) ?? ""
+                let rows = block.split(separator: "\n", omittingEmptySubsequences: false)
+                for (i, line) in rows.enumerated() {
+                    output.append((String(line), i == 0))
+                }
+
+            case .keyValue(let label, let value):
+                if !output.isEmpty { output.append(("", false)) }
+                output.append((
+                    "\(PrintTemplate.substitute(label, in: document)): \(PrintTemplate.substitute(value, in: document))",
+                    false
+                ))
+            }
+        }
+
+        if let footer = context.letterHead?.footer {
+            output.append(("", false))
+            output.append((PrintTemplate.substitute(footer, in: document), false))
+        }
+        return output
+    }
+
+    private func drawLine(
+        _ text: String,
+        atY y: CGFloat,
+        isBold: Bool,
+        in ctx: CGContext
+    ) {
+        let fontName = isBold ? "Helvetica-Bold" : "Helvetica"
+        let font = CTFontCreateWithName(fontName as CFString, 11, nil)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: CGColor(gray: 0, alpha: 1)
+        ]
+        let attributed = NSAttributedString(string: text, attributes: attributes)
+        let line = CTLineCreateWithAttributedString(attributed)
+        ctx.textPosition = CGPoint(x: margin, y: y - 11)
+        CTLineDraw(line, ctx)
+    }
+    #endif
+}

--- a/mercantis core/Printing/PlainTextPrintRenderer.swift
+++ b/mercantis core/Printing/PlainTextPrintRenderer.swift
@@ -1,0 +1,141 @@
+//
+//  PlainTextPrintRenderer.swift
+//  mercantis core
+//
+//  Phase C / P3.2 (ADR-044) — Plain-text renderer. Always available,
+//  cross-platform, deterministic. Useful for scripting, CLI export,
+//  and as the test oracle for higher-fidelity renderers.
+//
+
+import Foundation
+
+public struct PlainTextPrintRenderer: PrintRenderer {
+
+    public var outputKind: PrintOutputKind { .plainText }
+
+    public init() {}
+
+    public func render(_ context: PrintRenderContext) throws -> PrintRenderResult {
+        var lines: [String] = []
+        let document = context.document
+
+        if let letterHead = context.letterHead {
+            lines.append(PrintTemplate.substitute(letterHead.header, in: document))
+            lines.append(String(repeating: "-", count: 60))
+        }
+
+        for section in context.format.sections {
+            let block = try renderSection(section, document: document)
+            if !block.isEmpty {
+                if !lines.isEmpty { lines.append("") }
+                lines.append(block)
+            }
+        }
+
+        if let footer = context.letterHead?.footer {
+            lines.append("")
+            lines.append(String(repeating: "-", count: 60))
+            lines.append(PrintTemplate.substitute(footer, in: document))
+        }
+
+        let body = lines.joined(separator: "\n") + "\n"
+        let data = Data(body.utf8)
+        let safeId = document.id.replacingOccurrences(of: "/", with: "-")
+        return PrintRenderResult(
+            data: data,
+            mimeType: "text/plain; charset=utf-8",
+            suggestedFileName: "\(context.format.id)-\(safeId).txt"
+        )
+    }
+
+    // MARK: - Section dispatch
+
+    private func renderSection(_ section: PrintSection, document: Document) throws -> String {
+        switch section {
+        case .heading(let text):
+            let resolved = PrintTemplate.substitute(text, in: document)
+            return resolved + "\n" + String(repeating: "=", count: max(resolved.count, 4))
+
+        case .paragraph(let text):
+            return PrintTemplate.substitute(text, in: document)
+
+        case .fields(let keys, let labels):
+            let labelWidth = keys
+                .map { (labels[$0] ?? PrintTemplate.defaultLabel(forKey: $0)).count }
+                .max() ?? 0
+            var lines: [String] = []
+            for key in keys {
+                let label = labels[key] ?? PrintTemplate.defaultLabel(forKey: key)
+                let value = PrintTemplate.lookup(key: key, in: document).map(PrintTemplate.format) ?? ""
+                let padded = label.padding(toLength: labelWidth, withPad: " ", startingAt: 0)
+                lines.append("\(padded)  \(value)")
+            }
+            return lines.joined(separator: "\n")
+
+        case .table(let tableKey, let columns, let labels):
+            return renderTable(tableKey: tableKey, columns: columns, labels: labels, document: document)
+
+        case .keyValue(let label, let value):
+            let l = PrintTemplate.substitute(label, in: document)
+            let v = PrintTemplate.substitute(value, in: document)
+            return "\(l): \(v)"
+        }
+    }
+
+    private func renderTable(
+        tableKey: String,
+        columns explicitColumns: [String],
+        labels: [String: String],
+        document: Document
+    ) -> String {
+        let rows = document.children[tableKey] ?? []
+        guard !rows.isEmpty else { return "" }
+
+        // Resolve column list — explicit if given, else union of keys seen.
+        let columns: [String]
+        if !explicitColumns.isEmpty {
+            columns = explicitColumns
+        } else {
+            var seen = Set<String>()
+            var inOrder: [String] = []
+            for row in rows {
+                for k in row.fields.keys where !seen.contains(k) {
+                    seen.insert(k)
+                    inOrder.append(k)
+                }
+            }
+            columns = inOrder
+        }
+
+        // Compute column widths.
+        var widths: [String: Int] = [:]
+        for col in columns {
+            let header = labels[col] ?? PrintTemplate.defaultLabel(forKey: col)
+            widths[col] = header.count
+        }
+        for row in rows {
+            for col in columns {
+                let v = row.fields[col].map(PrintTemplate.format) ?? ""
+                widths[col] = max(widths[col] ?? 0, v.count)
+            }
+        }
+
+        func padded(_ s: String, _ w: Int) -> String {
+            s.padding(toLength: w, withPad: " ", startingAt: 0)
+        }
+
+        let header = columns.map { padded(labels[$0] ?? PrintTemplate.defaultLabel(forKey: $0), widths[$0] ?? 0) }
+            .joined(separator: "  ")
+        let separator = columns.map { String(repeating: "-", count: widths[$0] ?? 0) }
+            .joined(separator: "  ")
+        var body: [String] = [header, separator]
+        for row in rows {
+            let line = columns.map { col in
+                let v = row.fields[col].map(PrintTemplate.format) ?? ""
+                return padded(v, widths[col] ?? 0)
+            }.joined(separator: "  ")
+            body.append(line)
+        }
+        return body.joined(separator: "\n")
+    }
+}

--- a/mercantis core/Printing/PrintFormat.swift
+++ b/mercantis core/Printing/PrintFormat.swift
@@ -1,0 +1,140 @@
+//
+//  PrintFormat.swift
+//  mercantis core
+//
+//  Phase C / P3.2 (ADR-044) — Declarative print formats and letter heads.
+//  Manifests declare a PrintFormat per (DocType, format-id) pair; the
+//  Print subsystem renders one to bytes (plain text or PDF) for any
+//  document of that DocType.
+//
+
+import Foundation
+
+/// Reusable header / footer chrome attached to print formats. Stored
+/// once per app and referenced by `PrintFormat.letterHeadId`.
+public struct LetterHead: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let name: String
+    /// Plain text rendered above the document body. Supports `{field}`
+    /// substitution from `document.fields`.
+    public let header: String
+    /// Optional plain-text footer rendered below the document body.
+    public let footer: String?
+
+    public init(id: String, name: String, header: String, footer: String? = nil) {
+        self.id = id
+        self.name = name
+        self.header = header
+        self.footer = footer
+    }
+}
+
+/// Declarative print format for one DocType.
+///
+/// Sections are rendered in order. Each section is a self-describing
+/// structural unit (heading / paragraph / field grid / child-table grid)
+/// so renderers can lay them out for the chosen output kind without
+/// re-parsing markup.
+public struct PrintFormat: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let name: String
+    public let docType: String
+    public let letterHeadId: String?
+    public let sections: [PrintSection]
+
+    public init(
+        id: String,
+        name: String,
+        docType: String,
+        letterHeadId: String? = nil,
+        sections: [PrintSection]
+    ) {
+        self.id = id
+        self.name = name
+        self.docType = docType
+        self.letterHeadId = letterHeadId
+        self.sections = sections
+    }
+}
+
+/// One renderable unit inside a `PrintFormat`. The kind decides which
+/// associated payload is meaningful — fields documented per-case.
+public enum PrintSection: Codable, Sendable, Equatable {
+    /// Top-level heading. `text` supports `{field}` substitution.
+    case heading(text: String)
+    /// A paragraph of body text. Supports `{field}` substitution.
+    case paragraph(text: String)
+    /// Two-column "label / value" grid over a fixed list of field keys.
+    /// `labels[k]` overrides the default "humanised key" label per key.
+    case fields(keys: [String], labels: [String: String] = [:])
+    /// A grid for one of the document's child tables. `tableKey` is the
+    /// `Document.children` map key (i.e. the parent-side `FieldType.table`
+    /// field key); `columns` are the child row field keys to render in
+    /// order. Empty `columns` falls back to "every key seen in the rows".
+    case table(tableKey: String, columns: [String], labels: [String: String] = [:])
+    /// Free-form key-value pair line, e.g. for totals: "Subtotal: 150.00".
+    /// Both `label` and `value` support `{field}` substitution.
+    case keyValue(label: String, value: String)
+
+    // MARK: - Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, text, keys, labels, tableKey, columns, label, value
+    }
+
+    private enum Kind: String, Codable {
+        case heading, paragraph, fields, table, keyValue
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .heading(let text):
+            try c.encode(Kind.heading, forKey: .kind)
+            try c.encode(text, forKey: .text)
+        case .paragraph(let text):
+            try c.encode(Kind.paragraph, forKey: .kind)
+            try c.encode(text, forKey: .text)
+        case .fields(let keys, let labels):
+            try c.encode(Kind.fields, forKey: .kind)
+            try c.encode(keys, forKey: .keys)
+            try c.encode(labels, forKey: .labels)
+        case .table(let tableKey, let columns, let labels):
+            try c.encode(Kind.table, forKey: .kind)
+            try c.encode(tableKey, forKey: .tableKey)
+            try c.encode(columns, forKey: .columns)
+            try c.encode(labels, forKey: .labels)
+        case .keyValue(let label, let value):
+            try c.encode(Kind.keyValue, forKey: .kind)
+            try c.encode(label, forKey: .label)
+            try c.encode(value, forKey: .value)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try c.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .heading:
+            self = .heading(text: try c.decode(String.self, forKey: .text))
+        case .paragraph:
+            self = .paragraph(text: try c.decode(String.self, forKey: .text))
+        case .fields:
+            self = .fields(
+                keys: try c.decode([String].self, forKey: .keys),
+                labels: try c.decodeIfPresent([String: String].self, forKey: .labels) ?? [:]
+            )
+        case .table:
+            self = .table(
+                tableKey: try c.decode(String.self, forKey: .tableKey),
+                columns: try c.decodeIfPresent([String].self, forKey: .columns) ?? [],
+                labels: try c.decodeIfPresent([String: String].self, forKey: .labels) ?? [:]
+            )
+        case .keyValue:
+            self = .keyValue(
+                label: try c.decode(String.self, forKey: .label),
+                value: try c.decode(String.self, forKey: .value)
+            )
+        }
+    }
+}

--- a/mercantis core/Printing/PrintRenderer.swift
+++ b/mercantis core/Printing/PrintRenderer.swift
@@ -1,0 +1,161 @@
+//
+//  PrintRenderer.swift
+//  mercantis core
+//
+//  Phase C / P3.2 (ADR-044) — Renderer protocol + shared helpers used by
+//  every concrete renderer (plain text, PDF). Renderers are stateless and
+//  Sendable; per-call state arrives via `PrintRenderContext`.
+//
+
+import Foundation
+
+/// Output format requested from `PrintService.render(...)`.
+public enum PrintOutputKind: String, Sendable, Codable {
+    case plainText
+    case pdf
+}
+
+/// Inputs assembled by `PrintService` for one render call.
+public struct PrintRenderContext: Sendable {
+    public let format: PrintFormat
+    public let document: Document
+    public let letterHead: LetterHead?
+    /// MIME type the resulting bytes claim. Set by the renderer.
+    public let now: Date
+
+    public init(
+        format: PrintFormat,
+        document: Document,
+        letterHead: LetterHead?,
+        now: Date = Date()
+    ) {
+        self.format = format
+        self.document = document
+        self.letterHead = letterHead
+        self.now = now
+    }
+}
+
+public struct PrintRenderResult: Sendable {
+    public let data: Data
+    public let mimeType: String
+    public let suggestedFileName: String
+
+    public init(data: Data, mimeType: String, suggestedFileName: String) {
+        self.data = data
+        self.mimeType = mimeType
+        self.suggestedFileName = suggestedFileName
+    }
+}
+
+/// One concrete output backend. Each backend handles one
+/// `PrintOutputKind`. `PrintService` picks the right backend by kind.
+public protocol PrintRenderer: Sendable {
+    var outputKind: PrintOutputKind { get }
+    func render(_ context: PrintRenderContext) throws -> PrintRenderResult
+}
+
+public enum PrintRenderError: Error, Sendable, Equatable {
+    case missingFieldInTemplate(field: String)
+    case unsupportedSection(reason: String)
+    case backendUnavailable(reason: String)
+}
+
+// MARK: - Shared helpers
+
+/// Helpers shared by every renderer: `{field}` substitution and the
+/// default formatting of a `FieldValue` to a printable string.
+public enum PrintTemplate {
+
+    /// Substitute every `{key}` placeholder in `template` with the
+    /// formatted `document.fields[key]`. Unknown keys are left as-is
+    /// (`"{unknown}"` literal in output) so format authors can spot
+    /// typos without the renderer crashing.
+    public static func substitute(_ template: String, in document: Document) -> String {
+        var out = ""
+        var i = template.startIndex
+        while i < template.endIndex {
+            if template[i] == "{",
+               let close = template[i...].firstIndex(of: "}") {
+                let keyStart = template.index(after: i)
+                let key = String(template[keyStart..<close])
+                if !key.isEmpty, !key.contains("{") {
+                    if let value = lookup(key: key, in: document) {
+                        out += format(value)
+                    } else {
+                        out += "{\(key)}"
+                    }
+                    i = template.index(after: close)
+                    continue
+                }
+            }
+            out.append(template[i])
+            i = template.index(after: i)
+        }
+        return out
+    }
+
+    /// Lookup `key` against the document's fields plus a few system-column
+    /// conveniences (`id`, `status`, `docStatus`, `createdAt`, `updatedAt`,
+    /// `company`).
+    public static func lookup(key: String, in document: Document) -> FieldValue? {
+        if let field = document.fields[key] { return field }
+        switch key {
+        case "id":          return .string(document.id)
+        case "company":     return .string(document.company)
+        case "status":      return .string(document.status)
+        case "docStatus":   return .int(document.docStatus)
+        case "createdAt":   return .dateTime(document.createdAt)
+        case "updatedAt":   return .dateTime(document.updatedAt)
+        default:            return nil
+        }
+    }
+
+    /// Default printable form of a `FieldValue`. Renderers can override
+    /// per-type formatting if they need locale-aware money / date output.
+    public static func format(_ value: FieldValue) -> String {
+        switch value {
+        case .string(let s): return s
+        case .int(let i):    return String(i)
+        case .double(let d): return formattedDouble(d)
+        case .bool(let b):   return b ? "true" : "false"
+        case .null:          return ""
+        case .date(let d):
+            let f = DateFormatter()
+            f.dateStyle = .medium
+            f.timeStyle = .none
+            return f.string(from: d)
+        case .dateTime(let d):
+            let f = DateFormatter()
+            f.dateStyle = .medium
+            f.timeStyle = .short
+            return f.string(from: d)
+        case .data(let d):   return "<\(d.count) bytes>"
+        case .array(let xs): return xs.map(format).joined(separator: ", ")
+        }
+    }
+
+    private static func formattedDouble(_ d: Double) -> String {
+        if d == d.rounded() {
+            return String(format: "%.0f", d)
+        }
+        return String(format: "%g", d)
+    }
+
+    /// Humanise a snake_case or camelCase field key into a label.
+    public static func defaultLabel(forKey key: String) -> String {
+        if key.isEmpty { return key }
+        var spaced = ""
+        for (i, ch) in key.enumerated() {
+            if ch == "_" {
+                spaced += " "
+            } else if ch.isUppercase, i > 0 {
+                spaced += " "
+                spaced.append(ch)
+            } else {
+                spaced.append(ch)
+            }
+        }
+        return spaced.prefix(1).uppercased() + spaced.dropFirst()
+    }
+}

--- a/mercantis core/Printing/PrintService.swift
+++ b/mercantis core/Printing/PrintService.swift
@@ -1,0 +1,115 @@
+//
+//  PrintService.swift
+//  mercantis core
+//
+//  Phase C / P3.2 (ADR-044) — Public entry point. Looks up a registered
+//  `PrintFormat`, picks the renderer for the requested `PrintOutputKind`,
+//  and produces bytes.
+//
+
+import Foundation
+
+/// High-level print API for Hub and other host apps.
+///
+/// `PrintService` is intentionally a thin coordinator: it keeps a registry
+/// of formats and letter heads (typically populated from
+/// `AppManifest.printFormats` at install time), and dispatches to a
+/// pluggable renderer keyed by `PrintOutputKind`.
+public final class PrintService: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var formats: [String: PrintFormat] = [:]
+    private var letterHeads: [String: LetterHead] = [:]
+    private var renderers: [PrintOutputKind: PrintRenderer]
+
+    public init(renderers: [PrintRenderer] = PrintService.defaultRenderers()) {
+        var byKind: [PrintOutputKind: PrintRenderer] = [:]
+        for renderer in renderers {
+            byKind[renderer.outputKind] = renderer
+        }
+        self.renderers = byKind
+    }
+
+    /// Default renderer set: plain text + Core Graphics PDF.
+    public static func defaultRenderers() -> [PrintRenderer] {
+        [PlainTextPrintRenderer(), PDFPrintRenderer()]
+    }
+
+    // MARK: - Registration
+
+    public func register(format: PrintFormat) {
+        lock.lock(); defer { lock.unlock() }
+        formats[format.id] = format
+    }
+
+    public func register(letterHead: LetterHead) {
+        lock.lock(); defer { lock.unlock() }
+        letterHeads[letterHead.id] = letterHead
+    }
+
+    public func unregister(formatId: String) {
+        lock.lock(); defer { lock.unlock() }
+        formats.removeValue(forKey: formatId)
+    }
+
+    public func unregister(letterHeadId: String) {
+        lock.lock(); defer { lock.unlock() }
+        letterHeads.removeValue(forKey: letterHeadId)
+    }
+
+    public func registeredFormatIds() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return Array(formats.keys)
+    }
+
+    public func formats(forDocType docType: String) -> [PrintFormat] {
+        lock.lock(); defer { lock.unlock() }
+        return formats.values.filter { $0.docType == docType }
+    }
+
+    // MARK: - Render
+
+    /// Render `document` with the format identified by `formatId` to bytes
+    /// of `kind`. Throws if either no such format is registered or no
+    /// renderer for the requested output kind is configured.
+    public func render(
+        formatId: String,
+        document: Document,
+        as kind: PrintOutputKind,
+        now: Date = Date()
+    ) throws -> PrintRenderResult {
+        lock.lock()
+        let format = formats[formatId]
+        let letterHead: LetterHead? = format?.letterHeadId.flatMap { letterHeads[$0] }
+        let renderer = renderers[kind]
+        lock.unlock()
+
+        guard let format else {
+            throw PrintServiceError.unknownFormat(formatId)
+        }
+        guard let renderer else {
+            throw PrintServiceError.noRendererForKind(kind)
+        }
+        guard format.docType == document.docType else {
+            throw PrintServiceError.docTypeMismatch(
+                formatId: formatId,
+                expected: format.docType,
+                actual: document.docType
+            )
+        }
+
+        let context = PrintRenderContext(
+            format: format,
+            document: document,
+            letterHead: letterHead,
+            now: now
+        )
+        return try renderer.render(context)
+    }
+
+    public enum PrintServiceError: Error, Sendable, Equatable {
+        case unknownFormat(String)
+        case noRendererForKind(PrintOutputKind)
+        case docTypeMismatch(formatId: String, expected: String, actual: String)
+    }
+}

--- a/mercantis core/Reporting/DashboardEngine.swift
+++ b/mercantis core/Reporting/DashboardEngine.swift
@@ -1,0 +1,279 @@
+//
+//  DashboardEngine.swift
+//  mercantis core
+//
+//  Phase C / §3.10 (ADR-045) — Resolves a `DashboardDefinition` into a
+//  typed `DashboardResult`. The engine is rendering-agnostic: it produces
+//  the data model (counts, lists, chart series, shortcut metadata) and
+//  hands it to the UI layer. `MercantisCoreUI` is expected to ship a
+//  `GenericDashboardView` that consumes a `DashboardResult`; that view is
+//  out of scope for the engine library.
+//
+
+import Foundation
+
+/// Resolved data for one dashboard render. Shape mirrors
+/// `DashboardDefinition` 1:1 so a UI layer can iterate widgets and pick a
+/// renderer per `DashboardWidgetResult` case.
+public struct DashboardResult: Sendable, Equatable {
+    public let dashboardId: String
+    public let dashboardName: String
+    public let widgets: [DashboardWidgetResult]
+
+    public init(dashboardId: String, dashboardName: String, widgets: [DashboardWidgetResult]) {
+        self.dashboardId = dashboardId
+        self.dashboardName = dashboardName
+        self.widgets = widgets
+    }
+}
+
+/// One resolved widget. The kind tells the UI which case to read.
+public enum DashboardWidgetResult: Sendable, Equatable {
+    case count(title: String, value: Int, docType: String)
+    case list(title: String, columns: [String], rows: [[String?]], docType: String)
+    case chart(title: String, columns: [String], rows: [[String?]], reportId: String)
+    case shortcut(title: String, target: String)
+    /// Carries the underlying error so the UI can show "Could not load X"
+    /// instead of crashing the dashboard.
+    case error(title: String, reason: String)
+}
+
+/// Resolves dashboards into `DashboardResult` data models.
+///
+/// The engine pulls counts and lists from `DocumentEngine`, charts from
+/// `ReportEngine`, and shortcuts straight from the manifest declaration.
+/// Errors are captured per-widget so one bad tile doesn't blank the
+/// entire dashboard.
+public final class DashboardEngine: @unchecked Sendable {
+
+    private let documentEngine: DocumentEngine
+    private let reportEngine: ReportEngine?
+
+    private let lock = NSLock()
+    private var dashboards: [String: DashboardDefinition] = [:]
+
+    public init(
+        documentEngine: DocumentEngine,
+        reportEngine: ReportEngine? = nil
+    ) {
+        self.documentEngine = documentEngine
+        self.reportEngine = reportEngine
+    }
+
+    // MARK: - Registration
+
+    public func register(_ dashboard: DashboardDefinition) {
+        lock.lock(); defer { lock.unlock() }
+        dashboards[dashboard.id] = dashboard
+    }
+
+    public func unregister(dashboardId: String) {
+        lock.lock(); defer { lock.unlock() }
+        dashboards.removeValue(forKey: dashboardId)
+    }
+
+    public func registeredDashboardIds() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return Array(dashboards.keys).sorted()
+    }
+
+    // MARK: - Resolve
+
+    /// Resolve a dashboard by id. Throws only when no dashboard with the
+    /// given id is registered; per-widget failures fold into
+    /// `DashboardWidgetResult.error`.
+    public func resolve(
+        dashboardId: String,
+        userRoles: Set<String> = []
+    ) throws -> DashboardResult {
+        lock.lock()
+        let dashboard = dashboards[dashboardId]
+        lock.unlock()
+
+        guard let dashboard else {
+            throw DashboardEngineError.unknownDashboard(dashboardId)
+        }
+        let widgets = dashboard.widgets.map { widget in
+            resolveWidget(widget, userRoles: userRoles)
+        }
+        return DashboardResult(
+            dashboardId: dashboard.id,
+            dashboardName: dashboard.name,
+            widgets: widgets
+        )
+    }
+
+    // MARK: - Widget resolution
+
+    private func resolveWidget(
+        _ widget: DashboardWidget,
+        userRoles: Set<String>
+    ) -> DashboardWidgetResult {
+        switch widget.type.lowercased() {
+        case "count":   return resolveCount(widget)
+        case "list":    return resolveList(widget)
+        case "chart":   return resolveChart(widget, userRoles: userRoles)
+        case "shortcut": return resolveShortcut(widget)
+        default:
+            return .error(
+                title: widget.title,
+                reason: "Unknown widget type '\(widget.type)'"
+            )
+        }
+    }
+
+    private func resolveCount(_ widget: DashboardWidget) -> DashboardWidgetResult {
+        guard let docType = widget.docType, !docType.isEmpty else {
+            return .error(title: widget.title, reason: "count widget requires `docType`")
+        }
+        do {
+            let predicates = ParamFilters.predicates(from: widget.parameters)
+            let documents = try documentEngine.list(
+                docType: docType,
+                predicates: predicates.isEmpty ? nil : predicates,
+                applyRowAccess: false
+            )
+            return .count(title: widget.title, value: documents.count, docType: docType)
+        } catch {
+            return .error(title: widget.title, reason: "\(error)")
+        }
+    }
+
+    private func resolveList(_ widget: DashboardWidget) -> DashboardWidgetResult {
+        guard let docType = widget.docType, !docType.isEmpty else {
+            return .error(title: widget.title, reason: "list widget requires `docType`")
+        }
+        let columns = widget.parameters["columns"]?
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty } ?? []
+        let limit = widget.parameters["limit"].flatMap { Int($0) } ?? 10
+
+        do {
+            let predicates = ParamFilters.predicates(from: widget.parameters)
+            let documents = try documentEngine.list(
+                docType: docType,
+                predicates: predicates.isEmpty ? nil : predicates,
+                limit: limit,
+                applyRowAccess: false
+            )
+            // If no columns are declared, fall back to id + first user field.
+            let resolvedColumns: [String]
+            if columns.isEmpty {
+                resolvedColumns = ["id"] + (documents.first?.fields.keys.sorted().prefix(2) ?? [])
+            } else {
+                resolvedColumns = columns
+            }
+            let rows: [[String?]] = documents.map { doc in
+                resolvedColumns.map { col in
+                    let value = PrintTemplate.lookup(key: col, in: doc)
+                    return value.map(PrintTemplate.format)
+                }
+            }
+            return .list(
+                title: widget.title,
+                columns: resolvedColumns,
+                rows: rows,
+                docType: docType
+            )
+        } catch {
+            return .error(title: widget.title, reason: "\(error)")
+        }
+    }
+
+    private func resolveChart(_ widget: DashboardWidget, userRoles: Set<String>) -> DashboardWidgetResult {
+        guard let reportId = widget.reportId, !reportId.isEmpty else {
+            return .error(title: widget.title, reason: "chart widget requires `reportId`")
+        }
+        guard let reportEngine else {
+            return .error(title: widget.title, reason: "chart widget needs a configured ReportEngine")
+        }
+        let report = reportEngine.availableReports(for: userRoles)
+            .first { $0.id == reportId }
+        guard let report else {
+            return .error(title: widget.title, reason: "report '\(reportId)' not registered")
+        }
+        do {
+            let result = try reportEngine.execute(report: report)
+            return .chart(
+                title: widget.title,
+                columns: result.columns,
+                rows: result.rows,
+                reportId: reportId
+            )
+        } catch {
+            return .error(title: widget.title, reason: "\(error)")
+        }
+    }
+
+    private func resolveShortcut(_ widget: DashboardWidget) -> DashboardWidgetResult {
+        let target = widget.parameters["target"]
+            ?? widget.docType
+            ?? widget.reportId
+            ?? ""
+        return .shortcut(title: widget.title, target: target)
+    }
+
+    public enum DashboardEngineError: Error, Sendable, Equatable {
+        case unknownDashboard(String)
+    }
+}
+
+// MARK: - Parameter parsing helpers
+
+private enum ParamFilters {
+    /// Translate widget `parameters` into `ListFilter` predicates.
+    /// Supported syntax:
+    ///   - `where.<field>=<value>` ⇒ eq predicate
+    ///   - `where.<field>__gt=<n>` ⇒ gt predicate (and gte/lt/lte/like)
+    ///   - `status=Open` ⇒ shorthand eq (kept for ergonomics)
+    static func predicates(from parameters: [String: String]) -> [ListFilter] {
+        var out: [ListFilter] = []
+        for (key, raw) in parameters {
+            if key.hasPrefix("where.") {
+                let body = String(key.dropFirst("where.".count))
+                let parts = body.split(separator: "_", omittingEmptySubsequences: false)
+                if parts.count >= 3,
+                   let opIndex = (parts.count - 2 >= 0 ? Optional(parts.count - 2) : nil),
+                   parts[opIndex].isEmpty {
+                    // pattern: <field>__<op>
+                    let op = String(parts.last ?? "eq")
+                    let field = parts.dropLast(2).joined(separator: "_")
+                    if let predicate = predicate(field: field, op: op, value: raw) {
+                        out.append(predicate)
+                    }
+                } else {
+                    out.append(ListFilter(body, .eq(coerce(raw))))
+                }
+            } else if !["columns", "limit", "target"].contains(key),
+                      key.first?.isLetter == true {
+                out.append(ListFilter(key, .eq(coerce(raw))))
+            }
+        }
+        return out
+    }
+
+    private static func predicate(field: String, op: String, value: String) -> ListFilter? {
+        let coerced = coerce(value)
+        switch op {
+        case "eq":   return ListFilter(field, .eq(coerced))
+        case "neq":  return ListFilter(field, .neq(coerced))
+        case "gt":   return ListFilter(field, .gt(coerced))
+        case "gte":  return ListFilter(field, .gte(coerced))
+        case "lt":   return ListFilter(field, .lt(coerced))
+        case "lte":  return ListFilter(field, .lte(coerced))
+        case "like": return ListFilter(field, .like(value))
+        case "isnull":  return ListFilter(field, .isNull)
+        case "notnull": return ListFilter(field, .isNotNull)
+        default:     return nil
+        }
+    }
+
+    private static func coerce(_ raw: String) -> FieldValue {
+        if let i = Int(raw)    { return .int(i) }
+        if let d = Double(raw) { return .double(d) }
+        if raw.lowercased() == "true"  { return .bool(true) }
+        if raw.lowercased() == "false" { return .bool(false) }
+        return .string(raw)
+    }
+}

--- a/mercantis core/Storage/MigrationRunner.swift
+++ b/mercantis core/Storage/MigrationRunner.swift
@@ -85,6 +85,7 @@ public struct MigrationRunner {
         runner.register(version: 7, name: "add_tree_parent", sql: MigrationRunner.v7SQL)
         runner.register(version: 8, name: "add_workflow_transitions", sql: MigrationRunner.v8SQL)
         runner.register(version: 9, name: "add_naming_counter_blocks", sql: MigrationRunner.v9SQL)
+        runner.register(version: 10, name: "add_attachments", sql: MigrationRunner.v10SQL)
     }
 
     // MARK: - v1 Schema
@@ -310,5 +311,35 @@ public struct MigrationRunner {
             nextValue   INTEGER NOT NULL,
             PRIMARY KEY (seriesKey, deviceId)
         );
+        """
+
+    // MARK: - v10 Schema — attachments (Phase C / P3.1, ADR-043)
+
+    private static let v10SQL = """
+        -- File attachments per document. Bytes live on disk under the
+        -- attachment store's root directory; this table holds metadata only.
+        -- `fieldKey` is nullable: null means "general document attachment"
+        -- (not bound to a specific FieldType.attachment field), non-null
+        -- binds the attachment to the named field for typed UI rendering.
+        --
+        -- `sha256` enables content-addressable dedup at the store layer
+        -- and integrity checks at read time.
+        CREATE TABLE IF NOT EXISTS attachments (
+            id           TEXT    PRIMARY KEY NOT NULL,
+            documentId   TEXT    NOT NULL,
+            docType      TEXT    NOT NULL,
+            fieldKey     TEXT,
+            fileName     TEXT    NOT NULL,
+            mimeType     TEXT    NOT NULL DEFAULT 'application/octet-stream',
+            byteSize     INTEGER NOT NULL,
+            storagePath  TEXT    NOT NULL,
+            uploadedAt   TEXT    NOT NULL,
+            uploadedBy   TEXT    NOT NULL,
+            sha256       TEXT    NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_attachments_document ON attachments(documentId);
+        CREATE INDEX IF NOT EXISTS idx_attachments_doctype  ON attachments(docType);
+        CREATE INDEX IF NOT EXISTS idx_attachments_field    ON attachments(documentId, fieldKey);
         """
 }

--- a/mercantis coreTests/AttachmentTests.swift
+++ b/mercantis coreTests/AttachmentTests.swift
@@ -1,0 +1,187 @@
+//
+//  AttachmentTests.swift
+//  mercantis coreTests
+//
+//  Phase C / P3.1 (ADR-043) — File attachments via AttachmentManager.
+//  Covers attach / read / list / delete and the DocumentEngine cascade.
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class AttachmentTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+    private var store: AttachmentStore!
+    private var attachmentManager: AttachmentManager!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness(userId: "alice")
+        store = try AttachmentStore(beside: harness.database)
+        attachmentManager = AttachmentManager(
+            database: harness.database,
+            store: store
+        )
+        try harness.registry.register(TestSupport.makeDocType())
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        attachmentManager = nil
+        store = nil
+        harness = nil
+    }
+
+    // MARK: - Helpers
+
+    private func saveDoc(_ id: String) throws {
+        try harness.engine.save(TestSupport.makeDocument(
+            id: id,
+            fields: ["title": .string(id)]
+        ))
+    }
+
+    private func attach(
+        _ documentId: String,
+        fileName: String = "scan.pdf",
+        bytes: [UInt8] = [0x25, 0x50, 0x44, 0x46]
+    ) throws -> Attachment {
+        try attachmentManager.attach(
+            documentId: documentId,
+            docType: "Note",
+            fileName: fileName,
+            mimeType: "application/pdf",
+            data: Data(bytes),
+            userId: "alice"
+        )
+    }
+
+    // MARK: - Attach / read
+
+    func testAttachWritesMetadataAndBytes() throws {
+        try saveDoc("d1")
+        let attachment = try attach("d1")
+
+        XCTAssertEqual(attachment.documentId, "d1")
+        XCTAssertEqual(attachment.fileName, "scan.pdf")
+        XCTAssertEqual(attachment.mimeType, "application/pdf")
+        XCTAssertEqual(attachment.byteSize, 4)
+        XCTAssertFalse(attachment.sha256.isEmpty)
+
+        let bytes = try attachmentManager.read(attachment)
+        XCTAssertEqual(bytes, Data([0x25, 0x50, 0x44, 0x46]))
+    }
+
+    func testReadByIdMatchesAttachment() throws {
+        try saveDoc("d2")
+        let a = try attach("d2", bytes: Array("hello".utf8))
+        let bytes = try attachmentManager.read(id: a.id)
+        XCTAssertEqual(String(data: bytes, encoding: .utf8), "hello")
+    }
+
+    func testReadFailsWhenStoredBytesMismatchHash() throws {
+        try saveDoc("d3")
+        let a = try attach("d3", bytes: [1, 2, 3])
+
+        // Tamper with the on-disk file.
+        let tampered = store.rootURL.appendingPathComponent(a.storagePath)
+        try Data([9, 9, 9]).write(to: tampered)
+
+        XCTAssertThrowsError(try attachmentManager.read(a)) { error in
+            guard case AttachmentError.integrityFailure = error else {
+                return XCTFail("expected integrityFailure, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Listing
+
+    func testAttachmentsForDocumentReturnedInUploadOrder() throws {
+        try saveDoc("d4")
+        _ = try attach("d4", fileName: "first.pdf")
+        Thread.sleep(forTimeInterval: 0.02)
+        _ = try attach("d4", fileName: "second.pdf")
+
+        let list = try attachmentManager.attachments(forDocumentId: "d4")
+        XCTAssertEqual(list.map(\.fileName), ["first.pdf", "second.pdf"])
+    }
+
+    func testFieldKeyIsolatesAttachments() throws {
+        try saveDoc("d5")
+        _ = try attachmentManager.attach(
+            documentId: "d5", docType: "Note", fieldKey: "scan",
+            fileName: "scan.pdf", data: Data([1, 2]), userId: "alice"
+        )
+        _ = try attachmentManager.attach(
+            documentId: "d5", docType: "Note", fieldKey: "receipt",
+            fileName: "receipt.pdf", data: Data([3, 4]), userId: "alice"
+        )
+
+        let scans = try attachmentManager.attachments(forField: "scan", on: "d5")
+        XCTAssertEqual(scans.map(\.fileName), ["scan.pdf"])
+    }
+
+    // MARK: - Delete
+
+    func testDeleteRemovesMetadataAndBytes() throws {
+        try saveDoc("d6")
+        let a = try attach("d6")
+        XCTAssertTrue(store.exists(storagePath: a.storagePath))
+
+        try attachmentManager.delete(id: a.id, userId: "alice")
+
+        XCTAssertNil(try attachmentManager.metadata(id: a.id))
+        XCTAssertFalse(store.exists(storagePath: a.storagePath))
+    }
+
+    func testDocumentDeleteCascadesAttachments() throws {
+        // Re-create the harness with the manager wired into the engine so
+        // delete() cascades.
+        TestSupport.cleanUp(databaseURL: harness.url)
+        harness = try TestSupport.makeHarness(userId: "alice")
+        store = try AttachmentStore(beside: harness.database)
+        attachmentManager = AttachmentManager(database: harness.database, store: store)
+
+        let cascadingEngine = DocumentEngine(
+            database: harness.database,
+            registry: harness.registry,
+            deviceId: "test-device",
+            userId: "alice",
+            eventEmitter: harness.emitter,
+            attachmentManager: attachmentManager
+        )
+
+        try harness.registry.register(TestSupport.makeDocType())
+        try cascadingEngine.save(TestSupport.makeDocument(id: "casc",
+                                                           fields: ["title": .string("Casc")]))
+        let a = try attach("casc")
+        XCTAssertTrue(store.exists(storagePath: a.storagePath))
+
+        try cascadingEngine.delete(docType: "Note", id: "casc")
+
+        XCTAssertTrue(try attachmentManager.attachments(forDocumentId: "casc").isEmpty)
+        XCTAssertFalse(store.exists(storagePath: a.storagePath))
+    }
+
+    // MARK: - Audit log
+
+    func testAttachAndDeleteWriteAuditEntries() throws {
+        let auditWriter = AuditLogWriter(database: harness.database)
+        let manager = AttachmentManager(
+            database: harness.database, store: store, auditWriter: auditWriter
+        )
+
+        try saveDoc("d7")
+        let a = try manager.attach(
+            documentId: "d7", docType: "Note",
+            fileName: "x.pdf", data: Data([1]), userId: "alice"
+        )
+        try manager.delete(id: a.id, userId: "alice")
+
+        let entries = try auditWriter.entries(forDocumentId: "d7")
+        let actions = entries.map(\.action)
+        XCTAssertTrue(actions.contains("attach"))
+        XCTAssertTrue(actions.contains("detach"))
+    }
+}

--- a/mercantis coreTests/DashboardEngineTests.swift
+++ b/mercantis coreTests/DashboardEngineTests.swift
@@ -1,0 +1,216 @@
+//
+//  DashboardEngineTests.swift
+//  mercantis coreTests
+//
+//  Phase C / §3.10 (ADR-045) — DashboardEngine resolves DashboardWidget
+//  declarations against DocumentEngine + ReportEngine into a typed
+//  DashboardResult that a UI layer can render.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class DashboardEngineTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+    private var dashboardEngine: DashboardEngine!
+    private var reportEngine: ReportEngine!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness()
+        reportEngine = ReportEngine(documentEngine: harness.engine)
+        dashboardEngine = DashboardEngine(
+            documentEngine: harness.engine,
+            reportEngine: reportEngine
+        )
+        try harness.registry.register(TestSupport.makeDocType(
+            fields: [
+                TestSupport.textField("title", required: true),
+                TestSupport.numberField("priority"),
+                TestSupport.textField("status"),
+            ]
+        ))
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        dashboardEngine = nil
+        reportEngine = nil
+        harness = nil
+    }
+
+    // MARK: - Helpers
+
+    private func saveNote(_ id: String, priority: Int, status: String = "Open") throws {
+        var doc = TestSupport.makeDocument(
+            id: id,
+            fields: [
+                "title": .string(id),
+                "priority": .int(priority),
+                "status": .string(status),
+            ]
+        )
+        doc.status = status
+        try harness.engine.save(doc)
+    }
+
+    // MARK: - Resolution
+
+    func testCountWidgetReturnsTotalDocumentsForDocType() throws {
+        try saveNote("a", priority: 1)
+        try saveNote("b", priority: 2)
+        try saveNote("c", priority: 3)
+
+        let dashboard = DashboardDefinition(id: "home", name: "Home", widgets: [
+            DashboardWidget(type: "count", title: "Open notes", docType: "Note", parameters: [:])
+        ])
+        dashboardEngine.register(dashboard)
+
+        let result = try dashboardEngine.resolve(dashboardId: "home")
+        XCTAssertEqual(result.dashboardName, "Home")
+        XCTAssertEqual(result.widgets.count, 1)
+        guard case let .count(_, value, docType) = result.widgets[0] else {
+            return XCTFail("expected count case, got \(result.widgets[0])")
+        }
+        XCTAssertEqual(value, 3)
+        XCTAssertEqual(docType, "Note")
+    }
+
+    func testCountWidgetAppliesEqualityFilterFromParameters() throws {
+        try saveNote("a", priority: 1, status: "Open")
+        try saveNote("b", priority: 2, status: "Closed")
+        try saveNote("c", priority: 3, status: "Open")
+
+        let dashboard = DashboardDefinition(id: "open", name: "Open", widgets: [
+            DashboardWidget(
+                type: "count", title: "Open",
+                docType: "Note", parameters: ["status": "Open"]
+            )
+        ])
+        dashboardEngine.register(dashboard)
+
+        let result = try dashboardEngine.resolve(dashboardId: "open")
+        guard case let .count(_, value, _) = result.widgets[0] else {
+            return XCTFail("expected count case")
+        }
+        XCTAssertEqual(value, 2)
+    }
+
+    func testCountWidgetAppliesOperatorFilterFromWhereParameter() throws {
+        try saveNote("low",  priority: 1)
+        try saveNote("mid",  priority: 5)
+        try saveNote("high", priority: 9)
+
+        let dashboard = DashboardDefinition(id: "p", name: "P", widgets: [
+            DashboardWidget(
+                type: "count", title: "Big",
+                docType: "Note", parameters: ["where.priority__gt": "3"]
+            )
+        ])
+        dashboardEngine.register(dashboard)
+
+        let result = try dashboardEngine.resolve(dashboardId: "p")
+        guard case let .count(_, value, _) = result.widgets[0] else {
+            return XCTFail("expected count case")
+        }
+        XCTAssertEqual(value, 2)
+    }
+
+    func testListWidgetReturnsExplicitColumnsAndRespectsLimit() throws {
+        try saveNote("a", priority: 1)
+        try saveNote("b", priority: 2)
+        try saveNote("c", priority: 3)
+
+        let dashboard = DashboardDefinition(id: "list", name: "List", widgets: [
+            DashboardWidget(
+                type: "list", title: "Recent notes",
+                docType: "Note",
+                parameters: ["columns": "id,title", "limit": "2"]
+            )
+        ])
+        dashboardEngine.register(dashboard)
+
+        let result = try dashboardEngine.resolve(dashboardId: "list")
+        guard case let .list(_, columns, rows, _) = result.widgets[0] else {
+            return XCTFail("expected list case")
+        }
+        XCTAssertEqual(columns, ["id", "title"])
+        XCTAssertEqual(rows.count, 2)
+    }
+
+    func testChartWidgetExecutesUnderlyingReport() throws {
+        try saveNote("a", priority: 5)
+        try saveNote("b", priority: 7)
+
+        let report = ReportDefinition(
+            id: "priority-report", name: "Priorities", docType: "Note",
+            columns: ["title", "priority"], filters: []
+        )
+        reportEngine.register(report)
+
+        let dashboard = DashboardDefinition(id: "charts", name: "Charts", widgets: [
+            DashboardWidget(
+                type: "chart", title: "Priority chart",
+                reportId: "priority-report", parameters: [:]
+            )
+        ])
+        dashboardEngine.register(dashboard)
+
+        let result = try dashboardEngine.resolve(dashboardId: "charts")
+        guard case let .chart(_, columns, rows, reportId) = result.widgets[0] else {
+            return XCTFail("expected chart case")
+        }
+        XCTAssertEqual(columns, ["title", "priority"])
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(reportId, "priority-report")
+    }
+
+    func testChartWidgetReportsErrorWhenReportEngineMissing() throws {
+        let bare = DashboardEngine(documentEngine: harness.engine, reportEngine: nil)
+        bare.register(DashboardDefinition(id: "d", name: "D", widgets: [
+            DashboardWidget(type: "chart", title: "X", reportId: "anything", parameters: [:])
+        ]))
+
+        let result = try bare.resolve(dashboardId: "d")
+        guard case let .error(_, reason) = result.widgets[0] else {
+            return XCTFail("expected error case")
+        }
+        XCTAssertTrue(reason.contains("ReportEngine"))
+    }
+
+    func testShortcutWidgetCarriesTargetForRouting() throws {
+        let dashboard = DashboardDefinition(id: "s", name: "S", widgets: [
+            DashboardWidget(
+                type: "shortcut", title: "Open all notes",
+                docType: "Note", parameters: ["target": "/notes"]
+            )
+        ])
+        dashboardEngine.register(dashboard)
+
+        let result = try dashboardEngine.resolve(dashboardId: "s")
+        guard case let .shortcut(_, target) = result.widgets[0] else {
+            return XCTFail("expected shortcut case")
+        }
+        XCTAssertEqual(target, "/notes")
+    }
+
+    func testUnknownDashboardThrows() {
+        XCTAssertThrowsError(try dashboardEngine.resolve(dashboardId: "nope")) { error in
+            guard case DashboardEngine.DashboardEngineError.unknownDashboard = error else {
+                return XCTFail("expected unknownDashboard, got \(error)")
+            }
+        }
+    }
+
+    func testUnknownWidgetTypeBecomesErrorWidget() throws {
+        dashboardEngine.register(DashboardDefinition(id: "d", name: "D", widgets: [
+            DashboardWidget(type: "carousel", title: "Bad widget", parameters: [:])
+        ]))
+        let result = try dashboardEngine.resolve(dashboardId: "d")
+        guard case let .error(title, reason) = result.widgets[0] else {
+            return XCTFail("expected error case")
+        }
+        XCTAssertEqual(title, "Bad widget")
+        XCTAssertTrue(reason.contains("Unknown widget type"))
+    }
+}

--- a/mercantis coreTests/ImportExportTests.swift
+++ b/mercantis coreTests/ImportExportTests.swift
@@ -1,0 +1,209 @@
+//
+//  ImportExportTests.swift
+//  mercantis coreTests
+//
+//  Phase C / P3.3 (ADR-046) — DataExporter + DataImporter round trips
+//  through CSV and JSON. Imports re-route through `DocumentEngine.save`,
+//  so naming, validation, audit log, and per-device counter blocks all
+//  fire identically to interactive saves.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class ImportExportTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+    private var exporter: DataExporter!
+    private var importer: DataImporter!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness()
+        exporter = DataExporter(documentEngine: harness.engine, registry: harness.registry)
+        importer = DataImporter(documentEngine: harness.engine, registry: harness.registry)
+        try harness.registry.register(TestSupport.makeDocType(
+            fields: [
+                TestSupport.textField("title", required: true),
+                TestSupport.numberField("priority"),
+                TestSupport.textField("category"),
+            ]
+        ))
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        exporter = nil
+        importer = nil
+        harness = nil
+    }
+
+    private func saveDoc(_ id: String, title: String, priority: Int? = nil, category: String? = nil) throws {
+        var fields: [String: FieldValue] = ["title": .string(title)]
+        if let p = priority { fields["priority"] = .int(p) }
+        if let c = category { fields["category"] = .string(c) }
+        try harness.engine.save(TestSupport.makeDocument(id: id, fields: fields))
+    }
+
+    // MARK: - CSV codec
+
+    func testCSVEscapesCommasAndQuotes() {
+        XCTAssertEqual(CSVCodec.escape("plain"), "plain")
+        XCTAssertEqual(CSVCodec.escape("a,b"), "\"a,b\"")
+        XCTAssertEqual(CSVCodec.escape("she said \"hi\""), "\"she said \"\"hi\"\"\"")
+    }
+
+    func testCSVDecodesQuotedCellsWithEmbeddedCommas() throws {
+        let bytes = Data("name,desc\nAlice,\"Hello, world\"\n".utf8)
+        let table = try CSVCodec.decode(bytes)
+        XCTAssertEqual(table.headers, ["name", "desc"])
+        XCTAssertEqual(table.rows.first?["desc"], "Hello, world")
+    }
+
+    func testCSVDecodeRejectsUnterminatedQuotedCell() {
+        let bytes = Data("a,b\n\"unterminated".utf8)
+        XCTAssertThrowsError(try CSVCodec.decode(bytes)) { error in
+            guard case ImportExportError.malformedCSV = error else {
+                return XCTFail("expected malformedCSV, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - CSV export / import
+
+    func testCSVExportEmitsDeclaredFieldColumnsAndSystemColumns() throws {
+        try saveDoc("a", title: "Alpha", priority: 1, category: "x")
+        try saveDoc("b", title: "Bravo", priority: 2, category: "y")
+
+        let bytes = try exporter.export(docType: "Note", format: .csv)
+        let text = try XCTUnwrap(String(data: bytes, encoding: .utf8))
+
+        let lines = text.split(separator: "\n").map(String.init)
+        XCTAssertEqual(lines.first, "id,status,docStatus,title,priority,category")
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertTrue(lines.contains(where: { $0.contains("Alpha") }))
+        XCTAssertTrue(lines.contains(where: { $0.contains("Bravo") }))
+    }
+
+    func testCSVImportInsertsNewDocumentsThroughDocumentEngine() throws {
+        let csv = """
+        id,status,docStatus,title,priority,category
+        n1,Open,0,First,5,Alpha
+        n2,Open,0,Second,7,Beta
+        """
+        let report = try importer.import(docType: "Note", data: Data(csv.utf8), format: .csv)
+        XCTAssertEqual(report.rowsRead, 2)
+        XCTAssertEqual(report.insertedCount, 2)
+
+        let n1 = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "n1"))
+        XCTAssertEqual(n1.fields["title"], .string("First"))
+        XCTAssertEqual(n1.fields["priority"], .int(5))
+    }
+
+    func testCSVImportSkipExistingPolicyDoesNotOverwrite() throws {
+        try saveDoc("dup", title: "Original", priority: 1)
+
+        let csv = """
+        id,status,docStatus,title,priority,category
+        dup,Open,0,Replaced,99,X
+        """
+        let report = try importer.import(
+            docType: "Note", data: Data(csv.utf8),
+            format: .csv, conflictPolicy: .skipExisting
+        )
+        XCTAssertEqual(report.skippedCount, 1)
+        XCTAssertEqual(report.updatedCount, 0)
+
+        let unchanged = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "dup"))
+        XCTAssertEqual(unchanged.fields["title"], .string("Original"))
+    }
+
+    func testCSVImportOverwritePolicyUpdatesExistingDocument() throws {
+        try saveDoc("dup", title: "Old", priority: 1)
+
+        let csv = """
+        id,status,docStatus,title,priority,category
+        dup,Open,0,New,42,X
+        """
+        let report = try importer.import(docType: "Note", data: Data(csv.utf8), format: .csv)
+        XCTAssertEqual(report.updatedCount, 1)
+        XCTAssertEqual(report.insertedCount, 0)
+
+        let updated = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "dup"))
+        XCTAssertEqual(updated.fields["title"], .string("New"))
+        XCTAssertEqual(updated.fields["priority"], .int(42))
+    }
+
+    func testCSVImportMalformedNumberFailsRowIndividually() throws {
+        let csv = """
+        id,status,docStatus,title,priority,category
+        good,Open,0,Good,5,X
+        bad,Open,0,Bad,abc,Y
+        """
+        let report = try importer.import(docType: "Note", data: Data(csv.utf8), format: .csv)
+        XCTAssertEqual(report.insertedCount, 1)
+        XCTAssertEqual(report.failedCount, 1)
+    }
+
+    // MARK: - JSON round trip
+
+    func testJSONRoundTripPreservesChildrenAndTypedFieldValues() throws {
+        // Save a parent doc with a child table to verify JSON keeps
+        // children that CSV can't.
+        var parent = TestSupport.makeDocument(
+            id: "p1",
+            fields: ["title": .string("Parent")]
+        )
+        parent.children["lines"] = [
+            ChildRow(id: "l1", rowIndex: 0, fields: ["sku": .string("X"), "qty": .int(2)]),
+            ChildRow(id: "l2", rowIndex: 1, fields: ["sku": .string("Y"), "qty": .int(3)]),
+        ]
+        try harness.engine.save(parent)
+
+        let bytes = try exporter.export(docType: "Note", format: .json)
+
+        // Wipe and re-import.
+        try harness.engine.delete(docType: "Note", id: "p1")
+        XCTAssertNil(try harness.engine.fetch(docType: "Note", id: "p1"))
+
+        let report = try importer.import(docType: "Note", data: bytes, format: .json)
+        XCTAssertEqual(report.insertedCount, 1)
+
+        let restored = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "p1"))
+        XCTAssertEqual(restored.fields["title"], .string("Parent"))
+        XCTAssertEqual(restored.children["lines"]?.count, 2)
+        XCTAssertEqual(restored.children["lines"]?[0].fields["qty"], .int(2))
+    }
+
+    func testJSONImportRejectsMalformedPayload() throws {
+        let bytes = Data("{not really json".utf8)
+        XCTAssertThrowsError(try importer.import(docType: "Note", data: bytes, format: .json)) { error in
+            guard case ImportExportError.malformedJSON = error else {
+                return XCTFail("expected malformedJSON, got \(error)")
+            }
+        }
+    }
+
+    func testExportOfUnregisteredDocTypeThrows() {
+        XCTAssertThrowsError(try exporter.export(docType: "Unknown", format: .csv)) { error in
+            guard case ImportExportError.docTypeNotRegistered = error else {
+                return XCTFail("expected docTypeNotRegistered, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Predicate-bound export
+
+    func testExportRespectsPredicateFilter() throws {
+        try saveDoc("a", title: "Alpha", priority: 1)
+        try saveDoc("b", title: "Bravo", priority: 9)
+
+        let bytes = try exporter.export(
+            docType: "Note", format: .csv,
+            predicates: [ListFilter("priority", .gt(.int(5)))]
+        )
+        let text = try XCTUnwrap(String(data: bytes, encoding: .utf8))
+        let dataLines = text.split(separator: "\n").dropFirst()
+        XCTAssertEqual(dataLines.count, 1)
+        XCTAssertTrue(dataLines.first?.contains("Bravo") ?? false)
+    }
+}

--- a/mercantis coreTests/MigrationRunnerTests.swift
+++ b/mercantis coreTests/MigrationRunnerTests.swift
@@ -56,7 +56,7 @@ final class MigrationRunnerTests: XCTestCase {
         MigrationRunner.registerAll(into: &runner, pool: pool)
         try runner.migrate(pool: pool)
 
-        XCTAssertEqual(try highestAppliedVersion(), 9)
+        XCTAssertEqual(try highestAppliedVersion(), 10)
     }
 
     func testV1CreatesExpectedTables() throws {
@@ -148,6 +148,19 @@ final class MigrationRunnerTests: XCTestCase {
         XCTAssertTrue(try columnExists("blockStart", in: "naming_counter_blocks"))
         XCTAssertTrue(try columnExists("blockEnd",   in: "naming_counter_blocks"))
         XCTAssertTrue(try columnExists("nextValue",  in: "naming_counter_blocks"))
+    }
+
+    func testV10CreatesAttachmentsTable() throws {
+        var runner = MigrationRunner()
+        MigrationRunner.registerAll(into: &runner, pool: pool)
+        try runner.migrate(pool: pool)
+
+        XCTAssertTrue(try tableExists("attachments"))
+        XCTAssertTrue(try columnExists("documentId",  in: "attachments"))
+        XCTAssertTrue(try columnExists("fieldKey",    in: "attachments"))
+        XCTAssertTrue(try columnExists("fileName",    in: "attachments"))
+        XCTAssertTrue(try columnExists("storagePath", in: "attachments"))
+        XCTAssertTrue(try columnExists("sha256",      in: "attachments"))
     }
 
     func testSecondMigrateIsIdempotent() throws {

--- a/mercantis coreTests/PrintServiceTests.swift
+++ b/mercantis coreTests/PrintServiceTests.swift
@@ -1,0 +1,195 @@
+//
+//  PrintServiceTests.swift
+//  mercantis coreTests
+//
+//  Phase C / P3.2 (ADR-044) — PrintService + PlainTextPrintRenderer.
+//  PDF rendering is exercised via byte-prefix sanity (the bytes start with
+//  `%PDF-`). Pixel-level PDF tests are out of scope.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class PrintServiceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func sampleDocument() -> Document {
+        var doc = TestSupport.makeDocument(
+            id: "INV-001",
+            docType: "Invoice",
+            fields: [
+                "customer":    .string("ACME Corp"),
+                "currency":    .string("EUR"),
+                "subtotal":    .double(150),
+                "grand_total": .double(165),
+            ]
+        )
+        doc.children["items"] = [
+            ChildRow(id: "r1", rowIndex: 0, fields: [
+                "name": .string("Widget"),  "qty": .int(2), "price": .double(50)
+            ]),
+            ChildRow(id: "r2", rowIndex: 1, fields: [
+                "name": .string("Gizmo"),   "qty": .int(1), "price": .double(50)
+            ]),
+        ]
+        return doc
+    }
+
+    private func sampleFormat() -> PrintFormat {
+        PrintFormat(
+            id: "invoice-default",
+            name: "Default Invoice",
+            docType: "Invoice",
+            letterHeadId: "lh-acme",
+            sections: [
+                .heading(text: "Invoice {id}"),
+                .fields(keys: ["customer", "currency"]),
+                .table(
+                    tableKey: "items",
+                    columns: ["name", "qty", "price"],
+                    labels: ["qty": "Qty"]
+                ),
+                .keyValue(label: "Subtotal", value: "{subtotal}"),
+                .keyValue(label: "Total",    value: "{grand_total} {currency}"),
+            ]
+        )
+    }
+
+    private func makeService() -> PrintService {
+        let s = PrintService()
+        s.register(format: sampleFormat())
+        s.register(letterHead: LetterHead(
+            id: "lh-acme", name: "ACME",
+            header: "ACME Corp — Invoices",
+            footer: "Thank you for your business."
+        ))
+        return s
+    }
+
+    // MARK: - Registry
+
+    func testRegisteredFormatsAreLookupable() {
+        let s = makeService()
+        XCTAssertEqual(s.registeredFormatIds(), ["invoice-default"])
+        XCTAssertEqual(s.formats(forDocType: "Invoice").count, 1)
+        XCTAssertEqual(s.formats(forDocType: "Customer").count, 0)
+    }
+
+    func testUnregisterRemovesFormatAndLetterHead() {
+        let s = makeService()
+        s.unregister(formatId: "invoice-default")
+        s.unregister(letterHeadId: "lh-acme")
+        XCTAssertTrue(s.registeredFormatIds().isEmpty)
+    }
+
+    // MARK: - Render plain text
+
+    func testPlainTextOutputIncludesLetterHeadAndHeading() throws {
+        let result = try makeService().render(
+            formatId: "invoice-default",
+            document: sampleDocument(),
+            as: .plainText
+        )
+        XCTAssertEqual(result.mimeType, "text/plain; charset=utf-8")
+        let text = String(data: result.data, encoding: .utf8) ?? ""
+        XCTAssertTrue(text.contains("ACME Corp — Invoices"), "letter head header missing")
+        XCTAssertTrue(text.contains("Invoice INV-001"), "heading substitution failed")
+        XCTAssertTrue(text.contains("Thank you for your business."), "letter head footer missing")
+    }
+
+    func testPlainTextRendersFieldsGridAndChildTable() throws {
+        let result = try makeService().render(
+            formatId: "invoice-default", document: sampleDocument(), as: .plainText
+        )
+        let text = String(data: result.data, encoding: .utf8) ?? ""
+
+        XCTAssertTrue(text.contains("Customer"), "fields label missing")
+        XCTAssertTrue(text.contains("ACME Corp"), "fields value missing")
+
+        // Table heading (custom labels.qty + default label for `name`/`price`).
+        XCTAssertTrue(text.contains("Name"))
+        XCTAssertTrue(text.contains("Qty"))
+        XCTAssertTrue(text.contains("Price"))
+
+        // Row data.
+        XCTAssertTrue(text.contains("Widget"))
+        XCTAssertTrue(text.contains("Gizmo"))
+    }
+
+    func testPlainTextSubstitutesPlaceholdersInKeyValueRows() throws {
+        let result = try makeService().render(
+            formatId: "invoice-default", document: sampleDocument(), as: .plainText
+        )
+        let text = String(data: result.data, encoding: .utf8) ?? ""
+        XCTAssertTrue(text.contains("Total: 165 EUR"))
+    }
+
+    func testPlainTextLeavesUnknownPlaceholdersLiteral() throws {
+        let format = PrintFormat(
+            id: "x", name: "X", docType: "Note",
+            sections: [.paragraph(text: "Hello {missing_field} world")]
+        )
+        let s = PrintService()
+        s.register(format: format)
+
+        let result = try s.render(
+            formatId: "x",
+            document: TestSupport.makeDocument(id: "n1", docType: "Note", fields: ["title": .string("t")]),
+            as: .plainText
+        )
+        let text = String(data: result.data, encoding: .utf8) ?? ""
+        XCTAssertTrue(text.contains("{missing_field}"),
+                      "unknown placeholder must round-trip literal so authors notice")
+    }
+
+    // MARK: - Errors
+
+    func testRenderThrowsForUnknownFormat() {
+        XCTAssertThrowsError(try makeService().render(
+            formatId: "does-not-exist",
+            document: sampleDocument(),
+            as: .plainText
+        )) { error in
+            guard case PrintService.PrintServiceError.unknownFormat = error else {
+                return XCTFail("expected unknownFormat, got \(error)")
+            }
+        }
+    }
+
+    func testRenderThrowsOnDocTypeMismatch() {
+        var wrong = TestSupport.makeDocument(id: "x", docType: "Note")
+        wrong.fields = ["title": .string("x")]
+
+        XCTAssertThrowsError(try makeService().render(
+            formatId: "invoice-default",
+            document: wrong,
+            as: .plainText
+        )) { error in
+            guard case PrintService.PrintServiceError.docTypeMismatch = error else {
+                return XCTFail("expected docTypeMismatch, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - PDF byte sanity
+
+    func testPDFOutputStartsWithPDFMagicBytes() throws {
+        let result = try makeService().render(
+            formatId: "invoice-default", document: sampleDocument(), as: .pdf
+        )
+        XCTAssertEqual(result.mimeType, "application/pdf")
+        let prefix = result.data.prefix(5)
+        XCTAssertEqual(Array(prefix), Array("%PDF-".utf8),
+                       "PDF output must begin with the %PDF- magic header")
+    }
+
+    // MARK: - PrintFormat round-trip
+
+    func testPrintFormatRoundTripsThroughCodable() throws {
+        let original = sampleFormat()
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PrintFormat.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+}


### PR DESCRIPTION
Closes the four ERP-feature-breadth items documented in STATUS.md §3.9 and §3.10:

- §3.9 / P3.1 (ADR-043): Files/ subsystem. Attachment + AttachmentStore (filesystem) + AttachmentManager (atomic metadata + audit). Migration v10 adds the attachments table. DocumentEngine accepts an optional attachmentManager: dependency and cascades on delete.

- §3.9 / P3.2 (ADR-044): Printing/ subsystem. Declarative PrintFormat + LetterHead, structured PrintSection enum, pluggable PrintRenderer per PrintOutputKind. PlainTextPrintRenderer (pure Swift) and PDFPrintRenderer (CoreGraphics, behind canImport guard) ship in the default renderer set. PrintService coordinates registries + dispatch.

- §3.10 (ADR-045): DashboardEngine resolves DashboardDefinition widgets into a typed DashboardResult tree (count / list / chart / shortcut / error). Counts and lists run through DocumentEngine.list with widget- parameter-derived ListFilter predicates; charts defer to ReportEngine. Per-widget error isolation. SwiftUI view is a MercantisCoreUI follow-up.

- §3.9 / P3.3 (ADR-046): ImportExport/ subsystem. RFC-4180-ish CSVCodec, DataExporter (CSV + JSON envelope), DataImporter routed through DocumentEngine.save so validation / naming / audit / counter blocks all fire. Per-row outcome aggregation into ImportReport; overwrite / skipExisting / fail conflict policies.

Tests: AttachmentTests (10), PrintServiceTests (9), DashboardEngineTests (9), ImportExportTests (10), plus migration v10 coverage.

Docs: STATUS.md headline ~90%; §2 scorecard rows for Storage, Files, Print/PDF, ImportExport, Dashboards updated; §3.9 + §3.10 marked shipped; §4 Phase C complete. ARCHITECTURE-CHANGELOG entry added; ADRs 043-046 indexed.