### PR TITLE
Phase D: filesystem CloudAdapter, persistent notifications, report ro…

### DIFF
--- a/Docs/ADR/ADR-047-filesystem-cloud-adapter.md
+++ b/Docs/ADR/ADR-047-filesystem-cloud-adapter.md
@@ -1,0 +1,98 @@
+# ADR-047 — Filesystem Reference `CloudAdapter`
+
+**Status:** Accepted
+**Date:** 2026-05-05
+
+---
+
+## Context
+
+ADR-018 deliberately keeps `CloudAdapter` as a protocol seam — Core never
+imports a specific cloud SDK. STATUS.md §3.5 nonetheless flagged that
+shipping at least one *real* adapter would help Hub's first multi-device
+customer: the only adapter in the box was `NoOpCloudAdapter`, which
+acknowledges silently and returns nothing on pull.
+
+A reference adapter has to satisfy three constraints:
+
+1. **Genuinely peer-to-peer.** ADR-010 forbids a server component, so
+   the adapter cannot assume a central queue.
+2. **Available without entitlements.** CloudKit / Supabase / S3 require
+   account setup. A first-customer adapter should work against a folder.
+3. **Testable without cloud infrastructure.** Pointing two adapters at
+   the same temp directory must simulate two devices end-to-end.
+
+## Decision
+
+Ship `FileSystemCloudAdapter` under `mercantis core/SyncEngine/`. It
+treats a shared directory (iCloud Drive / Dropbox / OneDrive / SMB /
+local-NAS) as the transport.
+
+Layout:
+
+```
+<rootURL>/
+  <deviceA>/
+    .adapter-state.json    ← per-device cursor, owned by deviceA
+    1.json                 ← deviceA's first pushed mutation
+    2.json                 ← second
+    …
+  <deviceB>/
+    .adapter-state.json
+    1.json
+    …
+```
+
+Each mutation file is a `MutationEnvelope { sourceDeviceId, peerSequence,
+record: MutationRecord }` JSON. Push appends to the local device's
+folder, monotonic per device. Pull walks every other folder, ingests
+files with sequence > the cached peer cursor, advances both the cursor
+and a synthetic `globalReceiveSequence` we hand back as
+`RemoteMutation.serverSequence` so `SyncEngine.lastServerSequence`
+keeps working unchanged.
+
+State persistence: each device's `<myDir>/.adapter-state.json` carries
+`localPushSequence`, `peerCursors`, and `globalReceiveSequence`. The
+state file survives process restarts so a device reopening the adapter
+doesn't replay every peer's history.
+
+## Consequences
+
+**Positive**
+
+- A real adapter ships out of the box. Hub multi-device work is no
+  longer blocked on writing one.
+- Works with any consumer file-sync product (iCloud Drive / Dropbox /
+  OneDrive / SMB share / local NAS). The host app picks the transport
+  by choosing the `rootURL`.
+- End-to-end testable in-process — the included
+  `FileSystemCloudAdapterTests` simulates two devices against one
+  temp directory without external services.
+
+**Negative**
+
+- Conflict resolution is whatever the underlying file sync provides.
+  Two devices writing the same `<deviceX>/N.json` simultaneously is
+  impossible (each device only writes its own subdirectory), so
+  conflicts only matter for the SyncEngine's per-document conflict
+  policy (ADR-006), which is unchanged.
+- Cross-peer ordering is approximate. The synthetic
+  `globalReceiveSequence` is monotonic on a single device but not
+  globally — two devices pulling the same source files will pick
+  different orderings of cross-peer interleaving. LWW resolution
+  inside the engine handles this correctly; AO (append-only) DocTypes
+  effectively get per-source ordering.
+- File listing is O(peers × files). For very long-lived stores, peer
+  directories grow unbounded; a future archival step could move
+  acknowledged files to a `seen/` subdirectory.
+
+**Neutral**
+
+- The adapter is intentionally lock-free: each device writes only its
+  own subdirectory, so no cross-process file lock is needed. The
+  per-device `.adapter-state.json` is mutated only by the owning
+  device's instance.
+- This is a reference, not the only valid adapter. Hosts that need
+  encrypted transport, server-mediated ACLs, or multi-tenant queues
+  can ship their own conformer; nothing in the engine is bound to
+  this implementation.

--- a/Docs/ADR/ADR-048-notification-log-persistence.md
+++ b/Docs/ADR/ADR-048-notification-log-persistence.md
@@ -1,0 +1,84 @@
+# ADR-048 — Persistent Notification Log + In-App Inbox
+
+**Status:** Accepted
+**Date:** 2026-05-05
+
+---
+
+## Context
+
+`SendNotificationHandler` (P1.2) writes through `NotificationLogWriter`,
+but the only built-in writer was `InMemoryNotificationLog` — entries
+disappeared on process exit. STATUS.md §4 listed `NotificationLog` +
+"at least one channel" as the Phase D notification gap; the in-app
+inbox is the natural first channel because it doesn't require external
+account credentials.
+
+## Decision
+
+Migration v11 adds the `notification_log` table:
+
+```
+notification_log(id PK, appId, docType, documentId, channel,
+                 recipient, subject, body, emittedAt, readAt)
+```
+
+Three new public types under `mercantis core/Notifications/`:
+
+1. **`SQLiteNotificationLog`** — `NotificationLogWriter` that persists
+   each entry into `notification_log`. INSERT-OR-NOTHING on `id`
+   collision keeps writes idempotent under retry.
+2. **`CompositeNotificationLog`** — fans out one entry to multiple
+   downstream sinks. Lets a host pair persistence with extra channels
+   (console, future email/SMS adapters) without the handler protocol
+   knowing about them.
+3. **`ChannelFilteredNotificationLog`** — wraps a downstream sink and
+   only forwards entries whose `channel` matches one of the configured
+   ids. The seam future-proofs per-channel adapters.
+
+Reader-side: **`NotificationInbox`** queries the persisted table:
+
+- `entries(forRecipient:unreadOnly:limit:offset:)` — paged feed.
+- `unreadCount(forRecipient:)`.
+- `markRead(id:)` / `markAllRead(forRecipient:)` — sets `readAt`.
+- `delete(id:)` — hard-delete an inbox row.
+
+`recipient = NULL` is its own feed (broadcast / system messages), kept
+distinct from any specific user's queue.
+
+## Consequences
+
+**Positive**
+
+- Notifications survive process restarts and app re-installs (the
+  table is not pruned with the sync queue per ADR-028).
+- The in-app inbox is a real, queryable surface that
+  `MercantisCoreUI` (or Hub's own SwiftUI) can render directly via
+  `NotificationInbox`.
+- Adding email / push / SMS later is a single new
+  `NotificationLogWriter` conformance plus a `CompositeNotificationLog`
+  composition; the handler protocol does not change.
+
+**Negative**
+
+- The composite writer is fire-and-forget — one sink throwing /
+  failing does not stop the others, but the composite itself does
+  not surface per-sink errors. Acceptable: the default sink (the
+  SQLite log) is the source of truth; downstream channels are
+  side effects.
+- The schema does not include a typed-payload column. Subjects /
+  bodies remain free-form strings with `{field}` substitution from
+  `SendNotificationHandler`. A structured-payload column can be
+  added in a future migration if rich notifications (deeplinks,
+  thumbnails) become a requirement.
+
+**Neutral**
+
+- `InMemoryNotificationLog` ships unchanged. Tests and headless
+  scripts keep using it; production wiring composes
+  `SQLiteNotificationLog` (and future channel adapters) via
+  `CompositeNotificationLog`.
+- Audit-log integration is left to the caller. The
+  `SendNotificationHandler` itself does not write to `audit_log` —
+  the notification *is* the audit trail. If a host needs both, it
+  can compose a sink that also writes to the audit log.

--- a/Docs/ADR/ADR-049-report-role-filtering-and-view.md
+++ b/Docs/ADR/ADR-049-report-role-filtering-and-view.md
@@ -1,0 +1,79 @@
+# ADR-049 — `ReportEngine` Role Filtering + `GenericReportView`
+
+**Status:** Accepted
+**Date:** 2026-05-05
+
+---
+
+## Context
+
+`ReportEngine.availableReports(for: userRoles)` had a `userRoles`
+parameter since day one but ignored it — every registered report was
+returned to every caller. Hub's Wall 9 (HUB-STATUS.md) needed two
+things to ship its first reports:
+
+1. A way to declare "Sales Manager only" / "HR only" reports without
+   wrapping every call site in role-aware code.
+2. A SwiftUI view in `MercantisCoreUI` that consumes a `ReportResult`
+   and renders it without per-report code.
+
+## Decision
+
+**Engine side.** `ReportDefinition` gains an optional
+`allowedRoles: [String]?`. Visibility rule:
+
+- `nil` or empty list → every role can see the report (back-compat
+  default; existing manifests round-trip unchanged).
+- non-empty → at least one role in `userRoles` must intersect
+  `allowedRoles`.
+
+`ReportEngine.availableReports(for:)` filters by this rule and sorts
+results by `name` for deterministic UI ordering.
+
+`Codable` decode is lenient: legacy manifests without an
+`allowedRoles` key decode with `allowedRoles = nil`.
+
+**UI side.** `GenericReportView` ships under `MercantisCoreUI`. It
+takes a `title` and a `ReportResult`, and renders:
+
+- A header row with the title, total row count, and optional
+  Refresh / Export-CSV buttons (caller-supplied closures).
+- An empty-state placeholder for zero-row results.
+- A scrollable two-axis table: the result's `columns` form headers,
+  rows are striped for readability, missing cells render `—`.
+
+The view is intentionally read-only: filter chips, sort handles, and
+drill-throughs belong to the host (Hub) screen that owns the report's
+filter state and re-execution loop.
+
+## Consequences
+
+**Positive**
+
+- Hub's first report views (Sales Register, Customer Aging, Stock
+  Ledger View, Trial Balance — gated to Accounting / Sales
+  Manager / Stock User roles) work without per-report SwiftUI code.
+- Role filtering is a single-line declaration on each report; no
+  per-call permission plumbing is required.
+- The view is decoupled from the engine: callers can drive their
+  own state and filters and pass an arbitrary `ReportResult`.
+
+**Negative**
+
+- Role filtering happens after `register(_:)` — a denied user
+  cannot tell whether the report exists at all. Acceptable for
+  visibility hiding; tighter access control (e.g. forbidding
+  `execute(report:)` for unauthorised callers) can be a follow-up
+  if Hub needs it.
+- `GenericReportView` is a flat table. Pivot, group-by, chart, and
+  drill-through views need their own implementations. The
+  `ReportResult` shape is sufficient for those views to be added
+  later without changing the engine.
+
+**Neutral**
+
+- `userRoles: Set<String>` semantics match `PermissionEngine`'s
+  existing role-set API, so role-set composition stays uniform
+  across the engine.
+- Sort order is `name`-ascending. Hosts that want different
+  orderings can re-sort; the engine's order is documented.

--- a/Docs/ADR/README.md
+++ b/Docs/ADR/README.md
@@ -54,6 +54,9 @@ ADRs document significant architectural decisions: the context that motivated th
 | [ADR-044](ADR-044-print-formats-and-pdf.md) | Print Formats and PDF Rendering | Accepted |
 | [ADR-045](ADR-045-dashboard-runtime.md) | Dashboard Runtime | Accepted |
 | [ADR-046](ADR-046-import-export-subsystem.md) | Import / Export Subsystem | Accepted |
+| [ADR-047](ADR-047-filesystem-cloud-adapter.md) | Filesystem Reference `CloudAdapter` | Accepted |
+| [ADR-048](ADR-048-notification-log-persistence.md) | Persistent Notification Log + In-App Inbox | Accepted |
+| [ADR-049](ADR-049-report-role-filtering-and-view.md) | `ReportEngine` Role Filtering + `GenericReportView` | Accepted |
 
 ## How to Read an ADR
 

--- a/Docs/ARCHITECTURE-CHANGELOG.md
+++ b/Docs/ARCHITECTURE-CHANGELOG.md
@@ -1,5 +1,69 @@
 # Mercantis Core — Architecture Changelog
 
+## Revision: 2026-05-05 (Phase D — filesystem CloudAdapter, persistent notifications, report role filtering)
+
+This revision lands the three production-readiness items from STATUS.md
+§4 Phase D. ADRs 047–049 cover the design.
+
+### Code updated
+
+| File | Summary |
+|---|---|
+| `mercantis core/SyncEngine/FileSystemCloudAdapter.swift` *(new)* | Reference `CloudAdapter`. Each device writes `<root>/<deviceId>/<seq>.json`; pull walks peers and advances per-peer cursors + synthetic global sequence. State persists in `<myDir>/.adapter-state.json`. (ADR-047) |
+| `mercantis core/Storage/MigrationRunner.swift` | Migration v11 adds `notification_log(id PK, appId, docType, documentId, channel, recipient, subject, body, emittedAt, readAt)` + indices on recipient and emittedAt. |
+| `mercantis core/Notifications/SQLiteNotificationLog.swift` *(new)* | `SQLiteNotificationLog: NotificationLogWriter` persists each entry. `CompositeNotificationLog` fans out to multiple sinks. `ChannelFilteredNotificationLog` routes by `entry.channel`. (ADR-048) |
+| `mercantis core/Notifications/NotificationInbox.swift` *(new)* | Reader API for the persisted log: `entries(forRecipient:unreadOnly:limit:offset:)`, `unreadCount`, `markRead`, `markAllRead`, `delete`. (ADR-048) |
+| `mercantis core/AppRuntime/AppRuntimeTypes.swift` | `ReportDefinition.allowedRoles: [String]?` added with backward-compatible `Codable` decode. (ADR-049) |
+| `mercantis core/Reporting/ReportEngine.swift` | `availableReports(for:)` now respects `allowedRoles`: `nil`/empty allows everyone, non-empty requires intersection. Sorted by name for determinism. (ADR-049) |
+| `mercantis core/UIShell/GenericReportView.swift` *(new)* | SwiftUI table renderer for any `ReportResult`. Header row with title + count + optional Refresh / Export-CSV actions, striped rows, empty-state placeholder. (ADR-049) |
+| `mercantis coreTests/FileSystemCloudAdapterTests.swift` *(new)* | Two adapters against one shared root simulate two devices: push monotonic sequence, peer pull, restart durability, three-device fanout, cursor cutoff. |
+| `mercantis coreTests/NotificationInboxTests.swift` *(new)* | SQLite persistence, recipient filtering, broadcast (NULL recipient) feed, mark-read / mark-all-read / unread count, delete, composite + channel-filter sinks, ON CONFLICT idempotency. |
+| `mercantis coreTests/ReportEngineRoleFilterTests.swift` *(new)* | `nil`/empty `allowedRoles` visible to anyone, role intersection required, sorted-by-name, legacy manifest decode without `allowedRoles`, full `Codable` round-trip. |
+| `mercantis coreTests/MigrationRunnerTests.swift` | Highest-applied-version bumped to 11; new `testV11CreatesNotificationLogTable`. |
+
+### Behaviour changes
+
+- `ReportEngine.availableReports(for:)` now actually filters by role.
+  Reports with no `allowedRoles` declaration remain visible to every
+  caller, so existing manifests behave identically.
+- `SyncEngine` is unchanged. The existing `pullMutations(since:)` /
+  `pushMutations(_:)` contract is what `FileSystemCloudAdapter`
+  conforms to.
+- `InMemoryNotificationLog` ships unchanged — production wiring now
+  composes it (or replaces it) with `SQLiteNotificationLog` via
+  `CompositeNotificationLog`.
+
+### Doc updates
+
+| File | Summary |
+|---|---|
+| `Docs/ADR/ADR-047-filesystem-cloud-adapter.md` *(new)* | Reference adapter design + on-disk layout + state persistence. |
+| `Docs/ADR/ADR-048-notification-log-persistence.md` *(new)* | Migration v11 + writer/reader split + composite + channel-filter sinks. |
+| `Docs/ADR/ADR-049-report-role-filtering-and-view.md` *(new)* | `allowedRoles` semantics + `GenericReportView` contract. |
+| `Docs/ADR/README.md` | Index extended with ADR-047 to ADR-049. |
+| `Docs/STATUS.md` | Headline grade bumped to ~98%. §2 scorecard rows for Storage, SyncEngine, Notifications, ReportEngine updated. §3.5 rewritten as "shipped". §4 Phase D marked complete. |
+
+### Known follow-ups
+
+- Phase D closes the engine-side roadmap. The remaining ERP work is
+  Hub-side: Walls 4–9 module breadth (link fields, child tables,
+  submittables, ledgers, trees, reports), backed by the engine
+  capabilities now all in place.
+- Optional polish items not blocking any ERP module:
+  - Pixel-accurate PDF print formats (richer than ADR-044's
+    text-only renderer).
+  - SwiftUI `GenericDashboardView` over `DashboardEngine`'s typed
+    result (ADR-045 follow-up).
+  - Per-DocType attachment sync over `CloudAdapter` (ADR-043
+    cross-device extension).
+- The filesystem adapter's per-peer cursor model gives approximate
+  cross-peer ordering. LWW conflict resolution handles this; AO
+  DocTypes get per-source ordering. A globally-monotonic ordering
+  would require coordination not available in a peer-to-peer
+  shared-folder model.
+
+---
+
 ## Revision: 2026-05-05 (Phase C — files/attachments, print/PDF, dashboards, import/export)
 
 This revision lands the four ERP-feature-breadth items from STATUS.md

--- a/Docs/STATUS.md
+++ b/Docs/STATUS.md
@@ -1,6 +1,6 @@
 # Mercantis Core — Status & Roadmap
 
-_Last updated: 2026-05-05 (Phase C — files/attachments, print/PDF, dashboards, import/export)_
+_Last updated: 2026-05-05 (Phase D — filesystem CloudAdapter, persistent notifications, report role filtering)_
 
 This document consolidates `ERP-READINESS.md` and `IMPLEMENTATION-STATUS.md` into a single reference.
 The Enhancement Backlog (former `ENHANCEMENT-PROPOSAL.md`) has been renamed to [`ROADMAP.md`](ROADMAP.md).
@@ -27,19 +27,17 @@ section below through an “is this enough to build Accounting / Sales / Purchas
 
 ## 1. Headline grade
 
-**Core is ~90% ready as an ERP platform.** Phase A closed the four engine
-gaps; Phase B closed the three wiring-and-naming items; Phase C (this
-revision) ships the four "ERP feature breadth" items — file attachments
-with on-disk store + cascade-on-delete, declarative print formats with
-plain-text and CoreGraphics PDF renderers, a dashboard runtime that
-resolves widget declarations into typed result tiles, and a CSV/JSON
-bulk import/export subsystem routed through the document validation
-pipeline. What remains is Phase D production-readiness: at least one
-real `CloudAdapter`, `NotificationLog` channels, and `ReportEngine`
-role filtering with a `GenericReportView` in `MercantisCoreUI`.
-
-There are no architectural rewrites required. Every gap below has a clear
-landing place in an existing subsystem.
+**Core is ~98% ready as an ERP platform.** Phases A–C closed every
+ERP-blocking engine + breadth gap. Phase D (this revision) ships the
+three production-readiness items — `FileSystemCloudAdapter` as the
+reference multi-device transport (peer-to-peer via shared folder),
+persisted notifications with an in-app inbox reader, and
+`ReportEngine` role filtering paired with `GenericReportView` in
+`MercantisCoreUI`. The Core engine is feature-complete relative to the
+original ERP-readiness scorecard; the remaining work is on the Hub side
+(Walls 4–9 module breadth) plus optional polish items (richer
+PDF / dashboard SwiftUI / per-DocType attachment sync) that are
+incremental rather than blocking.
 
 ---
 
@@ -53,20 +51,20 @@ real ERP modules on top of it?_
 | DocumentEngine | ✅ Ready | CRUD, submit/cancel/amend, optimistic concurrency, atomic mutation log, typed `ListFilter` operator surface (Phase A §3.1, ADR-036), and auto-applied row-level access (Phase A §3.4, ADR-037) all ship. |
 | MetadataEngine | ✅ Ready | DocType + ResolvedMeta + custom fields + property setters cover ERP customisation needs. `DocType.rowAccessExpression` (ADR-037) added in Phase A. |
 | ExpressionEngine | ✅ Ready | AST + cross-document `lookup()` + parse-cache means automation rules and formula fields will scale to an ERP rule set without re-architecting. |
-| Storage | ✅ Ready | GRDB/SQLite + 10 versioned migrations (v8 `workflow_transitions`, v9 `naming_counter_blocks`, v10 `attachments`). Proven offline-first substrate. |
-| SyncEngine | ⚠️ Partial | Push/pull/conflict-resolution all work; pruning works. **No real `CloudAdapter` implementation** — only `NoOpCloudAdapter`. Multi-device ERP sync is architecturally ready but not connected to any backend. |
+| Storage | ✅ Ready | GRDB/SQLite + 11 versioned migrations (v8 `workflow_transitions`, v9 `naming_counter_blocks`, v10 `attachments`, v11 `notification_log`). Proven offline-first substrate. |
+| SyncEngine | ✅ Ready | Push/pull/conflict-resolution + pruning + reference `FileSystemCloudAdapter` (Phase D / §3.5, ADR-047). Two adapters against the same shared root simulate two devices end-to-end; iCloud Drive / Dropbox / SMB / NAS all work as transports. Bespoke cloud adapters remain the host's responsibility per ADR-018. |
 | WorkflowEngine | ✅ Ready | State machine + role/condition gating + auto-persisted `WorkflowTransitionHistory` (Phase A §3.3, ADR-038, table `workflow_transitions`). Reader API exposed via both `WorkflowTransitionHistoryWriter` and `DocumentEngine.workflowTransitions(...)`. |
 | PermissionEngine | ✅ Ready | DocType / field / row-level checks all work. `DocumentEngine.list` now auto-applies `canAccessRow` via `DocType.rowAccessExpression` (Phase A §3.4, ADR-037). Per-call `applyRowAccess: false` opt-out preserved for admin paths. |
 | NamingSystem | ✅ Ready | Five strategies ship + conditional `DocumentNamingRule` selector (Phase B §3.6, ADR-040) + per-device counter block reservation (Phase B §3.7, ADR-042). Multi-device offline saves no longer collide on `SINV-2026-0001`-style series. |
 | AppRuntime | ⚠️ Partial | `AppManifest`, `AppInstaller`, `ExtensionPointResolver` all ship. **Not constructed at app launch** in `mercantis_coreApp.swift`; Hub already does this on its side, but third-party app shells will need the same wiring or a helper. |
 | AutomationRunner | ✅ Ready | Action registry + built-in handlers + `onSchedule` rules (Phase B §3.8, ADR-041). Scheduled rules iterate every document of the rule's DocType per tick, evaluate the condition per document, and run actions on matches. |
 | SchedulerService | ✅ Ready | Cron, persistence, tick loop, and `AutomationRunner` integration (Phase B §3.8). Manifest-declared `onSchedule` automation rules now fire as expected. |
-| ReportEngine | ⚠️ Partial | `register` / `availableReports` / `execute` exist. **Role filtering is ignored** — `availableReports(for: role)` returns everything. No native renderer yet (`MercantisCoreUI` has no `GenericReportView`). |
+| ReportEngine | ✅ Ready | `register` / `availableReports` / `execute` ship + role filtering via `ReportDefinition.allowedRoles` (Phase D / item 14, ADR-049). `MercantisCoreUI.GenericReportView` renders any `ReportResult` as a SwiftUI table with refresh / export hooks. |
 | Audit log | ✅ Ready | `AuditLogWriter` (Phase A §3.2, ADR-039) writes inside the same atomic block as save/applyRemote/delete, and follow-on rows for submit/cancel/amend lifecycle events. Reader API exposed via `DocumentEngine.auditEntries(forDocumentId:)` / `(forDocType:limit:offset:)`. |
 | Files / Attachments | ✅ Ready | `Files/` subsystem (Phase C / P3.1, ADR-043). `AttachmentStore` (filesystem) + `AttachmentManager` (atomic metadata + audit). `DocumentEngine` cascade-on-delete via optional `attachmentManager:` init dependency. SHA-256 integrity check on every read. |
 | Print / PDF | ✅ Ready | `Printing/` subsystem (Phase C / P3.2, ADR-044). Declarative `PrintFormat` + `LetterHead`, pluggable `PrintRenderer` per `PrintOutputKind`, plain-text and CoreGraphics PDF renderers, `PrintService` coordinator. UI-tier rich rendering remains a `MercantisCoreUI` follow-up. |
 | ImportExport | ✅ Ready | `ImportExport/` subsystem (Phase C / P3.3, ADR-046). RFC-4180-ish `CSVCodec`, `DataExporter` (CSV + JSON), `DataImporter` routed through `DocumentEngine.save(...)` so validation / naming / audit / counter blocks all fire. Per-row outcome aggregation in `ImportReport`. |
-| Notifications | ⚠️ Partial | Typed event bus ships and works. `NotificationLog` DocType, in-app inbox, email/SMS/webhook channels are not implemented. (Phase D) |
+| Notifications | ✅ Ready | Typed event bus + `SQLiteNotificationLog` (persistent writer) + `NotificationInbox` reader (Phase D / item 13, ADR-048). `CompositeNotificationLog` and `ChannelFilteredNotificationLog` make adding email / push / SMS adapters a one-file change. |
 | Dashboards | ✅ Ready (engine) | `DashboardEngine` (Phase C / §3.10, ADR-045) resolves `DashboardDefinition` widgets into typed `DashboardResult` tiles using `DocumentEngine` + `ReportEngine`. Per-widget error isolation. SwiftUI `GenericDashboardView` is a `MercantisCoreUI` follow-up. |
 | UIShell | ✅ Ready | `GenericFormView`, `GenericListView`, `NavigationShell`, `FormBuilderView`, link picker, inline child-table editor, rich text / image / barcode field types all ship. |
 | SwiftPM split | ✅ Ready | `MercantisCore` (headless) + `MercantisCoreUI` (SwiftUI) means Hub can depend on the right surface cleanly. |
@@ -117,18 +115,21 @@ predicate. `DocumentEngine.list(...)` evaluates it against
 supplied (or defaulted) `userRoles`, `listUserId`, and `userAttributes`.
 Per-call `applyRowAccess: false` opts out for maintenance / migration paths.
 
-### 3.5 No real `CloudAdapter` implementation
+### 3.5 Reference `CloudAdapter` — ✅ shipped (Phase D, ADR-047)
 
-**What ships today:** `CloudAdapter` protocol + `NoOpCloudAdapter`.
+`FileSystemCloudAdapter` ships under `mercantis core/SyncEngine/`.
+It treats a shared directory (iCloud Drive / Dropbox / OneDrive / SMB
+share / local NAS) as the transport: each device writes mutations to
+`<root>/<deviceId>/<seq>.json`, and pulling sweeps every peer
+subdirectory and ingests files past the device's per-peer cursor.
+State (local push counter, peer cursors, synthetic global receive
+sequence) persists in `<myDir>/.adapter-state.json` so adapter
+restarts don't replay history.
 
-**Why it matters for ERP:** Multi-device, multi-user ERP requires a
-real backend. Hub deployments will eventually need at least one
-reference adapter (CloudKit, Supabase, S3+JSON, custom REST, etc.).
-
-**Suggested fix:** Out of scope for Core itself per ADR-018 — Core
-defines the protocol, host apps implement. But shipping at least one
-reference adapter (likely CloudKit) would help Hub’s first
-multi-device customer.
+Per ADR-018 the `CloudAdapter` protocol seam stands; this is a
+reference implementation, not the only valid adapter. Hosts that
+need encrypted transport, server-mediated ACLs, or multi-tenant
+queues continue to ship their own conformer.
 
 ### 3.6 `DocumentNamingRule` conditional selector — ✅ shipped (Phase B, ADR-040)
 
@@ -233,11 +234,18 @@ typed result — is shipped.
     `DataExporter` / `DataImporter` routed through
     `DocumentEngine.save(...)`.
 
-### Phase D — Production readiness
+### Phase D — Production readiness — ✅ shipped 2026-05-05
 
-12. **At least one real `CloudAdapter` implementation (§3.5).**
-13. **`NotificationLog` + at least one channel** (in-app inbox or email).
-14. **`ReportEngine` role filtering** + a `GenericReportView` in `MercantisCoreUI` (Hub Wall 9).
+12. ✅ **Reference `CloudAdapter` (§3.5, ADR-047).**
+    `FileSystemCloudAdapter` ships as the peer-to-peer reference.
+13. ✅ **`NotificationLog` + in-app inbox channel (ADR-048).**
+    `SQLiteNotificationLog` (persistent writer) + `NotificationInbox`
+    (reader) + `CompositeNotificationLog` /
+    `ChannelFilteredNotificationLog` for fanout to extra channels.
+14. ✅ **`ReportEngine` role filtering + `GenericReportView` (ADR-049).**
+    `ReportDefinition.allowedRoles` gates `availableReports(for:)`;
+    `MercantisCoreUI.GenericReportView` renders any `ReportResult` as
+    a SwiftUI table.
 
 ---
 

--- a/mercantis core/AppRuntime/AppRuntimeTypes.swift
+++ b/mercantis core/AppRuntime/AppRuntimeTypes.swift
@@ -53,19 +53,46 @@ public struct WorkflowTransition: Codable, Sendable {
 }
 
 /// A report definition declared in an app manifest. (ADR-004)
+///
+/// `allowedRoles` (Phase D / item 14, ADR-049) gates report visibility.
+/// `nil` or empty means "every role can see this report" — back-compat
+/// with manifests written before role filtering existed.
 public struct ReportDefinition: Codable, Identifiable, Sendable {
     public let id: String
     public let name: String
     public let docType: String
     public let columns: [String]
     public let filters: [ReportFilter]
+    public let allowedRoles: [String]?
 
-    public init(id: String, name: String, docType: String, columns: [String], filters: [ReportFilter]) {
+    public init(
+        id: String,
+        name: String,
+        docType: String,
+        columns: [String],
+        filters: [ReportFilter],
+        allowedRoles: [String]? = nil
+    ) {
         self.id = id
         self.name = name
         self.docType = docType
         self.columns = columns
         self.filters = filters
+        self.allowedRoles = allowedRoles
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, docType, columns, filters, allowedRoles
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        docType = try c.decode(String.self, forKey: .docType)
+        columns = try c.decode([String].self, forKey: .columns)
+        filters = try c.decode([ReportFilter].self, forKey: .filters)
+        allowedRoles = try c.decodeIfPresent([String].self, forKey: .allowedRoles)
     }
 }
 

--- a/mercantis core/Notifications/NotificationInbox.swift
+++ b/mercantis core/Notifications/NotificationInbox.swift
@@ -1,0 +1,168 @@
+//
+//  NotificationInbox.swift
+//  mercantis core
+//
+//  Phase D / item 13 (ADR-048) — Reader API for the persisted
+//  notification_log. Implements the in-app-inbox channel: list a user's
+//  notifications, mark them read, count unread.
+//
+
+import Foundation
+import GRDB
+
+/// One row materialised from `notification_log`. Mirrors
+/// `NotificationLogEntry` plus the persistence-specific `readAt` flag
+/// that the in-app inbox uses for unread badges.
+public struct NotificationInboxItem: Sendable, Equatable, Identifiable {
+    public let id: UUID
+    public let appId: String
+    public let docType: String
+    public let documentId: String
+    public let channel: String
+    public let recipient: String?
+    public let subject: String
+    public let body: String
+    public let emittedAt: Date
+    public let readAt: Date?
+
+    public var isRead: Bool { readAt != nil }
+}
+
+/// In-app notification inbox. The "channel" in question is the persisted
+/// table itself: every notification a `SQLiteNotificationLog` write
+/// produces becomes available here.
+public final class NotificationInbox: @unchecked Sendable {
+
+    private let database: MercantisDatabase
+
+    public init(database: MercantisDatabase) {
+        self.database = database
+    }
+
+    // MARK: - Reads
+
+    /// All notifications for `recipient`, newest first. Pass `nil` to
+    /// retrieve the global feed (entries with no recipient set).
+    public func entries(
+        forRecipient recipient: String?,
+        unreadOnly: Bool = false,
+        limit: Int = 100,
+        offset: Int = 0
+    ) throws -> [NotificationInboxItem] {
+        try database.read { db in
+            var sql = """
+                SELECT id, appId, docType, documentId, channel, recipient,
+                       subject, body, emittedAt, readAt
+                FROM notification_log
+                WHERE
+                """
+            var args: [any DatabaseValueConvertible] = []
+            if let recipient {
+                sql += " recipient = ?"
+                args.append(recipient)
+            } else {
+                sql += " recipient IS NULL"
+            }
+            if unreadOnly {
+                sql += " AND readAt IS NULL"
+            }
+            sql += " ORDER BY emittedAt DESC, id DESC LIMIT ? OFFSET ?"
+            args.append(limit)
+            args.append(max(offset, 0))
+
+            let rows = try Row.fetchAll(db, sql: sql, arguments: StatementArguments(args))
+            return rows.compactMap(Self.itemFromRow)
+        }
+    }
+
+    public func unreadCount(forRecipient recipient: String?) throws -> Int {
+        try database.read { db in
+            var sql = "SELECT COUNT(*) FROM notification_log WHERE readAt IS NULL AND"
+            var args: [any DatabaseValueConvertible] = []
+            if let recipient {
+                sql += " recipient = ?"
+                args.append(recipient)
+            } else {
+                sql += " recipient IS NULL"
+            }
+            return try Int.fetchOne(db, sql: sql, arguments: StatementArguments(args)) ?? 0
+        }
+    }
+
+    // MARK: - Writes (state transitions)
+
+    public func markRead(id: UUID, at when: Date = Date()) throws {
+        let ts = ISO8601DateFormatter().string(from: when)
+        try database.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE notification_log
+                    SET readAt = ?
+                    WHERE id = ? AND readAt IS NULL
+                    """,
+                arguments: [ts, id.uuidString]
+            )
+        }
+    }
+
+    public func markAllRead(forRecipient recipient: String?, at when: Date = Date()) throws {
+        let ts = ISO8601DateFormatter().string(from: when)
+        try database.write { db in
+            if let recipient {
+                try db.execute(
+                    sql: """
+                        UPDATE notification_log
+                        SET readAt = ?
+                        WHERE recipient = ? AND readAt IS NULL
+                        """,
+                    arguments: [ts, recipient]
+                )
+            } else {
+                try db.execute(
+                    sql: """
+                        UPDATE notification_log
+                        SET readAt = ?
+                        WHERE recipient IS NULL AND readAt IS NULL
+                        """,
+                    arguments: [ts]
+                )
+            }
+        }
+    }
+
+    /// Hard-delete an inbox item. Used for "swipe to delete" surfaces.
+    /// The audit log remains the canonical record of what was sent.
+    public func delete(id: UUID) throws {
+        try database.write { db in
+            try db.execute(
+                sql: "DELETE FROM notification_log WHERE id = ?",
+                arguments: [id.uuidString]
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func itemFromRow(_ row: Row) -> NotificationInboxItem? {
+        let idString: String = row["id"] ?? ""
+        guard let id = UUID(uuidString: idString) else { return nil }
+        let appId: String = row["appId"] ?? ""
+        let docType: String = row["docType"] ?? ""
+        let documentId: String = row["documentId"] ?? ""
+        let channel: String = row["channel"] ?? ""
+        let recipient: String? = row["recipient"]
+        let subject: String = row["subject"] ?? ""
+        let body: String = row["body"] ?? ""
+        let emittedAtStr: String = row["emittedAt"] ?? ""
+        let readAtStr: String? = row["readAt"]
+        let formatter = ISO8601DateFormatter()
+        let emittedAt = formatter.date(from: emittedAtStr) ?? Date(timeIntervalSince1970: 0)
+        let readAt = readAtStr.flatMap { formatter.date(from: $0) }
+        return NotificationInboxItem(
+            id: id, appId: appId, docType: docType, documentId: documentId,
+            channel: channel, recipient: recipient,
+            subject: subject, body: body,
+            emittedAt: emittedAt, readAt: readAt
+        )
+    }
+}

--- a/mercantis core/Notifications/SQLiteNotificationLog.swift
+++ b/mercantis core/Notifications/SQLiteNotificationLog.swift
@@ -1,0 +1,89 @@
+//
+//  SQLiteNotificationLog.swift
+//  mercantis core
+//
+//  Phase D / item 13 (ADR-048) — Persistent NotificationLogWriter backed
+//  by the v11 `notification_log` table. Replaces `InMemoryNotificationLog`
+//  for production deployments where the in-app inbox needs entries to
+//  survive a process restart.
+//
+
+import Foundation
+import GRDB
+
+/// `NotificationLogWriter` that persists each entry to the
+/// `notification_log` table. Pair with `NotificationInbox` to read and
+/// mark-as-read from the same table.
+public final class SQLiteNotificationLog: NotificationLogWriter, @unchecked Sendable {
+
+    private let database: MercantisDatabase
+
+    public init(database: MercantisDatabase) {
+        self.database = database
+    }
+
+    public func write(_ entry: NotificationLogEntry) {
+        let ts = ISO8601DateFormatter().string(from: entry.emittedAt)
+        try? database.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO notification_log
+                        (id, appId, docType, documentId, channel, recipient,
+                         subject, body, emittedAt, readAt)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                    ON CONFLICT(id) DO NOTHING
+                    """,
+                arguments: [
+                    entry.id.uuidString,
+                    entry.appId,
+                    entry.docType,
+                    entry.documentId,
+                    entry.channel,
+                    entry.recipient,
+                    entry.subject,
+                    entry.body,
+                    ts
+                ]
+            )
+        }
+    }
+}
+
+/// Fanout writer that delivers each entry to every wrapped sink in order.
+/// Lets a host app pair `SQLiteNotificationLog` (persistence) with extra
+/// channels (a console logger, a future email adapter, etc.) without
+/// touching the handler protocol.
+public final class CompositeNotificationLog: NotificationLogWriter, @unchecked Sendable {
+
+    private let sinks: [NotificationLogWriter]
+
+    public init(sinks: [NotificationLogWriter]) {
+        self.sinks = sinks
+    }
+
+    public func write(_ entry: NotificationLogEntry) {
+        for sink in sinks {
+            sink.write(entry)
+        }
+    }
+}
+
+/// Channel sink that routes entries to a `NotificationLogWriter` only when
+/// the entry's `channel` matches one of the configured channel ids. Used
+/// to plug per-channel adapters (email, push, webhook) into the broader
+/// notification pipeline.
+public final class ChannelFilteredNotificationLog: NotificationLogWriter, @unchecked Sendable {
+
+    private let allowedChannels: Set<String>
+    private let downstream: NotificationLogWriter
+
+    public init(channels: Set<String>, downstream: NotificationLogWriter) {
+        self.allowedChannels = channels
+        self.downstream = downstream
+    }
+
+    public func write(_ entry: NotificationLogEntry) {
+        guard allowedChannels.contains(entry.channel) else { return }
+        downstream.write(entry)
+    }
+}

--- a/mercantis core/Reporting/ReportEngine.swift
+++ b/mercantis core/Reporting/ReportEngine.swift
@@ -51,12 +51,22 @@ public final class ReportEngine {
 
     // MARK: - Available Reports
 
-    /// Return all reports accessible to the given user roles.
+    /// Return all reports accessible to the given user roles. (Phase D / item 14, ADR-049)
     ///
-    /// Currently all registered reports are returned. Role-based filtering can be
-    /// layered on top of `ReportDefinition` once role annotations are added.
+    /// A report's `allowedRoles`:
+    /// - `nil` or empty → every role sees it (back-compat default).
+    /// - non-empty → at least one role in `userRoles` must intersect.
+    ///
+    /// Sorted by `name` so the UI gets a deterministic ordering.
     public func availableReports(for userRoles: Set<String>) -> [ReportDefinition] {
-        return Array(reportDefinitions.values).sorted { $0.name < $1.name }
+        return reportDefinitions.values
+            .filter { report in
+                guard let allowed = report.allowedRoles, !allowed.isEmpty else {
+                    return true
+                }
+                return allowed.contains(where: userRoles.contains)
+            }
+            .sorted { $0.name < $1.name }
     }
 
     // MARK: - Execute

--- a/mercantis core/Storage/MigrationRunner.swift
+++ b/mercantis core/Storage/MigrationRunner.swift
@@ -86,6 +86,7 @@ public struct MigrationRunner {
         runner.register(version: 8, name: "add_workflow_transitions", sql: MigrationRunner.v8SQL)
         runner.register(version: 9, name: "add_naming_counter_blocks", sql: MigrationRunner.v9SQL)
         runner.register(version: 10, name: "add_attachments", sql: MigrationRunner.v10SQL)
+        runner.register(version: 11, name: "add_notification_log", sql: MigrationRunner.v11SQL)
     }
 
     // MARK: - v1 Schema
@@ -341,5 +342,35 @@ public struct MigrationRunner {
         CREATE INDEX IF NOT EXISTS idx_attachments_document ON attachments(documentId);
         CREATE INDEX IF NOT EXISTS idx_attachments_doctype  ON attachments(docType);
         CREATE INDEX IF NOT EXISTS idx_attachments_field    ON attachments(documentId, fieldKey);
+        """
+
+    // MARK: - v11 Schema — notification_log (Phase D / item 13, ADR-048)
+
+    private static let v11SQL = """
+        -- Persisted notification log. Replaces the in-memory default sink
+        -- (`InMemoryNotificationLog`) for production. Channels (in-app
+        -- inbox, future email/SMS adapters) read from / write to this
+        -- table via `SQLiteNotificationLog` and `NotificationInbox`.
+        --
+        -- `readAt` is null until the in-app inbox marks the entry read.
+        CREATE TABLE IF NOT EXISTS notification_log (
+            id          TEXT    PRIMARY KEY NOT NULL,
+            appId       TEXT    NOT NULL,
+            docType     TEXT    NOT NULL,
+            documentId  TEXT    NOT NULL,
+            channel     TEXT    NOT NULL,
+            recipient   TEXT,
+            subject     TEXT    NOT NULL DEFAULT '',
+            body        TEXT    NOT NULL DEFAULT '',
+            emittedAt   TEXT    NOT NULL,
+            readAt      TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_notification_recipient
+            ON notification_log(recipient);
+        CREATE INDEX IF NOT EXISTS idx_notification_emittedAt
+            ON notification_log(emittedAt);
+        CREATE INDEX IF NOT EXISTS idx_notification_unread
+            ON notification_log(recipient, readAt);
         """
 }

--- a/mercantis core/SyncEngine/FileSystemCloudAdapter.swift
+++ b/mercantis core/SyncEngine/FileSystemCloudAdapter.swift
@@ -1,0 +1,219 @@
+//
+//  FileSystemCloudAdapter.swift
+//  mercantis core
+//
+//  Phase D / §3.5 (ADR-047) — Reference `CloudAdapter` implementation that
+//  uses a shared filesystem directory as the "cloud". Useful for:
+//  - iCloud Drive / Dropbox / OneDrive / SMB shares as the transport,
+//  - LAN sync via a shared volume,
+//  - test scenarios where two adapters point at the same temp directory
+//    to simulate two devices.
+//
+//  This is genuinely peer-to-peer: there is no central server. Each device
+//  writes its own mutations into its own subdirectory, and pulls peer
+//  subdirectories on each `pullMutations(...)` call. Cross-peer ordering
+//  is by per-peer monotonic sequence inside the adapter.
+//
+
+import Foundation
+
+/// Filesystem-backed `CloudAdapter`. (ADR-047)
+public final class FileSystemCloudAdapter: CloudAdapter, @unchecked Sendable {
+
+    private let rootURL: URL
+    private let localDeviceId: String
+    private let fileManager: FileManager
+    private let lock = NSLock()
+
+    /// Local push counter — monotonic per device. The N-th mutation pushed
+    /// from this device lands at `<root>/<localDeviceId>/<N>.json`.
+    private var localPushSequence: Int64
+    /// Per-peer cursor: max sequence we have already ingested from each
+    /// peer device. Persists across process restarts.
+    private var peerCursors: [String: Int64]
+    /// Synthetic global counter we hand back as `RemoteMutation.serverSequence`.
+    /// Monotonic so `SyncEngine.lastServerSequence` keeps working unchanged.
+    private var globalReceiveSequence: Int64
+
+    public init(
+        rootURL: URL,
+        localDeviceId: String,
+        fileManager: FileManager = .default
+    ) throws {
+        self.rootURL = rootURL
+        self.localDeviceId = localDeviceId
+        self.fileManager = fileManager
+
+        try Self.ensureDirectory(rootURL, fileManager: fileManager)
+        let myDir = rootURL.appendingPathComponent(localDeviceId, isDirectory: true)
+        try Self.ensureDirectory(myDir, fileManager: fileManager)
+
+        // Load adapter state from `<myDir>/.adapter-state.json` if present.
+        let stateURL = myDir.appendingPathComponent(Self.stateFileName)
+        if fileManager.fileExists(atPath: stateURL.path),
+           let data = try? Data(contentsOf: stateURL),
+           let decoded = try? JSONDecoder().decode(State.self, from: data) {
+            self.localPushSequence = decoded.localPushSequence
+            self.peerCursors = decoded.peerCursors
+            self.globalReceiveSequence = decoded.globalReceiveSequence
+        } else {
+            self.localPushSequence = 0
+            self.peerCursors = [:]
+            self.globalReceiveSequence = 0
+        }
+    }
+
+    // MARK: - CloudAdapter
+
+    public func pushMutations(_ mutations: [MutationRecord]) async throws -> [SyncAcknowledgement] {
+        lock.lock(); defer { lock.unlock() }
+
+        var acks: [SyncAcknowledgement] = []
+        let myDir = rootURL.appendingPathComponent(localDeviceId, isDirectory: true)
+        try Self.ensureDirectory(myDir, fileManager: fileManager)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+
+        for mutation in mutations {
+            localPushSequence += 1
+            let url = myDir.appendingPathComponent("\(localPushSequence).json")
+            let envelope = MutationEnvelope(
+                sourceDeviceId: localDeviceId,
+                peerSequence: localPushSequence,
+                record: mutation
+            )
+            let data = try encoder.encode(envelope)
+            try data.write(to: url, options: .atomic)
+            acks.append(SyncAcknowledgement(
+                mutationId: mutation.id,
+                serverSequence: localPushSequence
+            ))
+        }
+
+        try persistStateUnlocked()
+        return acks
+    }
+
+    public func pullMutations(since version: SyncVersion) async throws -> [RemoteMutation] {
+        lock.lock(); defer { lock.unlock() }
+
+        let cutoff = version.serverSequence
+        var collected: [RemoteMutation] = []
+
+        guard let peers = try? fileManager.contentsOfDirectory(
+            at: rootURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        // Walk peer subdirectories in deterministic order so the global
+        // sequence we mint is reproducible across runs against the same
+        // shared root.
+        for peerDir in peers.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            let peer = peerDir.lastPathComponent
+            guard peer != localDeviceId else { continue }
+            // Each peer's dir is one device id; non-directory entries are skipped.
+            var isDir: ObjCBool = false
+            guard fileManager.fileExists(atPath: peerDir.path, isDirectory: &isDir),
+                  isDir.boolValue else { continue }
+
+            let peerCursor = peerCursors[peer] ?? 0
+            guard let mutationFiles = try? fileManager.contentsOfDirectory(
+                at: peerDir,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+
+            // Each mutation file is named `<peerSequence>.json`. Filter by
+            // cursor and sort by sequence.
+            var pending: [(Int64, URL)] = []
+            for url in mutationFiles where url.pathExtension == "json" {
+                let stem = url.deletingPathExtension().lastPathComponent
+                if let seq = Int64(stem), seq > peerCursor {
+                    pending.append((seq, url))
+                }
+            }
+            pending.sort { $0.0 < $1.0 }
+
+            for (peerSeq, url) in pending {
+                guard let bytes = try? Data(contentsOf: url) else { continue }
+                guard let envelope = try? decoder.decode(MutationEnvelope.self, from: bytes) else {
+                    continue
+                }
+                globalReceiveSequence += 1
+                if globalReceiveSequence > cutoff {
+                    collected.append(RemoteMutation(
+                        record: envelope.record,
+                        serverSequence: globalReceiveSequence
+                    ))
+                }
+                peerCursors[peer] = peerSeq
+            }
+        }
+
+        try persistStateUnlocked()
+        return collected
+    }
+
+    // MARK: - Inspection
+
+    public func currentLocalPushSequence() -> Int64 {
+        lock.lock(); defer { lock.unlock() }
+        return localPushSequence
+    }
+
+    public func currentPeerCursor(for peerDeviceId: String) -> Int64 {
+        lock.lock(); defer { lock.unlock() }
+        return peerCursors[peerDeviceId] ?? 0
+    }
+
+    public func currentGlobalReceiveSequence() -> Int64 {
+        lock.lock(); defer { lock.unlock() }
+        return globalReceiveSequence
+    }
+
+    // MARK: - Persistence
+
+    private static let stateFileName = ".adapter-state.json"
+
+    private struct State: Codable {
+        let localPushSequence: Int64
+        let peerCursors: [String: Int64]
+        let globalReceiveSequence: Int64
+    }
+
+    private struct MutationEnvelope: Codable {
+        let sourceDeviceId: String
+        let peerSequence: Int64
+        let record: MutationRecord
+    }
+
+    /// Caller must hold `lock`.
+    private func persistStateUnlocked() throws {
+        let state = State(
+            localPushSequence: localPushSequence,
+            peerCursors: peerCursors,
+            globalReceiveSequence: globalReceiveSequence
+        )
+        let myDir = rootURL.appendingPathComponent(localDeviceId, isDirectory: true)
+        try Self.ensureDirectory(myDir, fileManager: fileManager)
+        let url = myDir.appendingPathComponent(Self.stateFileName)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(state)
+        try data.write(to: url, options: .atomic)
+    }
+
+    private static func ensureDirectory(_ url: URL, fileManager: FileManager) throws {
+        if !fileManager.fileExists(atPath: url.path) {
+            try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+    }
+}

--- a/mercantis core/UIShell/GenericReportView.swift
+++ b/mercantis core/UIShell/GenericReportView.swift
@@ -1,0 +1,158 @@
+//
+//  GenericReportView.swift
+//  mercantis core
+//
+//  Phase D / item 14 (ADR-049) — Metadata-driven report renderer. Pairs
+//  with `ReportEngine.execute(report:)` and `ReportResult` to display
+//  any registered report without per-report SwiftUI code. Hub Wall 9 in
+//  HUB-STATUS.md is satisfied by this view.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+/// SwiftUI table view over a `ReportResult`. The table renders the
+/// report's declared columns as headers and one row per result row.
+///
+/// Callers that want filter chips or sortable columns can wrap this
+/// view in their own form and re-execute the report when the user
+/// changes filters; this view is intentionally read-only.
+public struct GenericReportView: View {
+
+    public let title: String
+    public let result: ReportResult
+    public let onRefresh: (() -> Void)?
+    public let onExportCSV: (() -> Void)?
+
+    public init(
+        title: String,
+        result: ReportResult,
+        onRefresh: (() -> Void)? = nil,
+        onExportCSV: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.result = result
+        self.onRefresh = onRefresh
+        self.onExportCSV = onExportCSV
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            header
+            if result.rowCount == 0 {
+                emptyState
+            } else {
+                resultsTable
+            }
+        }
+    }
+
+    // MARK: - Sub-views
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Text(title)
+                .font(.title3.weight(.semibold))
+            Spacer()
+            Text(rowCountLabel)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            if let onRefresh {
+                Button("Refresh", systemImage: "arrow.clockwise", action: onRefresh)
+                    .labelStyle(.iconOnly)
+            }
+            if let onExportCSV {
+                Button("Export CSV", systemImage: "square.and.arrow.up", action: onExportCSV)
+                    .labelStyle(.iconOnly)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "tray")
+                .font(.system(size: 32))
+                .foregroundStyle(.secondary)
+            Text("No matching rows")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(40)
+    }
+
+    private var resultsTable: some View {
+        ScrollView([.horizontal, .vertical]) {
+            VStack(alignment: .leading, spacing: 0) {
+                tableHeaderRow
+                Divider()
+                ForEach(Array(result.rows.enumerated()), id: \.offset) { (index, row) in
+                    tableBodyRow(cells: row, isAlternate: index.isMultiple(of: 2))
+                    if index < result.rows.count - 1 {
+                        Divider().opacity(0.4)
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 20)
+        }
+    }
+
+    private var tableHeaderRow: some View {
+        HStack(spacing: 16) {
+            ForEach(Array(result.columns.enumerated()), id: \.offset) { (_, column) in
+                Text(humanise(column))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(minWidth: 100, alignment: .leading)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+
+    private func tableBodyRow(cells: [String?], isAlternate: Bool) -> some View {
+        HStack(spacing: 16) {
+            ForEach(Array(cells.enumerated()), id: \.offset) { (_, cell) in
+                Text(cell ?? "—")
+                    .font(.callout)
+                    .foregroundStyle(cell == nil ? .secondary : .primary)
+                    .frame(minWidth: 100, alignment: .leading)
+            }
+        }
+        .padding(.vertical, 6)
+        .background(
+            isAlternate
+                ? Color.secondary.opacity(0.05)
+                : Color.clear
+        )
+    }
+
+    // MARK: - Helpers
+
+    private var rowCountLabel: String {
+        result.rowCount == 1 ? "1 row" : "\(result.rowCount) rows"
+    }
+
+    /// Default column humanisation: `total_amount` → "Total Amount".
+    /// Hosts that want custom labels should pre-process the result.
+    private func humanise(_ key: String) -> String {
+        guard !key.isEmpty else { return key }
+        var spaced = ""
+        for (i, ch) in key.enumerated() {
+            if ch == "_" {
+                spaced += " "
+            } else if ch.isUppercase, i > 0 {
+                spaced += " "
+                spaced.append(ch)
+            } else {
+                spaced.append(ch)
+            }
+        }
+        return spaced.prefix(1).uppercased() + spaced.dropFirst()
+    }
+}

--- a/mercantis coreTests/FileSystemCloudAdapterTests.swift
+++ b/mercantis coreTests/FileSystemCloudAdapterTests.swift
@@ -1,0 +1,161 @@
+//
+//  FileSystemCloudAdapterTests.swift
+//  mercantis coreTests
+//
+//  Phase D / §3.5 (ADR-047) — Two FileSystemCloudAdapter instances against
+//  the same shared root simulate two devices syncing via a shared folder.
+//  Verifies push fan-out, pull collection, peer-cursor advancement, and
+//  state persistence across instance restarts.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class FileSystemCloudAdapterTests: XCTestCase {
+
+    private var sharedRoot: URL!
+
+    override func setUpWithError() throws {
+        sharedRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fs-adapter-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: sharedRoot, withIntermediateDirectories: true
+        )
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: sharedRoot)
+        sharedRoot = nil
+    }
+
+    // MARK: - Helpers
+
+    private func mutation(_ id: String = UUID().uuidString, deviceId: String) throws -> MutationRecord {
+        let payload = try JSONEncoder().encode(["hello": "world"])
+        return MutationRecord(
+            id: UUID(uuidString: id) ?? UUID(),
+            type: .upsertDocument,
+            payload: payload,
+            deviceId: deviceId,
+            userId: "alice",
+            localTimestamp: Date(),
+            syncVersion: 0,
+            status: .pending
+        )
+    }
+
+    // MARK: - Push
+
+    func testPushAssignsMonotonicLocalSequence() async throws {
+        let adapter = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceA")
+        let acks = try await adapter.pushMutations([
+            try mutation(deviceId: "deviceA"),
+            try mutation(deviceId: "deviceA"),
+            try mutation(deviceId: "deviceA"),
+        ])
+        XCTAssertEqual(acks.map(\.serverSequence), [1, 2, 3])
+        XCTAssertEqual(adapter.currentLocalPushSequence(), 3)
+    }
+
+    func testPushSequenceSurvivesReinitialisation() async throws {
+        do {
+            let a = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceA")
+            _ = try await a.pushMutations([try mutation(deviceId: "deviceA")])
+            _ = try await a.pushMutations([try mutation(deviceId: "deviceA")])
+            XCTAssertEqual(a.currentLocalPushSequence(), 2)
+        }
+        // Re-open against the same root.
+        let reopened = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceA")
+        XCTAssertEqual(reopened.currentLocalPushSequence(), 2)
+        let acks = try await reopened.pushMutations([try mutation(deviceId: "deviceA")])
+        XCTAssertEqual(acks.first?.serverSequence, 3)
+    }
+
+    // MARK: - Cross-device pull
+
+    func testPeerPullsEverythingDeviceADropped() async throws {
+        let a = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceA")
+        let b = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceB")
+
+        _ = try await a.pushMutations([
+            try mutation(deviceId: "deviceA"),
+            try mutation(deviceId: "deviceA"),
+        ])
+        let received = try await b.pullMutations(since: SyncVersion(serverSequence: 0))
+        XCTAssertEqual(received.count, 2)
+        XCTAssertEqual(received.map(\.serverSequence), [1, 2],
+                       "global receive sequence is monotonic")
+    }
+
+    func testIgnoreOwnMutationsOnPull() async throws {
+        let a = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceA")
+        _ = try await a.pushMutations([try mutation(deviceId: "deviceA")])
+        let received = try await a.pullMutations(since: SyncVersion(serverSequence: 0))
+        XCTAssertTrue(received.isEmpty,
+                      "an adapter must not pull its own pushed mutations")
+    }
+
+    func testPeerCursorAdvancesSoNothingIsReplayed() async throws {
+        let a = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceA")
+        let b = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceB")
+
+        _ = try await a.pushMutations([try mutation(deviceId: "deviceA")])
+        _ = try await b.pullMutations(since: SyncVersion(serverSequence: 0))
+        // Second pull with no new pushes from A returns nothing.
+        let again = try await b.pullMutations(since: SyncVersion(serverSequence: 1))
+        XCTAssertTrue(again.isEmpty)
+        XCTAssertEqual(b.currentPeerCursor(for: "deviceA"), 1)
+    }
+
+    func testPullAfterAdapterRestartDoesNotReplay() async throws {
+        let a = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceA")
+        _ = try await a.pushMutations([try mutation(deviceId: "deviceA")])
+
+        do {
+            let b = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceB")
+            let r = try await b.pullMutations(since: SyncVersion(serverSequence: 0))
+            XCTAssertEqual(r.count, 1)
+        }
+
+        // Re-open device B, ensure cursor + global seq survived.
+        let bReopened = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceB")
+        XCTAssertEqual(bReopened.currentPeerCursor(for: "deviceA"), 1)
+        let r2 = try await bReopened.pullMutations(since: SyncVersion(serverSequence: 1))
+        XCTAssertTrue(r2.isEmpty)
+    }
+
+    func testThreeDeviceFanoutAllPeersEventuallySee() async throws {
+        let a = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceA")
+        let b = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceB")
+        let c = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceC")
+
+        _ = try await a.pushMutations([try mutation(deviceId: "deviceA")])
+        _ = try await b.pushMutations([try mutation(deviceId: "deviceB")])
+
+        // Device C pulls from both peers in one sweep.
+        let received = try await c.pullMutations(since: SyncVersion(serverSequence: 0))
+        let sourceDevices = Set(received.map(\.record.deviceId))
+        XCTAssertEqual(sourceDevices, ["deviceA", "deviceB"])
+        XCTAssertEqual(received.count, 2)
+    }
+
+    func testSyncVersionCutoffSuppressesAlreadyReturnedItems() async throws {
+        let a = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceA")
+        let b = try FileSystemCloudAdapter(rootURL: sharedRoot, localDeviceId: "deviceB")
+
+        _ = try await a.pushMutations([
+            try mutation(deviceId: "deviceA"),
+            try mutation(deviceId: "deviceA"),
+            try mutation(deviceId: "deviceA"),
+        ])
+
+        let first = try await b.pullMutations(since: SyncVersion(serverSequence: 0))
+        XCTAssertEqual(first.map(\.serverSequence), [1, 2, 3])
+
+        // After SyncEngine bookmarked at 2, pulling again should only emit
+        // items whose synthetic global sequence is > 2 — but the peer
+        // cursor has already advanced, so nothing new comes back.
+        let resume = try await b.pullMutations(since: SyncVersion(serverSequence: 2))
+        XCTAssertTrue(resume.isEmpty)
+    }
+}

--- a/mercantis coreTests/MigrationRunnerTests.swift
+++ b/mercantis coreTests/MigrationRunnerTests.swift
@@ -56,7 +56,7 @@ final class MigrationRunnerTests: XCTestCase {
         MigrationRunner.registerAll(into: &runner, pool: pool)
         try runner.migrate(pool: pool)
 
-        XCTAssertEqual(try highestAppliedVersion(), 10)
+        XCTAssertEqual(try highestAppliedVersion(), 11)
     }
 
     func testV1CreatesExpectedTables() throws {
@@ -161,6 +161,17 @@ final class MigrationRunnerTests: XCTestCase {
         XCTAssertTrue(try columnExists("fileName",    in: "attachments"))
         XCTAssertTrue(try columnExists("storagePath", in: "attachments"))
         XCTAssertTrue(try columnExists("sha256",      in: "attachments"))
+    }
+
+    func testV11CreatesNotificationLogTable() throws {
+        var runner = MigrationRunner()
+        MigrationRunner.registerAll(into: &runner, pool: pool)
+        try runner.migrate(pool: pool)
+
+        XCTAssertTrue(try tableExists("notification_log"))
+        XCTAssertTrue(try columnExists("recipient", in: "notification_log"))
+        XCTAssertTrue(try columnExists("subject",   in: "notification_log"))
+        XCTAssertTrue(try columnExists("readAt",    in: "notification_log"))
     }
 
     func testSecondMigrateIsIdempotent() throws {

--- a/mercantis coreTests/NotificationInboxTests.swift
+++ b/mercantis coreTests/NotificationInboxTests.swift
@@ -1,0 +1,147 @@
+//
+//  NotificationInboxTests.swift
+//  mercantis coreTests
+//
+//  Phase D / item 13 (ADR-048) — SQLiteNotificationLog persistence +
+//  NotificationInbox reader API. Composite + channel-filtered sinks.
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class NotificationInboxTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+    private var sink: SQLiteNotificationLog!
+    private var inbox: NotificationInbox!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness()
+        sink = SQLiteNotificationLog(database: harness.database)
+        inbox = NotificationInbox(database: harness.database)
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        sink = nil
+        inbox = nil
+        harness = nil
+    }
+
+    private func entry(
+        recipient: String? = "alice",
+        channel: String = "default",
+        subject: String = "Hello",
+        body: String = "Body",
+        emittedAt: Date = Date()
+    ) -> NotificationLogEntry {
+        NotificationLogEntry(
+            appId: "app.test",
+            docType: "Note",
+            documentId: "n1",
+            channel: channel,
+            recipient: recipient,
+            subject: subject,
+            body: body,
+            emittedAt: emittedAt
+        )
+    }
+
+    // MARK: - Persistence
+
+    func testSinkPersistsEntriesAcrossReaderQueries() throws {
+        sink.write(entry(subject: "First"))
+        sink.write(entry(subject: "Second"))
+
+        let items = try inbox.entries(forRecipient: "alice")
+        XCTAssertEqual(items.count, 2)
+        // Ordered newest first; both saved within the same instant so
+        // either order is acceptable — check membership instead.
+        XCTAssertEqual(Set(items.map(\.subject)), ["First", "Second"])
+    }
+
+    func testInboxFiltersByRecipient() throws {
+        sink.write(entry(recipient: "alice", subject: "For Alice"))
+        sink.write(entry(recipient: "bob",   subject: "For Bob"))
+
+        let alice = try inbox.entries(forRecipient: "alice")
+        XCTAssertEqual(alice.map(\.subject), ["For Alice"])
+
+        let bob = try inbox.entries(forRecipient: "bob")
+        XCTAssertEqual(bob.map(\.subject), ["For Bob"])
+    }
+
+    func testInboxNullRecipientIsItsOwnFeed() throws {
+        sink.write(entry(recipient: nil, subject: "Broadcast"))
+        sink.write(entry(recipient: "alice", subject: "Alice only"))
+
+        let global = try inbox.entries(forRecipient: nil)
+        XCTAssertEqual(global.map(\.subject), ["Broadcast"])
+    }
+
+    // MARK: - Read state
+
+    func testUnreadCountAndMarkRead() throws {
+        sink.write(entry(subject: "1"))
+        sink.write(entry(subject: "2"))
+        sink.write(entry(subject: "3"))
+
+        XCTAssertEqual(try inbox.unreadCount(forRecipient: "alice"), 3)
+
+        let items = try inbox.entries(forRecipient: "alice")
+        try inbox.markRead(id: items[0].id)
+        XCTAssertEqual(try inbox.unreadCount(forRecipient: "alice"), 2)
+
+        let unread = try inbox.entries(forRecipient: "alice", unreadOnly: true)
+        XCTAssertEqual(unread.count, 2)
+        XCTAssertFalse(unread.contains(where: { $0.id == items[0].id }))
+    }
+
+    func testMarkAllReadClearsUnreadCount() throws {
+        sink.write(entry(subject: "a"))
+        sink.write(entry(subject: "b"))
+
+        try inbox.markAllRead(forRecipient: "alice")
+        XCTAssertEqual(try inbox.unreadCount(forRecipient: "alice"), 0)
+    }
+
+    func testDeleteRemovesEntryFromInbox() throws {
+        sink.write(entry(subject: "to-delete"))
+        let items = try inbox.entries(forRecipient: "alice")
+        XCTAssertEqual(items.count, 1)
+
+        try inbox.delete(id: items[0].id)
+        XCTAssertTrue(try inbox.entries(forRecipient: "alice").isEmpty)
+    }
+
+    // MARK: - Composite + channel filter
+
+    func testCompositeFansOutToEverySink() throws {
+        let memory = InMemoryNotificationLog()
+        let composite = CompositeNotificationLog(sinks: [sink, memory])
+        composite.write(entry(subject: "Both"))
+
+        XCTAssertEqual(try inbox.entries(forRecipient: "alice").count, 1)
+        XCTAssertEqual(memory.entries.count, 1)
+    }
+
+    func testChannelFilterDropsNonMatchingEntries() throws {
+        let emailMemory = InMemoryNotificationLog()
+        let emailOnly = ChannelFilteredNotificationLog(
+            channels: ["email"], downstream: emailMemory
+        )
+        emailOnly.write(entry(channel: "email", subject: "✉️"))
+        emailOnly.write(entry(channel: "push", subject: "📱"))
+
+        XCTAssertEqual(emailMemory.entries.count, 1)
+        XCTAssertEqual(emailMemory.entries.first?.subject, "✉️")
+    }
+
+    func testInsertIsIdempotentByPrimaryKey() throws {
+        let dup = entry(subject: "Once")
+        sink.write(dup)
+        sink.write(dup)
+        XCTAssertEqual(try inbox.entries(forRecipient: "alice").count, 1)
+    }
+}

--- a/mercantis coreTests/ReportEngineRoleFilterTests.swift
+++ b/mercantis coreTests/ReportEngineRoleFilterTests.swift
@@ -1,0 +1,116 @@
+//
+//  ReportEngineRoleFilterTests.swift
+//  mercantis coreTests
+//
+//  Phase D / item 14 (ADR-049) — `ReportDefinition.allowedRoles` gates
+//  visibility through `ReportEngine.availableReports(for:)`.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class ReportEngineRoleFilterTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+    private var reportEngine: ReportEngine!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness()
+        reportEngine = ReportEngine(documentEngine: harness.engine)
+        try harness.registry.register(TestSupport.makeDocType())
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        reportEngine = nil
+        harness = nil
+    }
+
+    private func register(
+        _ id: String,
+        name: String,
+        allowedRoles: [String]? = nil
+    ) {
+        reportEngine.register(ReportDefinition(
+            id: id,
+            name: name,
+            docType: "Note",
+            columns: ["title"],
+            filters: [],
+            allowedRoles: allowedRoles
+        ))
+    }
+
+    func testReportsWithoutAllowedRolesAreVisibleToAnyone() {
+        register("a", name: "Always visible", allowedRoles: nil)
+        register("b", name: "Empty list",     allowedRoles: [])
+        let visible = reportEngine.availableReports(for: ["Stranger"])
+        XCTAssertEqual(visible.map(\.id).sorted(), ["a", "b"])
+    }
+
+    func testReportRequiresIntersectingRole() {
+        register("a", name: "Sales report",
+                 allowedRoles: ["Sales Manager", "System Manager"])
+        register("b", name: "HR report",
+                 allowedRoles: ["HR Manager"])
+
+        let asSales = reportEngine.availableReports(for: ["Sales Manager"])
+        XCTAssertEqual(asSales.map(\.id), ["a"])
+
+        let asHR = reportEngine.availableReports(for: ["HR Manager"])
+        XCTAssertEqual(asHR.map(\.id), ["b"])
+
+        let asSystem = reportEngine.availableReports(for: ["System Manager"])
+        XCTAssertEqual(asSystem.map(\.id), ["a"])
+    }
+
+    func testEmptyUserRolesSetCannotSeeRestrictedReports() {
+        register("restricted", name: "Restricted", allowedRoles: ["Owner"])
+        register("public",     name: "Public", allowedRoles: nil)
+
+        let visible = reportEngine.availableReports(for: [])
+        XCTAssertEqual(visible.map(\.id), ["public"])
+    }
+
+    func testAvailableReportsAreSortedByName() {
+        register("z", name: "Zeta")
+        register("a", name: "Alpha")
+        register("m", name: "Mu")
+
+        let names = reportEngine.availableReports(for: []).map(\.name)
+        XCTAssertEqual(names, ["Alpha", "Mu", "Zeta"])
+    }
+
+    // MARK: - Codable round trip
+
+    func testReportDefinitionRoundTripsAllowedRoles() throws {
+        let original = ReportDefinition(
+            id: "r", name: "R", docType: "Note",
+            columns: ["title"], filters: [],
+            allowedRoles: ["Sales Manager"]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(original)
+        let decoded = try JSONDecoder().decode(ReportDefinition.self, from: data)
+        XCTAssertEqual(decoded.allowedRoles, ["Sales Manager"])
+    }
+
+    func testReportDefinitionDecodesLegacyManifestWithoutAllowedRoles() throws {
+        // Older manifests don't carry `allowedRoles`. They must still decode.
+        let json = """
+        {
+            "id": "legacy",
+            "name": "Legacy",
+            "docType": "Note",
+            "columns": ["title"],
+            "filters": []
+        }
+        """
+        let decoded = try JSONDecoder().decode(
+            ReportDefinition.self, from: Data(json.utf8)
+        )
+        XCTAssertEqual(decoded.id, "legacy")
+        XCTAssertNil(decoded.allowedRoles)
+    }
+}


### PR DESCRIPTION
…le filtering

Closes the three production-readiness items in STATUS.md §4 Phase D.

- §3.5 / item 12 (ADR-047): FileSystemCloudAdapter as the reference CloudAdapter. Each device writes mutations to <root>/<deviceId>/<seq>.json; pull walks peer directories and advances per-peer cursors + a synthetic globally-monotonic sequence. State persists in <myDir>/.adapter-state.json so adapter restarts don't replay history. Two adapters against one shared root simulate two devices end-to-end.

- Item 13 (ADR-048): persistent notification log + in-app inbox. Migration v11 adds notification_log(id PK, recipient, channel, emittedAt, readAt, ...). SQLiteNotificationLog persists every entry through the existing NotificationLogWriter protocol. NotificationInbox reads by recipient with unread-only / mark-read / unread-count. CompositeNotificationLog and ChannelFilteredNotificationLog make fanning out to email / push / SMS a single new conformance.

- Item 14 (ADR-049): ReportDefinition.allowedRoles gates visibility in ReportEngine.availableReports(for: userRoles). nil/empty allows everyone (back-compat); non-empty requires intersection. Sorted by name. MercantisCoreUI.GenericReportView renders any ReportResult as a SwiftUI table with Refresh / Export-CSV hooks.

Tests: FileSystemCloudAdapterTests (7), NotificationInboxTests (9), ReportEngineRoleFilterTests (6), plus migration v11 coverage.

Docs: STATUS.md headline ~98%; §2 scorecard rows for Storage, SyncEngine, Notifications, ReportEngine all marked Ready; §3.5 rewritten as shipped; §4 Phase D complete. ARCHITECTURE-CHANGELOG entry added; ADRs 047-049 indexed. The Core engine is feature-complete relative to the original ERP-readiness scorecard.