### PR TITLE
fix(print): drop AppKit/UIKit dependency + mark PrintTemplate nonisol…

### DIFF
--- a/mercantis core/Printing/PDFPrintRenderer.swift
+++ b/mercantis core/Printing/PDFPrintRenderer.swift
@@ -157,13 +157,22 @@ public struct PDFPrintRenderer: PrintRenderer {
         isBold: Bool,
         in ctx: CGContext
     ) {
+        // Use CoreText's own attribute keys so the renderer compiles
+        // without an AppKit / UIKit dependency. The runtime semantics
+        // are identical to NSAttributedString.Key.font / .foregroundColor;
+        // only the key constants differ.
         let fontName = isBold ? "Helvetica-Bold" : "Helvetica"
         let font = CTFontCreateWithName(fontName as CFString, 11, nil)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: CGColor(gray: 0, alpha: 1)
+        let attributes: [CFString: Any] = [
+            kCTFontAttributeName: font,
+            kCTForegroundColorAttributeName: CGColor(gray: 0, alpha: 1)
         ]
-        let attributed = NSAttributedString(string: text, attributes: attributes)
+        let attributed = CFAttributedStringCreate(
+            nil,
+            text as CFString,
+            attributes as CFDictionary
+        )
+        guard let attributed else { return }
         let line = CTLineCreateWithAttributedString(attributed)
         ctx.textPosition = CGPoint(x: margin, y: y - 11)
         CTLineDraw(line, ctx)

--- a/mercantis core/Printing/PrintRenderer.swift
+++ b/mercantis core/Printing/PrintRenderer.swift
@@ -65,13 +65,18 @@ public enum PrintRenderError: Error, Sendable, Equatable {
 
 /// Helpers shared by every renderer: `{field}` substitution and the
 /// default formatting of a `FieldValue` to a printable string.
+///
+/// All methods are `nonisolated` so they can be called from any actor
+/// context (Swift 6 strict-concurrency builds infer `@MainActor` on
+/// some module-level statics; explicit `nonisolated` keeps the
+/// renderer pipeline portable).
 public enum PrintTemplate {
 
     /// Substitute every `{key}` placeholder in `template` with the
     /// formatted `document.fields[key]`. Unknown keys are left as-is
     /// (`"{unknown}"` literal in output) so format authors can spot
     /// typos without the renderer crashing.
-    public static func substitute(_ template: String, in document: Document) -> String {
+    nonisolated public static func substitute(_ template: String, in document: Document) -> String {
         var out = ""
         var i = template.startIndex
         while i < template.endIndex {
@@ -98,7 +103,7 @@ public enum PrintTemplate {
     /// Lookup `key` against the document's fields plus a few system-column
     /// conveniences (`id`, `status`, `docStatus`, `createdAt`, `updatedAt`,
     /// `company`).
-    public static func lookup(key: String, in document: Document) -> FieldValue? {
+    nonisolated public static func lookup(key: String, in document: Document) -> FieldValue? {
         if let field = document.fields[key] { return field }
         switch key {
         case "id":          return .string(document.id)
@@ -113,7 +118,7 @@ public enum PrintTemplate {
 
     /// Default printable form of a `FieldValue`. Renderers can override
     /// per-type formatting if they need locale-aware money / date output.
-    public static func format(_ value: FieldValue) -> String {
+    nonisolated public static func format(_ value: FieldValue) -> String {
         switch value {
         case .string(let s): return s
         case .int(let i):    return String(i)
@@ -135,7 +140,7 @@ public enum PrintTemplate {
         }
     }
 
-    private static func formattedDouble(_ d: Double) -> String {
+    nonisolated private static func formattedDouble(_ d: Double) -> String {
         if d == d.rounded() {
             return String(format: "%.0f", d)
         }
@@ -143,7 +148,7 @@ public enum PrintTemplate {
     }
 
     /// Humanise a snake_case or camelCase field key into a label.
-    public static func defaultLabel(forKey key: String) -> String {
+    nonisolated public static func defaultLabel(forKey key: String) -> String {
         if key.isEmpty { return key }
         var spaced = ""
         for (i, ch) in key.enumerated() {


### PR DESCRIPTION
…ated

Two compile errors on Apple platforms with strict-concurrency:

1. NSAttributedString.Key.font / .foregroundColor live in AppKit/UIKit, not CoreText. PDFPrintRenderer is meant to compile against CoreGraphics + CoreText only — adding an AppKit import would couple the engine library to a UI framework. Switch to CoreText's own attribute keys (kCTFontAttributeName / kCTForegroundColorAttributeName) and CFAttributedStringCreate; runtime semantics are identical.

2. `PrintTemplate.format` was being inferred @MainActor under Swift 6 strict concurrency, which made the function reference rejected at `.map(PrintTemplate.format)` call sites in PDFPrintRenderer, PlainTextPrintRenderer, and DashboardEngine. PrintTemplate's helpers are pure functions of their inputs — annotate every public helper (and the private `formattedDouble`) `nonisolated` so they are callable from any actor context.