### PR TITLE
fix(strict-concurrency): nonisolated CSV / Inbox helpers, sync core i…

### DIFF
--- a/mercantis core/ImportExport/CSVCodec.swift
+++ b/mercantis core/ImportExport/CSVCodec.swift
@@ -20,7 +20,7 @@ public enum CSVCodec {
 
     /// Render a header + rows array as RFC-4180 CSV bytes (LF line endings).
     /// `headers` defines column order; missing cells render empty.
-    public static func encode(headers: [String], rows: [[String: String]]) -> Data {
+    nonisolated public static func encode(headers: [String], rows: [[String: String]]) -> Data {
         var out = ""
         out += headers.map(escape).joined(separator: ",")
         out += "\n"
@@ -33,7 +33,7 @@ public enum CSVCodec {
 
     /// Escape one CSV cell. Quotes the value when it contains a separator,
     /// quote, CR, or LF.
-    public static func escape(_ raw: String) -> String {
+    nonisolated public static func escape(_ raw: String) -> String {
         if raw.isEmpty { return "" }
         let needsQuote = raw.contains(",") || raw.contains("\"") || raw.contains("\n") || raw.contains("\r")
         if !needsQuote { return raw }
@@ -50,7 +50,7 @@ public enum CSVCodec {
 
     /// Parse `bytes` as RFC-4180 CSV. Throws `ImportExportError.malformedCSV`
     /// on quote / row mismatches (e.g. unterminated quoted cells).
-    public static func decode(_ bytes: Data) throws -> DecodedTable {
+    nonisolated public static func decode(_ bytes: Data) throws -> DecodedTable {
         guard let text = String(data: bytes, encoding: .utf8) else {
             throw ImportExportError.malformedCSV(line: 0, reason: "input is not valid UTF-8")
         }
@@ -68,7 +68,7 @@ public enum CSVCodec {
         return DecodedTable(headers: header, rows: Array(dataRows))
     }
 
-    private static func parseRows(_ text: String) throws -> [[String]] {
+    nonisolated private static func parseRows(_ text: String) throws -> [[String]] {
         var rows: [[String]] = []
         var currentRow: [String] = []
         var currentCell = ""

--- a/mercantis core/Notifications/NotificationInbox.swift
+++ b/mercantis core/Notifications/NotificationInbox.swift
@@ -143,7 +143,7 @@ public final class NotificationInbox: @unchecked Sendable {
 
     // MARK: - Helpers
 
-    private static func itemFromRow(_ row: Row) -> NotificationInboxItem? {
+    nonisolated private static func itemFromRow(_ row: Row) -> NotificationInboxItem? {
         let idString: String = row["id"] ?? ""
         guard let id = UUID(uuidString: idString) else { return nil }
         let appId: String = row["appId"] ?? ""

--- a/mercantis core/SyncEngine/FileSystemCloudAdapter.swift
+++ b/mercantis core/SyncEngine/FileSystemCloudAdapter.swift
@@ -66,6 +66,21 @@ public final class FileSystemCloudAdapter: CloudAdapter, @unchecked Sendable {
     // MARK: - CloudAdapter
 
     public func pushMutations(_ mutations: [MutationRecord]) async throws -> [SyncAcknowledgement] {
+        // The actual work is synchronous file I/O; routing it through a
+        // sync helper sidesteps Swift 6's prohibition on `NSLock.lock()`
+        // from async contexts without forcing the type to be an actor
+        // (which would have to make the `currentLocalPushSequence()` and
+        // friends async too).
+        try _pushMutations(mutations)
+    }
+
+    public func pullMutations(since version: SyncVersion) async throws -> [RemoteMutation] {
+        try _pullMutations(since: version)
+    }
+
+    // MARK: - Synchronous core (locked sections)
+
+    private func _pushMutations(_ mutations: [MutationRecord]) throws -> [SyncAcknowledgement] {
         lock.lock(); defer { lock.unlock() }
 
         var acks: [SyncAcknowledgement] = []
@@ -96,7 +111,7 @@ public final class FileSystemCloudAdapter: CloudAdapter, @unchecked Sendable {
         return acks
     }
 
-    public func pullMutations(since version: SyncVersion) async throws -> [RemoteMutation] {
+    private func _pullMutations(since version: SyncVersion) throws -> [RemoteMutation] {
         lock.lock(); defer { lock.unlock() }
 
         let cutoff = version.serverSequence


### PR DESCRIPTION
…n cloud adapter

Three more Swift 6 strict-concurrency errors:

- ImportExport/CSVCodec.swift: `escape`, `encode`, `decode`, and the internal `parseRows` were being inferred @MainActor, so `headers.map(escape)` was rejected as a function reference. Mark every helper `nonisolated` since they are pure functions of their inputs.

- Notifications/NotificationInbox.swift: same pattern at `rows.compactMap(Self.itemFromRow)`. Mark `itemFromRow` nonisolated.

- SyncEngine/FileSystemCloudAdapter.swift: `NSLock.lock()/unlock()` is unavailable from async contexts in Swift 6 (the runtime can hop threads on suspension and a re-entrant unlock would be unsound). Split the pre-existing `pushMutations(_:)` and `pullMutations(since:)` into thin async wrappers that delegate to synchronous private cores `_pushMutations` / `_pullMutations`, which keep the existing `lock.lock()/defer unlock()` pattern.

  Done this way (instead of converting the type to an `actor`) so the synchronous inspection methods `currentLocalPushSequence()`, `currentPeerCursor(for:)`, `currentGlobalReceiveSequence()` remain non-async — they're called from tests and host diagnostics that don't want to await.