### PR TITLE
Add customizable form editor and link search to record collection

### DIFF
--- a/mercantis core/UIShell/CreateRecordSheet.swift
+++ b/mercantis core/UIShell/CreateRecordSheet.swift
@@ -15,8 +15,24 @@ struct CreateRecordSheet: View {
     let docType: DocType
     @Binding var draft: Document
     let onCreate: (Document) throws -> Void
+    let linkSearchProvider: ((String, String) -> [Document])?
+    let childDocTypeProvider: ((String) -> DocType?)?
 
     @State private var errorMessage: String?
+
+    init(
+        docType: DocType,
+        draft: Binding<Document>,
+        onCreate: @escaping (Document) throws -> Void,
+        linkSearchProvider: ((String, String) -> [Document])? = nil,
+        childDocTypeProvider: ((String) -> DocType?)? = nil
+    ) {
+        self.docType = docType
+        self._draft = draft
+        self.onCreate = onCreate
+        self.linkSearchProvider = linkSearchProvider
+        self.childDocTypeProvider = childDocTypeProvider
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -32,8 +48,13 @@ struct CreateRecordSheet: View {
                     .background(MercantisTheme.fillSoft(for: .danger))
             }
 
-            GenericFormView(docType: docType, document: $draft)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            GenericFormView(
+                docType: docType,
+                document: $draft,
+                linkSearchProvider: linkSearchProvider,
+                childDocTypeProvider: childDocTypeProvider
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             Divider()
             footer

--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -21,6 +21,9 @@ public struct RecordCollectionHostView: View {
     let onSelectionChange: ((Document?) -> Void)?
     let detailHeader: ((Document) -> AnyView)?
     let externalCreateTrigger: Binding<Bool>?
+    let linkSearchProvider: ((String, String) -> [Document])?
+    let childDocTypeProvider: ((String) -> DocType?)?
+    let detailEditor: ((Binding<Document>) -> AnyView)?
 
     @State private var selectedDocument: Document?
     @State private var selectedDocumentID: String?
@@ -45,7 +48,10 @@ public struct RecordCollectionHostView: View {
         initialSelectedDocumentID: String? = nil,
         onSelectionChange: ((Document?) -> Void)? = nil,
         detailHeader: ((Document) -> AnyView)? = nil,
-        externalCreateTrigger: Binding<Bool>? = nil
+        externalCreateTrigger: Binding<Bool>? = nil,
+        linkSearchProvider: ((String, String) -> [Document])? = nil,
+        childDocTypeProvider: ((String) -> DocType?)? = nil,
+        detailEditor: ((Binding<Document>) -> AnyView)? = nil
     ) {
         self.preferenceKey = preferenceKey
         self.docType = docType
@@ -64,6 +70,9 @@ public struct RecordCollectionHostView: View {
         self.onSelectionChange = onSelectionChange
         self.detailHeader = detailHeader
         self.externalCreateTrigger = externalCreateTrigger
+        self.linkSearchProvider = linkSearchProvider
+        self.childDocTypeProvider = childDocTypeProvider
+        self.detailEditor = detailEditor
         _selectedViewMode = State(initialValue: configuration.defaultViewMode)
     }
 
@@ -81,7 +90,9 @@ public struct RecordCollectionHostView: View {
                     get: { createSheetDraft ?? emptyDocument(for: docType.id) },
                     set: { createSheetDraft = $0 }
                 ),
-                onCreate: performCreate(_:)
+                onCreate: performCreate(_:),
+                linkSearchProvider: linkSearchProvider,
+                childDocTypeProvider: childDocTypeProvider
             )
         }
         .onAppear {
@@ -178,8 +189,17 @@ public struct RecordCollectionHostView: View {
                     detailHeader(selectedDocument)
                 }
 
-                GenericFormView(docType: docType, document: selectedDocumentBinding)
+                if let detailEditor {
+                    detailEditor(selectedDocumentBinding)
+                } else {
+                    GenericFormView(
+                        docType: docType,
+                        document: selectedDocumentBinding,
+                        linkSearchProvider: linkSearchProvider,
+                        childDocTypeProvider: childDocTypeProvider
+                    )
                     .disabled(!allowsDetailEditing)
+                }
 
                 if let detailSaveError {
                     Text(detailSaveError)
@@ -190,7 +210,7 @@ public struct RecordCollectionHostView: View {
                         .padding(.horizontal)
                 }
 
-                if let onSaveDocument {
+                if detailEditor == nil, let onSaveDocument {
                     HStack {
                         Spacer()
                         Button("Save") {


### PR DESCRIPTION
## Summary
This PR extends `RecordCollectionHostView` and `CreateRecordSheet` with new customization options for form editing and document linking, enabling more flexible record management workflows.

## Key Changes
- **Added three new optional parameters to `RecordCollectionHostView`:**
  - `linkSearchProvider`: Closure to search for documents by type and query string
  - `childDocTypeProvider`: Closure to resolve document types by ID
  - `detailEditor`: Custom view builder for the detail editing panel

- **Updated `CreateRecordSheet`:**
  - Added explicit initializer to properly handle new optional parameters
  - Passed `linkSearchProvider` and `childDocTypeProvider` to `GenericFormView`

- **Enhanced detail view rendering:**
  - Made detail editor customizable via `detailEditor` parameter
  - Falls back to `GenericFormView` when custom editor not provided
  - Passed search and type provider closures to `GenericFormView` for link resolution

- **Conditional save button display:**
  - Save button now only displays when using default `GenericFormView` (not custom `detailEditor`)

## Implementation Details
- All new parameters are optional with nil defaults, maintaining backward compatibility
- The `linkSearchProvider` and `childDocTypeProvider` are threaded through both the create sheet and detail view to enable consistent document linking behavior
- Custom detail editors can completely replace the default form view while maintaining the header and error handling UI

https://claude.ai/code/session_01TB3fWhSqNjJNemk5o5Gqpw