### PR TITLE
fix(ui-shell): stop rendering the workspace create button twice

### DIFF
--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -155,7 +155,10 @@ public struct RecordCollectionHostView: View {
             selectedViewMode: $selectedViewMode,
             supportedViewModes: configuration.supportedViewModes,
             primaryActionTitle: primaryCreateActionTitle,
-            onPrimaryAction: createDocumentAction,
+            // Primary create lives in the hero header; surfacing it here too
+            // would render two identical "+ New <DocType>" buttons on every
+            // workspace.
+            onPrimaryAction: nil,
             overflowMenuContent: workspaceOverflowMenu
         )
     }


### PR DESCRIPTION
RecordCollectionHostView was wiring the same primary create action into both the hero header and the toolbar, so every workspace showed two identical "+ New <DocType>" buttons. The hero header is the canonical place for the workspace's primary action; drop the toolbar copy.