### PR TITLE
feat(customization): end-user custom fields with positioning

### DIFF
--- a/Tests/MercantisCoreUITests/CustomizeWorkspaceSheetTests.swift
+++ b/Tests/MercantisCoreUITests/CustomizeWorkspaceSheetTests.swift
@@ -1,0 +1,103 @@
+//
+//  CustomizeWorkspaceSheetTests.swift
+//  MercantisCoreUITests
+//
+//  Covers the small-business-friendly bits of the customize sheet: the
+//  label → key derivation and the make-FieldDefinition translation.
+//
+
+import XCTest
+@testable import MercantisCoreUI
+@testable import MercantisCore
+
+final class CustomizeWorkspaceSheetTests: XCTestCase {
+
+    typealias Draft = CustomizeWorkspaceSheet.Draft
+
+    // MARK: - deriveKey
+
+    func testDeriveKeySnakeCasesMultiWordLabels() {
+        XCTAssertEqual(Draft.deriveKey(from: "VAT Number"), "vat_number")
+        XCTAssertEqual(Draft.deriveKey(from: "Customer  Loyalty   Tier"), "customer_loyalty_tier")
+    }
+
+    func testDeriveKeyStripsDiacritics() {
+        XCTAssertEqual(Draft.deriveKey(from: "Numéro Fiscal"), "numero_fiscal")
+    }
+
+    func testDeriveKeyStripsPunctuationAndSymbols() {
+        XCTAssertEqual(Draft.deriveKey(from: "VAT-#1 Number!"), "vat_1_number")
+    }
+
+    func testDeriveKeyTrimsTrailingUnderscores() {
+        XCTAssertEqual(Draft.deriveKey(from: "Discount %"), "discount")
+    }
+
+    func testDeriveKeyDropsLeadingDigits() {
+        XCTAssertEqual(Draft.deriveKey(from: "2024 quota"), "quota")
+    }
+
+    func testDeriveKeyReturnsEmptyForEmptyLabel() {
+        XCTAssertEqual(Draft.deriveKey(from: ""), "")
+        XCTAssertEqual(Draft.deriveKey(from: "   "), "")
+    }
+
+    // MARK: - makeFieldDefinition
+
+    func testMakeFieldDefinitionDerivesKeyAndCarriesType() throws {
+        let draft = Draft(
+            label: "VAT Number",
+            type: .text,
+            required: true,
+            insertAfter: "email",
+            optionsText: ""
+        )
+        let definition = try XCTUnwrap(draft.makeFieldDefinition())
+        XCTAssertEqual(definition.key, "vat_number")
+        XCTAssertEqual(definition.label, "VAT Number")
+        XCTAssertEqual(definition.type, .text)
+        XCTAssertTrue(definition.required)
+        XCTAssertNil(definition.options, "Non-select fields shouldn't carry an options array.")
+    }
+
+    func testMakeFieldDefinitionParsesSelectOptionsLineByLine() throws {
+        let draft = Draft(
+            label: "Tier",
+            type: .select,
+            required: false,
+            insertAfter: nil,
+            optionsText: "Bronze\nSilver\n   \nGold"
+        )
+        let definition = try XCTUnwrap(draft.makeFieldDefinition())
+        XCTAssertEqual(definition.type, .select)
+        XCTAssertEqual(definition.options, ["Bronze", "Silver", "Gold"])
+    }
+
+    func testMakeFieldDefinitionPreservesLockedKeyOnEdit() throws {
+        // User created "VAT" → key "vat". Later they rename the label to
+        // "VAT Number". The persisted key must stay "vat" so existing
+        // documents that store `fields["vat"]` still match.
+        let draft = Draft(
+            label: "VAT Number",
+            type: .text,
+            required: false,
+            insertAfter: nil,
+            optionsText: "",
+            lockedKey: "vat"
+        )
+        let definition = try XCTUnwrap(draft.makeFieldDefinition())
+        XCTAssertEqual(definition.key, "vat")
+        XCTAssertEqual(definition.label, "VAT Number")
+    }
+
+    func testMakeFieldDefinitionReturnsNilForEmptyLabel() {
+        let draft = Draft(
+            label: "  ",
+            type: .text,
+            required: false,
+            insertAfter: nil,
+            optionsText: ""
+        )
+        XCTAssertNil(draft.makeFieldDefinition())
+    }
+}

--- a/mercantis core/Customization/CustomFieldStore.swift
+++ b/mercantis core/Customization/CustomFieldStore.swift
@@ -1,0 +1,166 @@
+//
+//  CustomFieldStore.swift
+//  mercantis core
+//
+//  Persistence for end-user `CustomField` rows added on top of a base
+//  DocType. (ADR-021)
+//
+//  The store is the source of truth that hydrates
+//  `MetaComposer.setCustomFields(_:for:)` at boot — without that load step
+//  custom fields would only live in memory and disappear on relaunch.
+//
+
+import Foundation
+import GRDB
+
+/// CRUD over the `custom_fields` SQLite table.
+public final class CustomFieldStore {
+
+    private let database: MercantisDatabase
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(database: MercantisDatabase) {
+        self.database = database
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let decoder = JSONDecoder()
+        self.encoder = encoder
+        self.decoder = decoder
+    }
+
+    // MARK: - Reads
+
+    /// All custom fields, grouped by DocType id. Used at app start to seed
+    /// the `MetaComposer`.
+    public func loadAll() throws -> [String: [CustomField]] {
+        try database.read { db in
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT id, doctype, insert_after, field_definition
+                FROM custom_fields
+                ORDER BY doctype, created_at
+                """)
+            var grouped: [String: [CustomField]] = [:]
+            for row in rows {
+                let field = try decode(row: row)
+                grouped[field.docType, default: []].append(field)
+            }
+            return grouped
+        }
+    }
+
+    /// Custom fields for one DocType, ordered by creation time.
+    public func list(forDocType docTypeId: String) throws -> [CustomField] {
+        try database.read { db in
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT id, doctype, insert_after, field_definition
+                FROM custom_fields
+                WHERE doctype = ?
+                ORDER BY created_at
+                """, arguments: [docTypeId])
+            return try rows.map(decode(row:))
+        }
+    }
+
+    // MARK: - Writes
+
+    /// Insert a new custom field. Fails if `(docType, field_key)` already
+    /// exists (the UNIQUE constraint guards against duplicate keys).
+    public func add(_ field: CustomField) throws {
+        let payload = try jsonString(for: field.fieldDefinition)
+        let now = ISO8601DateFormatter().string(from: Date())
+        try database.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO custom_fields
+                        (id, doctype, field_key, insert_after, field_definition, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                arguments: [
+                    field.id,
+                    field.docType,
+                    field.fieldDefinition.key,
+                    nullIfEmpty(field.insertAfter),
+                    payload,
+                    now,
+                    now
+                ]
+            )
+        }
+    }
+
+    /// Replace an existing custom field's definition and/or position.
+    public func update(_ field: CustomField) throws {
+        let payload = try jsonString(for: field.fieldDefinition)
+        let now = ISO8601DateFormatter().string(from: Date())
+        try database.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE custom_fields
+                       SET field_key = ?,
+                           insert_after = ?,
+                           field_definition = ?,
+                           updated_at = ?
+                     WHERE id = ?
+                    """,
+                arguments: [
+                    field.fieldDefinition.key,
+                    nullIfEmpty(field.insertAfter),
+                    payload,
+                    now,
+                    field.id
+                ]
+            )
+        }
+    }
+
+    /// Remove the field with the given id.
+    public func remove(id: String) throws {
+        try database.write { db in
+            try db.execute(
+                sql: "DELETE FROM custom_fields WHERE id = ?",
+                arguments: [id]
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func decode(row: Row) throws -> CustomField {
+        let id: String = row["id"]
+        let docType: String = row["doctype"]
+        let insertAfter: String? = row["insert_after"]
+        let payload: String = row["field_definition"]
+        guard let data = payload.data(using: .utf8) else {
+            throw CustomFieldStoreError.invalidPayload(id: id)
+        }
+        let definition = try decoder.decode(FieldDefinition.self, from: data)
+        return CustomField(
+            id: id,
+            docType: docType,
+            fieldDefinition: definition,
+            insertAfter: insertAfter
+        )
+    }
+
+    private func jsonString(for definition: FieldDefinition) throws -> String {
+        let data = try encoder.encode(definition)
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+
+    private func nullIfEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+public enum CustomFieldStoreError: Error, LocalizedError {
+    case invalidPayload(id: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidPayload(let id):
+            return "Custom field \(id) has an unreadable field_definition payload."
+        }
+    }
+}

--- a/mercantis core/Storage/MigrationRunner.swift
+++ b/mercantis core/Storage/MigrationRunner.swift
@@ -87,6 +87,7 @@ public struct MigrationRunner {
         runner.register(version: 9, name: "add_naming_counter_blocks", sql: MigrationRunner.v9SQL)
         runner.register(version: 10, name: "add_attachments", sql: MigrationRunner.v10SQL)
         runner.register(version: 11, name: "add_notification_log", sql: MigrationRunner.v11SQL)
+        runner.register(version: 12, name: "add_custom_fields", sql: MigrationRunner.v12SQL)
     }
 
     // MARK: - v1 Schema
@@ -372,5 +373,32 @@ public struct MigrationRunner {
             ON notification_log(emittedAt);
         CREATE INDEX IF NOT EXISTS idx_notification_unread
             ON notification_log(recipient, readAt);
+        """
+
+    // MARK: - v12 Schema (Custom Fields)
+
+    private static let v12SQL = """
+        -- End-user customizations layered on top of a base DocType. (ADR-021)
+        --
+        -- A row here adds a single field to `docType` without mutating the
+        -- base DocType definition, so app-manifest reinstalls don't clobber
+        -- it and the field can be removed without a schema migration.
+        --
+        -- `insertAfter` is the field key the custom field should be placed
+        -- after in the rendered form; NULL means "append to the end".
+        -- `field_definition` is the JSON-encoded FieldDefinition.
+        CREATE TABLE IF NOT EXISTS custom_fields (
+            id                TEXT PRIMARY KEY NOT NULL,
+            doctype           TEXT NOT NULL,
+            field_key         TEXT NOT NULL,
+            insert_after      TEXT,
+            field_definition  TEXT NOT NULL,
+            created_at        TEXT NOT NULL,
+            updated_at        TEXT NOT NULL,
+            UNIQUE (doctype, field_key)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_custom_fields_doctype
+            ON custom_fields(doctype);
         """
 }

--- a/mercantis core/UIShell/CustomizeWorkspaceSheet.swift
+++ b/mercantis core/UIShell/CustomizeWorkspaceSheet.swift
@@ -1,0 +1,638 @@
+//
+//  CustomizeWorkspaceSheet.swift
+//  mercantis core
+//
+//  End-user "Customize fields" sheet. Reachable from the workspace
+//  toolbar's pencil/slider icon on `RecordCollectionHostView`. Designed
+//  for small-business users: minimum required choices (label, type,
+//  position, required toggle), automatic field-key derivation, and
+//  inline list of existing custom fields with edit/remove.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+/// Subset of `FieldType` that we expose to end users. Power-user types
+/// (link, table, image, attachment, formula, status, …) are intentionally
+/// excluded from v1 — they each need a much richer authoring UI.
+enum CustomizableFieldType: String, CaseIterable, Identifiable {
+    case text
+    case longText
+    case number
+    case decimal
+    case currency
+    case boolean
+    case date
+    case select
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .text:     return "Text"
+        case .longText: return "Long text"
+        case .number:   return "Number (whole)"
+        case .decimal:  return "Number (decimal)"
+        case .currency: return "Money"
+        case .boolean:  return "Yes / No"
+        case .date:     return "Date"
+        case .select:   return "Choice list"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .text:     return "textformat"
+        case .longText: return "text.alignleft"
+        case .number:   return "number"
+        case .decimal:  return "number.square"
+        case .currency: return "dollarsign.circle"
+        case .boolean:  return "checkmark.square"
+        case .date:     return "calendar"
+        case .select:   return "list.bullet"
+        }
+    }
+
+    var fieldType: FieldType {
+        switch self {
+        case .text:     return .text
+        case .longText: return .longText
+        case .number:   return .number
+        case .decimal:  return .decimal
+        case .currency: return .currency
+        case .boolean:  return .boolean
+        case .date:     return .date
+        case .select:   return .select
+        }
+    }
+
+    /// Best-effort reverse mapping for editing existing fields. Returns
+    /// `.text` for types we don't expose in the customize UI so an
+    /// imported / power-user-authored field still renders something.
+    static func from(_ type: FieldType) -> CustomizableFieldType {
+        switch type {
+        case .text:      return .text
+        case .longText:  return .longText
+        case .number:    return .number
+        case .decimal:   return .decimal
+        case .currency:  return .currency
+        case .boolean:   return .boolean
+        case .date:      return .date
+        case .select:    return .select
+        default:         return .text
+        }
+    }
+}
+
+/// Sheet body. Owned by `RecordCollectionHostView` so all callers share
+/// the same UX without re-implementing it.
+struct CustomizeWorkspaceSheet: View {
+
+    let docTypeName: String
+    /// Field keys that already exist on the base DocType. Used both for
+    /// the "Position after" picker and for uniqueness checks.
+    let baseFields: [BaseFieldEntry]
+    /// Existing custom fields (so the user can edit/remove them).
+    let customFields: [CustomField]
+
+    let onAdd: (CustomField) throws -> Void
+    let onUpdate: (CustomField) throws -> Void
+    let onRemove: (String) throws -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var editorState: EditorState?
+    @State private var errorMessage: String?
+    @State private var pendingRemoval: CustomField?
+
+    struct BaseFieldEntry: Identifiable, Hashable {
+        let key: String
+        let label: String
+        var id: String { key }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if let editorState {
+                editor(state: editorState)
+            } else {
+                listPane
+            }
+        }
+        .frame(minWidth: 520, idealWidth: 600, minHeight: 460, idealHeight: 560)
+        .alert(
+            "Remove this field?",
+            isPresented: removalBinding,
+            presenting: pendingRemoval
+        ) { field in
+            Button("Remove", role: .destructive) {
+                guard let field = pendingRemoval else { return }
+                runProtected { try onRemove(field.id) }
+                pendingRemoval = nil
+            }
+            Button("Cancel", role: .cancel) { pendingRemoval = nil }
+        } message: { field in
+            Text("Records that already have a value for \"\(field.fieldDefinition.label)\" will keep it, but the field won't show on the form anymore.")
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "slider.horizontal.3")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(MercantisTheme.accent)
+                .frame(width: 28, height: 28)
+                .background(MercantisTheme.accentFillSoft, in: RoundedRectangle(cornerRadius: 7))
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Customize \(docTypeName)")
+                    .font(.system(size: 15, weight: .semibold))
+                Text("Add your own fields without touching the original record.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if editorState == nil {
+                Button {
+                    editorState = EditorState(mode: .add, draft: makeDraft())
+                } label: {
+                    Label("Add Field", systemImage: "plus")
+                }
+                .buttonStyle(MercantisPrimaryButtonStyle())
+            }
+
+            Button("Done") { dismiss() }
+                .buttonStyle(MercantisSecondaryButtonStyle())
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(MercantisTheme.surface)
+    }
+
+    // MARK: - List of existing custom fields
+
+    @ViewBuilder
+    private var listPane: some View {
+        if customFields.isEmpty {
+            ContentUnavailableView(
+                "No custom fields yet",
+                systemImage: "rectangle.dashed",
+                description: Text("Tap **Add Field** to add the first one. It will appear on every \(docTypeName) record.")
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List {
+                ForEach(customFields, id: \.id) { field in
+                    row(for: field)
+                }
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+    }
+
+    private func row(for field: CustomField) -> some View {
+        let typeLabel = CustomizableFieldType.from(field.fieldDefinition.type).label
+        let position: String = {
+            if let after = field.insertAfter, !after.isEmpty,
+               let base = baseFields.first(where: { $0.key == after }) {
+                return "After \(base.label)"
+            }
+            return "End of form"
+        }()
+
+        return HStack(spacing: 10) {
+            Image(systemName: CustomizableFieldType.from(field.fieldDefinition.type).symbol)
+                .foregroundStyle(MercantisTheme.accent)
+                .frame(width: 22, height: 22)
+                .background(MercantisTheme.accentFillSoft, in: RoundedRectangle(cornerRadius: 6))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(field.fieldDefinition.label)
+                    .font(.system(size: 13, weight: .semibold))
+                HStack(spacing: 6) {
+                    Text(typeLabel)
+                    Text("·")
+                    Text(position)
+                    if field.fieldDefinition.required {
+                        Text("·")
+                        Text("Required").foregroundStyle(MercantisTheme.warning)
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                editorState = EditorState(mode: .edit(field.id), draft: Draft(from: field, baseFields: baseFields))
+            } label: {
+                Image(systemName: "pencil")
+            }
+            .buttonStyle(.borderless)
+            .help("Edit field")
+
+            Button(role: .destructive) {
+                pendingRemoval = field
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .help("Remove field")
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Editor (add / edit)
+
+    private func editor(state: EditorState) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                Text(state.mode.title)
+                    .font(.system(size: 14, weight: .semibold))
+
+                draftForm(state: state)
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding(16)
+        }
+        .safeAreaInset(edge: .bottom) {
+            HStack {
+                Button("Cancel") {
+                    editorState = nil
+                    errorMessage = nil
+                }
+                .buttonStyle(MercantisSecondaryButtonStyle())
+
+                Spacer()
+
+                Button(state.mode.commitTitle) {
+                    commit(state: state)
+                }
+                .buttonStyle(MercantisPrimaryButtonStyle())
+                .disabled(!state.draft.isCommitReady)
+                .keyboardShortcut(.return, modifiers: [.command])
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(.bar)
+        }
+    }
+
+    @ViewBuilder
+    private func draftForm(state: EditorState) -> some View {
+        let bound = bindingForState()
+
+        Form {
+            Section {
+                LabeledContent("Label") {
+                    TextField("e.g. VAT Number", text: bound.label)
+                        .textFieldStyle(.roundedBorder)
+                }
+                LabeledContent("Field key") {
+                    Text(bound.derivedKey.wrappedValue)
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
+                Toggle("Required", isOn: bound.required)
+            } header: {
+                Text("Basics")
+            } footer: {
+                Text("The field key is derived from the label and used internally. It can't be changed after creating the field.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Type") {
+                Picker("Type", selection: bound.type) {
+                    ForEach(CustomizableFieldType.allCases) { type in
+                        Label(type.label, systemImage: type.symbol).tag(type)
+                    }
+                }
+                .pickerStyle(.menu)
+                .disabled(state.mode.isEdit)
+                .help(state.mode.isEdit
+                      ? "Type can't be changed after creating the field — remove and re-add to switch type."
+                      : "")
+
+                if bound.type.wrappedValue == .select {
+                    LabeledContent("Choices") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            TextEditor(text: bound.optionsText)
+                                .frame(minHeight: 72)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .stroke(.separator, lineWidth: 1)
+                                )
+                            Text("One choice per line.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+
+            Section("Position") {
+                Picker("Place after", selection: bound.insertAfter) {
+                    Text("End of form").tag(String?.none)
+                    ForEach(positionCandidates(for: state), id: \.key) { entry in
+                        Text(entry.label).tag(String?.some(entry.key))
+                    }
+                }
+                .pickerStyle(.menu)
+            }
+        }
+        #if os(macOS)
+        .formStyle(.grouped)
+        #endif
+    }
+
+    private func bindingForState() -> EditorBindings {
+        EditorBindings(
+            label: Binding(
+                get: { editorState?.draft.label ?? "" },
+                set: { editorState?.draft.label = $0 }
+            ),
+            type: Binding(
+                get: { editorState?.draft.type ?? .text },
+                set: { editorState?.draft.type = $0 }
+            ),
+            required: Binding(
+                get: { editorState?.draft.required ?? false },
+                set: { editorState?.draft.required = $0 }
+            ),
+            insertAfter: Binding(
+                get: { editorState?.draft.insertAfter },
+                set: { editorState?.draft.insertAfter = $0 }
+            ),
+            optionsText: Binding(
+                get: { editorState?.draft.optionsText ?? "" },
+                set: { editorState?.draft.optionsText = $0 }
+            ),
+            derivedKey: Binding(
+                get: { editorState?.draft.derivedKey ?? "—" },
+                set: { _ in }
+            )
+        )
+    }
+
+    // MARK: - Commit
+
+    private func commit(state: EditorState) {
+        let draft = state.draft
+        guard let definition = draft.makeFieldDefinition() else {
+            errorMessage = "Please enter a label for the field."
+            return
+        }
+
+        if case .add = state.mode {
+            if reservedKeys.contains(definition.key) {
+                errorMessage = "\"\(definition.key)\" is already used on this form. Pick a different label."
+                return
+            }
+        } else if case .edit(let id) = state.mode {
+            let conflicting = reservedKeys
+                .subtracting(currentEditingFieldKey(id: id))
+            if conflicting.contains(definition.key) {
+                errorMessage = "\"\(definition.key)\" clashes with another field. Pick a different label."
+                return
+            }
+        }
+
+        runProtected {
+            switch state.mode {
+            case .add:
+                try onAdd(CustomField(
+                    docType: docTypeName,
+                    fieldDefinition: definition,
+                    insertAfter: draft.insertAfter
+                ))
+            case .edit(let id):
+                try onUpdate(CustomField(
+                    id: id,
+                    docType: docTypeName,
+                    fieldDefinition: definition,
+                    insertAfter: draft.insertAfter
+                ))
+            }
+            editorState = nil
+        }
+    }
+
+    private func runProtected(_ block: () throws -> Void) {
+        do {
+            try block()
+            errorMessage = nil
+        } catch {
+            errorMessage = (error as NSError).localizedDescription
+        }
+    }
+
+    // MARK: - Validation helpers
+
+    /// Position picker options. Excludes the field currently being edited
+    /// so users can't place a field after itself (which would no-op in the
+    /// merge step but is still confusing UX).
+    private func positionCandidates(for state: EditorState) -> [BaseFieldEntry] {
+        guard case .edit(let id) = state.mode,
+              let editing = customFields.first(where: { $0.id == id }) else {
+            return baseFields
+        }
+        return baseFields.filter { $0.key != editing.fieldDefinition.key }
+    }
+
+    private var reservedKeys: Set<String> {
+        // baseFields already includes existing custom fields' keys (the
+        // host passes the composed list), so this single set covers both
+        // built-in and custom collisions.
+        Set(baseFields.map(\.key))
+    }
+
+    private func currentEditingFieldKey(id: String) -> Set<String> {
+        if let existing = customFields.first(where: { $0.id == id }) {
+            return [existing.fieldDefinition.key]
+        }
+        return []
+    }
+
+    private var removalBinding: Binding<Bool> {
+        Binding<Bool>(
+            get: { pendingRemoval != nil },
+            set: { if !$0 { pendingRemoval = nil } }
+        )
+    }
+
+    private func makeDraft() -> Draft {
+        Draft(
+            label: "",
+            type: .text,
+            required: false,
+            insertAfter: nil,
+            optionsText: ""
+        )
+    }
+}
+
+// MARK: - Draft / editor state
+
+extension CustomizeWorkspaceSheet {
+
+    /// Mutable shape of the field being authored. We translate to / from
+    /// `FieldDefinition` only at commit time so the user can change their
+    /// mind freely.
+    struct Draft {
+        var label: String
+        var type: CustomizableFieldType
+        var required: Bool
+        var insertAfter: String?
+        var optionsText: String
+        /// In edit mode, the field's persistent key is locked to its
+        /// original value so existing document payloads keep matching.
+        /// `nil` in add mode (key is derived from the label).
+        var lockedKey: String?
+
+        init(label: String, type: CustomizableFieldType, required: Bool, insertAfter: String?, optionsText: String, lockedKey: String? = nil) {
+            self.label = label
+            self.type = type
+            self.required = required
+            self.insertAfter = insertAfter
+            self.optionsText = optionsText
+            self.lockedKey = lockedKey
+        }
+
+        init(from field: CustomField, baseFields: [BaseFieldEntry]) {
+            self.label = field.fieldDefinition.label
+            self.type = CustomizableFieldType.from(field.fieldDefinition.type)
+            self.required = field.fieldDefinition.required
+            self.insertAfter = field.insertAfter
+            self.optionsText = (field.fieldDefinition.options ?? []).joined(separator: "\n")
+            self.lockedKey = field.fieldDefinition.key
+        }
+
+        var derivedKey: String {
+            if let lockedKey, !lockedKey.isEmpty { return lockedKey }
+            let candidate = Self.deriveKey(from: label)
+            return candidate.isEmpty ? "—" : candidate
+        }
+
+        var isCommitReady: Bool {
+            !derivedKey.isEmpty && derivedKey != "—"
+        }
+
+        func makeFieldDefinition() -> FieldDefinition? {
+            let key: String
+            if let lockedKey, !lockedKey.isEmpty {
+                key = lockedKey
+            } else {
+                key = Self.deriveKey(from: label)
+                guard !key.isEmpty else { return nil }
+            }
+
+            let options: [String]?
+            if type == .select {
+                let parsed = optionsText
+                    .split(whereSeparator: { $0.isNewline })
+                    .map { $0.trimmingCharacters(in: .whitespaces) }
+                    .filter { !$0.isEmpty }
+                options = parsed.isEmpty ? nil : parsed
+            } else {
+                options = nil
+            }
+
+            return FieldDefinition(
+                key: key,
+                label: label.trimmingCharacters(in: .whitespacesAndNewlines),
+                type: type.fieldType,
+                required: required,
+                options: options
+            )
+        }
+
+        /// "VAT Number" → "vat_number". Strips diacritics, collapses
+        /// non-alphanumerics into a single underscore, lowercases, and
+        /// trims leading digits so the result is a usable identifier.
+        static func deriveKey(from label: String) -> String {
+            let folded = label.folding(options: .diacriticInsensitive, locale: .current)
+            var current = ""
+            var lastWasSeparator = false
+            for ch in folded {
+                if ch.isLetter || ch.isNumber {
+                    current.append(Character(ch.lowercased()))
+                    lastWasSeparator = false
+                } else if !current.isEmpty && !lastWasSeparator {
+                    current.append("_")
+                    lastWasSeparator = true
+                }
+            }
+            while current.hasSuffix("_") { current.removeLast() }
+            while let first = current.first, first.isNumber || first == "_" {
+                current.removeFirst()
+            }
+            return current
+        }
+    }
+
+    enum EditorMode: Equatable {
+        case add
+        case edit(String)
+
+        var title: String {
+            switch self {
+            case .add: return "New field"
+            case .edit: return "Edit field"
+            }
+        }
+
+        var commitTitle: String {
+            switch self {
+            case .add: return "Add Field"
+            case .edit: return "Save Changes"
+            }
+        }
+
+        var isEdit: Bool {
+            if case .edit = self { return true }
+            return false
+        }
+    }
+
+    struct EditorState: Equatable {
+        let mode: EditorMode
+        var draft: Draft
+
+        static func == (lhs: EditorState, rhs: EditorState) -> Bool {
+            lhs.mode == rhs.mode
+                && lhs.draft.label == rhs.draft.label
+                && lhs.draft.type == rhs.draft.type
+                && lhs.draft.required == rhs.draft.required
+                && lhs.draft.insertAfter == rhs.draft.insertAfter
+                && lhs.draft.optionsText == rhs.draft.optionsText
+        }
+    }
+
+    struct EditorBindings {
+        var label: Binding<String>
+        var type: Binding<CustomizableFieldType>
+        var required: Binding<Bool>
+        var insertAfter: Binding<String?>
+        var optionsText: Binding<String>
+        var derivedKey: Binding<String>
+    }
+}

--- a/mercantis core/UIShell/DocTypeBuilderView.swift
+++ b/mercantis core/UIShell/DocTypeBuilderView.swift
@@ -29,6 +29,9 @@ final class DocTypeToolingContext: ObservableObject {
         eventEmitter: eventEmitter
     )
     private var reportEngine: ReportEngine?
+    /// Storage for end-user `CustomField` rows. Exposed so workspaces can
+    /// list / mutate fields on the active DocType.
+    private(set) lazy var customFieldStore = CustomFieldStore(database: database)
 
     init() {
         let dbURL = Self.databaseURL()

--- a/mercantis core/UIShell/NavigationShell.swift
+++ b/mercantis core/UIShell/NavigationShell.swift
@@ -406,42 +406,22 @@ public struct NavigationShell: View {
     @ViewBuilder
     private func docTypeDetail(docTypeId: String) -> some View {
         if let docType = tooling.docType(withId: docTypeId) {
-            let documents = tooling.listDocuments(docTypeId: docType.id)
-            RecordCollectionHostView(
-                preferenceKey: "docType.\(docType.id)",
+            DocTypeWorkspaceContainer(
                 docType: docType,
-                workspaceTitle: docType.id == BuiltInDocTypes.module.id ? "Modules" : nil,
-                documents: documents,
-                configuration: recordCollectionConfiguration(),
-                onCreateDocument: {
-                    let draft = tooling.createDraftDocument(for: docType)
-                    addRecent(.docType(docType.id))
-                    return draft
+                tooling: tooling,
+                activeDocument: Binding(
+                    get: { activeDocument },
+                    set: { activeDocument = $0 }
+                ),
+                onRecordTouched: { documentId in
+                    addRecent(.record(docTypeId: docType.id, documentId: documentId))
                 },
-                onSaveDocument: { document in
-                    let saved = try tooling.saveDocument(document)
-                    activeDocument = saved
-                    addRecent(.record(docTypeId: docType.id, documentId: saved.id))
-                    return saved
-                },
-                onDeleteDocument: { document in
-                    try tooling.deleteDocument(docType: docType.id, id: document.id)
-                    if activeDocument?.id == document.id {
-                        activeDocument = nil
-                    }
-                },
-                initialSelectedDocumentID: activeDocument?.id,
-                onSelectionChange: { selected in
-                    activeDocument = selected
-                    if let selected {
-                        addRecent(.record(docTypeId: docType.id, documentId: selected.id))
-                    }
-                },
-                detailHeader: docType.id == BuiltInDocTypes.module.id
+                detailHeaderForModule: docType.id == BuiltInDocTypes.module.id
                     ? { document in AnyView(moduleSelectedRecordHeader(for: document)) }
                     : nil,
                 externalCreateTrigger: createTriggerBinding(for: docType.id)
             )
+            .id(docType.id)
         } else {
             Text("DocType not found")
                 .foregroundStyle(.secondary)
@@ -1011,4 +991,94 @@ struct WorkspaceDefinition: Identifiable, Hashable {
         WorkspaceDefinition(section: .modules, title: "Modules", icon: "square.grid.2x2", placement: .primary),
         WorkspaceDefinition(section: .settings, title: "Settings", icon: "gear", placement: .secondary)
     ]
+}
+
+/// Small wrapper that owns the per-DocType custom-field state and bridges
+/// the tooling context to `RecordCollectionHostView`. Extracted from
+/// `NavigationShell.docTypeDetail` because the host's customize hooks
+/// need a reactive `[CustomField]` source that re-renders when the user
+/// adds, edits, or removes a field.
+private struct DocTypeWorkspaceContainer: View {
+    let docType: DocType
+    @ObservedObject var tooling: DocTypeToolingContext
+    @Binding var activeDocument: Document?
+    let onRecordTouched: (String) -> Void
+    let detailHeaderForModule: ((Document) -> AnyView)?
+    let externalCreateTrigger: Binding<Bool>
+
+    @State private var customFields: [CustomField] = []
+    @State private var errorMessage: String?
+
+    var body: some View {
+        let documents = tooling.listDocuments(docTypeId: docType.id)
+        return VStack(spacing: 0) {
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal)
+                    .padding(.vertical, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            RecordCollectionHostView(
+                preferenceKey: "docType.\(docType.id)",
+                docType: docType,
+                workspaceTitle: docType.id == BuiltInDocTypes.module.id ? "Modules" : nil,
+                documents: documents,
+                configuration: RecordCollectionViewConfiguration(
+                    supportedViewModes: [.list, .browse, .detail],
+                    defaultViewMode: .list
+                ),
+                onCreateDocument: {
+                    let draft = tooling.createDraftDocument(for: docType)
+                    onRecordTouched(docType.id)
+                    return draft
+                },
+                onSaveDocument: { document in
+                    let saved = try tooling.saveDocument(document)
+                    activeDocument = saved
+                    onRecordTouched(saved.id)
+                    return saved
+                },
+                onDeleteDocument: { document in
+                    try tooling.deleteDocument(docType: docType.id, id: document.id)
+                    if activeDocument?.id == document.id {
+                        activeDocument = nil
+                    }
+                },
+                customFields: customFields,
+                onAddCustomField: { field in
+                    try tooling.customFieldStore.add(field)
+                    reloadCustomFields()
+                },
+                onUpdateCustomField: { field in
+                    try tooling.customFieldStore.update(field)
+                    reloadCustomFields()
+                },
+                onRemoveCustomField: { id in
+                    try tooling.customFieldStore.remove(id: id)
+                    reloadCustomFields()
+                },
+                initialSelectedDocumentID: activeDocument?.id,
+                onSelectionChange: { selected in
+                    activeDocument = selected
+                    if let selected {
+                        onRecordTouched(selected.id)
+                    }
+                },
+                detailHeader: detailHeaderForModule,
+                externalCreateTrigger: externalCreateTrigger
+            )
+        }
+        .onAppear { reloadCustomFields() }
+    }
+
+    private func reloadCustomFields() {
+        do {
+            customFields = try tooling.customFieldStore.list(forDocType: docType.id)
+            errorMessage = nil
+        } catch {
+            errorMessage = "Couldn't load custom fields: \(error.localizedDescription)"
+        }
+    }
 }

--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -25,13 +25,24 @@ public struct RecordCollectionHostView: View {
     /// selection after a successful delete; the caller is responsible for
     /// reloading the `documents` collection it passes in.
     let onDeleteDocument: ((Document) throws -> Void)?
+    /// End-user-authored fields layered on top of `docType`. The host
+    /// merges them into a single composed DocType before rendering the
+    /// list and form, so consumers don't need to do the merge themselves.
+    let customFields: [CustomField]
+    /// Persists a new custom field. When all three customize callbacks are
+    /// provided, a "Customize" toolbar button surfaces a sheet that lets
+    /// end users add / edit / remove fields without touching the base
+    /// DocType definition.
+    let onAddCustomField: ((CustomField) throws -> Void)?
+    let onUpdateCustomField: ((CustomField) throws -> Void)?
+    let onRemoveCustomField: ((String) throws -> Void)?
     let initialSelectedDocumentID: String?
     let onSelectionChange: ((Document?) -> Void)?
     let detailHeader: ((Document) -> AnyView)?
     let externalCreateTrigger: Binding<Bool>?
     let linkSearchProvider: ((String, String) -> [Document])?
     let childDocTypeProvider: ((String) -> DocType?)?
-    let detailEditor: ((Binding<Document>) -> AnyView)?
+    let detailEditor: ((DocType, Binding<Document>) -> AnyView)?
 
     @State private var selectedDocument: Document?
     @State private var selectedDocumentID: String?
@@ -41,6 +52,7 @@ public struct RecordCollectionHostView: View {
     @State private var lastSavedAt: Date?
     @State private var lastSavedID: String?
     @State private var pendingDeleteDocument: Document?
+    @State private var showCustomizeSheet = false
 
     public init(
         preferenceKey: String,
@@ -57,13 +69,17 @@ public struct RecordCollectionHostView: View {
         workspaceOverflowMenu: (() -> AnyView)? = nil,
         onSaveDocument: ((Document) throws -> Document?)? = nil,
         onDeleteDocument: ((Document) throws -> Void)? = nil,
+        customFields: [CustomField] = [],
+        onAddCustomField: ((CustomField) throws -> Void)? = nil,
+        onUpdateCustomField: ((CustomField) throws -> Void)? = nil,
+        onRemoveCustomField: ((String) throws -> Void)? = nil,
         initialSelectedDocumentID: String? = nil,
         onSelectionChange: ((Document?) -> Void)? = nil,
         detailHeader: ((Document) -> AnyView)? = nil,
         externalCreateTrigger: Binding<Bool>? = nil,
         linkSearchProvider: ((String, String) -> [Document])? = nil,
         childDocTypeProvider: ((String) -> DocType?)? = nil,
-        detailEditor: ((Binding<Document>) -> AnyView)? = nil
+        detailEditor: ((DocType, Binding<Document>) -> AnyView)? = nil
     ) {
         self.preferenceKey = preferenceKey
         self.docType = docType
@@ -79,6 +95,10 @@ public struct RecordCollectionHostView: View {
         self.workspaceOverflowMenu = workspaceOverflowMenu
         self.onSaveDocument = onSaveDocument
         self.onDeleteDocument = onDeleteDocument
+        self.customFields = customFields
+        self.onAddCustomField = onAddCustomField
+        self.onUpdateCustomField = onUpdateCustomField
+        self.onRemoveCustomField = onRemoveCustomField
         self.initialSelectedDocumentID = initialSelectedDocumentID
         self.onSelectionChange = onSelectionChange
         self.detailHeader = detailHeader
@@ -98,7 +118,7 @@ public struct RecordCollectionHostView: View {
         .toolbar(content: workspaceToolbar)
         .sheet(item: $createSheetDraft) { _ in
             CreateRecordSheet(
-                docType: docType,
+                docType: effectiveDocType,
                 draft: Binding(
                     get: { createSheetDraft ?? emptyDocument(for: docType.id) },
                     set: { createSheetDraft = $0 }
@@ -142,6 +162,56 @@ public struct RecordCollectionHostView: View {
         } message: { document in
             Text("This will permanently remove \(document.id.isEmpty ? "this draft" : document.id). This action cannot be undone.")
         }
+        .sheet(isPresented: $showCustomizeSheet) {
+            if canCustomizeFields {
+                // `effectiveDocType.fields` is base + custom so the Position
+                // picker lets users place a new field after either a built-in
+                // field or one of their own additions.
+                CustomizeWorkspaceSheet(
+                    docTypeName: docType.name,
+                    baseFields: effectiveDocType.fields.map {
+                        CustomizeWorkspaceSheet.BaseFieldEntry(key: $0.key, label: $0.label)
+                    },
+                    customFields: customFields,
+                    onAdd: onAddCustomField ?? { _ in },
+                    onUpdate: onUpdateCustomField ?? { _ in },
+                    onRemove: onRemoveCustomField ?? { _ in }
+                )
+            }
+        }
+    }
+
+    /// All three customize callbacks must be supplied to enable the
+    /// in-app editor. A consumer that wants read-only custom fields can
+    /// pass `customFields` without any of the callbacks.
+    private var canCustomizeFields: Bool {
+        onAddCustomField != nil
+            && onUpdateCustomField != nil
+            && onRemoveCustomField != nil
+    }
+
+    /// `docType` with any persisted custom fields merged in at their
+    /// declared `insertAfter` positions. Used wherever the host renders
+    /// the form / list so end-user fields show up natively.
+    private var effectiveDocType: DocType {
+        Self.merge(base: docType, customFields: customFields)
+    }
+
+    private static func merge(base: DocType, customFields: [CustomField]) -> DocType {
+        guard !customFields.isEmpty else { return base }
+        var composed = base
+        var fields = composed.fields
+        for cf in customFields {
+            let new = cf.fieldDefinition
+            if let after = cf.insertAfter, !after.isEmpty,
+               let idx = fields.firstIndex(where: { $0.key == after }) {
+                fields.insert(new, at: fields.index(after: idx))
+            } else {
+                fields.append(new)
+            }
+        }
+        composed.fields = fields
+        return composed
     }
 
     private var pendingDeleteBinding: Binding<Bool> {
@@ -196,13 +266,16 @@ public struct RecordCollectionHostView: View {
             // would render two identical "+ New <DocType>" buttons on every
             // workspace.
             onPrimaryAction: nil,
+            onCustomizeFields: canCustomizeFields
+                ? { showCustomizeSheet = true }
+                : nil,
             overflowMenuContent: workspaceOverflowMenu
         )
     }
 
     private var listPane: some View {
         GenericListView(
-            docType: docType,
+            docType: effectiveDocType,
             documents: documents,
             onSelect: selectDocument(_:),
             onCreate: handleCreateDocument
@@ -230,10 +303,10 @@ public struct RecordCollectionHostView: View {
                 }
 
                 if let detailEditor {
-                    detailEditor(selectedDocumentBinding)
+                    detailEditor(effectiveDocType, selectedDocumentBinding)
                 } else {
                     GenericFormView(
-                        docType: docType,
+                        docType: effectiveDocType,
                         document: selectedDocumentBinding,
                         linkSearchProvider: linkSearchProvider,
                         childDocTypeProvider: childDocTypeProvider

--- a/mercantis core/UIShell/RecordWorkspaceChrome.swift
+++ b/mercantis core/UIShell/RecordWorkspaceChrome.swift
@@ -9,6 +9,7 @@ public struct RecordWorkspaceToolbarContent: ToolbarContent {
     let supportedViewModes: [RecordViewMode]
     let primaryActionTitle: String
     let onPrimaryAction: (() -> Void)?
+    let onCustomizeFields: (() -> Void)?
     let overflowMenuContent: (() -> AnyView)?
 
     public init(
@@ -17,6 +18,7 @@ public struct RecordWorkspaceToolbarContent: ToolbarContent {
         supportedViewModes: [RecordViewMode],
         primaryActionTitle: String = "New",
         onPrimaryAction: (() -> Void)? = nil,
+        onCustomizeFields: (() -> Void)? = nil,
         overflowMenuContent: (() -> AnyView)? = nil
     ) {
         self.statusText = statusText
@@ -24,6 +26,7 @@ public struct RecordWorkspaceToolbarContent: ToolbarContent {
         self.supportedViewModes = supportedViewModes
         self.primaryActionTitle = primaryActionTitle
         self.onPrimaryAction = onPrimaryAction
+        self.onCustomizeFields = onCustomizeFields
         self.overflowMenuContent = overflowMenuContent
     }
 
@@ -44,6 +47,15 @@ public struct RecordWorkspaceToolbarContent: ToolbarContent {
             .labelsHidden()
             .frame(minWidth: 220)
             .accessibilityLabel(Text("Record View Mode"))
+        }
+
+        if let onCustomizeFields {
+            ToolbarItem(placement: .automatic) {
+                Button(action: onCustomizeFields) {
+                    Label("Customize", systemImage: "slider.horizontal.3")
+                }
+                .help("Add or change custom fields on this form")
+            }
         }
 
         if let onPrimaryAction {

--- a/mercantis coreTests/CustomFieldStoreTests.swift
+++ b/mercantis coreTests/CustomFieldStoreTests.swift
@@ -1,0 +1,132 @@
+//
+//  CustomFieldStoreTests.swift
+//  mercantis coreTests
+//
+//  Covers persistence of end-user CustomField rows: insert / list /
+//  update / remove + uniqueness of (docType, fieldKey).
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class CustomFieldStoreTests: XCTestCase {
+
+    private var url: URL!
+    private var database: MercantisDatabase!
+    private var store: CustomFieldStore!
+
+    override func setUpWithError() throws {
+        url = TestSupport.tempDatabaseURL()
+        database = try TestSupport.makeDatabase(at: url)
+        store = CustomFieldStore(database: database)
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: url)
+    }
+
+    // MARK: - List
+
+    func testListReturnsEmptyForUnknownDocType() throws {
+        XCTAssertTrue(try store.list(forDocType: "Customer").isEmpty)
+    }
+
+    func testListReturnsRowsInCreationOrder() throws {
+        try store.add(makeField(docType: "Customer", key: "vat_number"))
+        try store.add(makeField(docType: "Customer", key: "loyalty_tier"))
+
+        let fields = try store.list(forDocType: "Customer")
+        XCTAssertEqual(fields.map(\.fieldDefinition.key), ["vat_number", "loyalty_tier"])
+    }
+
+    func testListScopesByDocType() throws {
+        try store.add(makeField(docType: "Customer", key: "vat_number"))
+        try store.add(makeField(docType: "Supplier", key: "vat_number"))
+
+        XCTAssertEqual(try store.list(forDocType: "Customer").count, 1)
+        XCTAssertEqual(try store.list(forDocType: "Supplier").count, 1)
+    }
+
+    // MARK: - loadAll
+
+    func testLoadAllGroupsByDocType() throws {
+        try store.add(makeField(docType: "Customer", key: "vat_number"))
+        try store.add(makeField(docType: "Customer", key: "loyalty_tier"))
+        try store.add(makeField(docType: "Supplier", key: "vat_number"))
+
+        let grouped = try store.loadAll()
+        XCTAssertEqual(Set(grouped.keys), ["Customer", "Supplier"])
+        XCTAssertEqual(grouped["Customer"]?.count, 2)
+        XCTAssertEqual(grouped["Supplier"]?.count, 1)
+    }
+
+    // MARK: - Add
+
+    func testDuplicateKeyOnSameDocTypeIsRejected() throws {
+        try store.add(makeField(docType: "Customer", key: "vat_number"))
+        XCTAssertThrowsError(try store.add(makeField(docType: "Customer", key: "vat_number")))
+    }
+
+    func testInsertAfterIsPersistedAndNullifiedWhenEmpty() throws {
+        try store.add(makeField(docType: "Customer", key: "a", insertAfter: "phone"))
+        try store.add(makeField(docType: "Customer", key: "b", insertAfter: ""))
+
+        let fields = try store.list(forDocType: "Customer")
+        XCTAssertEqual(fields[0].insertAfter, "phone")
+        XCTAssertNil(fields[1].insertAfter, "Empty insert_after should round-trip as nil.")
+    }
+
+    // MARK: - Update
+
+    func testUpdateReplacesDefinitionAndInsertAfter() throws {
+        var field = makeField(docType: "Customer", key: "vat_number", label: "VAT", insertAfter: nil)
+        try store.add(field)
+
+        field = CustomField(
+            id: field.id,
+            docType: field.docType,
+            fieldDefinition: FieldDefinition(
+                key: "vat_number",
+                label: "VAT Number",
+                type: .text,
+                required: true
+            ),
+            insertAfter: "email"
+        )
+        try store.update(field)
+
+        let reloaded = try XCTUnwrap(try store.list(forDocType: "Customer").first)
+        XCTAssertEqual(reloaded.fieldDefinition.label, "VAT Number")
+        XCTAssertTrue(reloaded.fieldDefinition.required)
+        XCTAssertEqual(reloaded.insertAfter, "email")
+    }
+
+    // MARK: - Remove
+
+    func testRemoveDropsTheRow() throws {
+        let field = makeField(docType: "Customer", key: "vat_number")
+        try store.add(field)
+        try store.remove(id: field.id)
+        XCTAssertTrue(try store.list(forDocType: "Customer").isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeField(
+        docType: String,
+        key: String,
+        label: String? = nil,
+        insertAfter: String? = nil
+    ) -> CustomField {
+        CustomField(
+            docType: docType,
+            fieldDefinition: FieldDefinition(
+                key: key,
+                label: label ?? key,
+                type: .text,
+                required: false
+            ),
+            insertAfter: insertAfter
+        )
+    }
+}


### PR DESCRIPTION
Adds an end-to-end "Customize fields" affordance so a small-business user can extend any record workspace (e.g. add VAT Number to Customer) without touching the manifest or restarting the app.

Persistence (Core):
- Migration v12 introduces a `custom_fields` table with a UNIQUE (doctype, field_key) constraint and an `insert_after` column for positioning.
- `CustomFieldStore` provides CRUD over that table plus a `loadAll()` hydrator for app start. Backed by GRDB, round-trips through `FieldDefinition`'s existing Codable surface.

Composition + UI (Core):
- `RecordCollectionHostView` gains `customFields:` plus `onAddCustomField` / `onUpdateCustomField` / `onRemoveCustomField` hooks. When all three are present a "Customize" toolbar button appears (via `RecordWorkspaceToolbarContent.onCustomizeFields`) and opens the new `CustomizeWorkspaceSheet`.
- The host merges customFields onto the base DocType (preserving `insertAfter`) and renders form, list, and create sheet from this composed DocType, so end-user fields show up natively without any caller-side work.
- `detailEditor` closures now receive the composed `DocType` alongside the document binding so custom editors (e.g. Hub's `HubDocumentEditor`) can render the merged fields without re-doing the merge themselves.

Customize sheet UX:
- Designed for non-developers: Label, Type (Text / Long text / Number / Decimal / Money / Yes-No / Date / Choice), Required toggle, and a Position picker offering "End of form" or any existing field (built-in or custom).
- Field key is derived from the label (e.g. "VAT Number" → `vat_number`) — diacritic-folded, snake-cased, leading-digit stripped.
- On edit the key is locked to its original value so existing document payloads keep matching, and the type picker is disabled (changing type would break data round-trip).
- Inline list with edit / remove (native confirmationDialog), explicit empty state, and clear copy.

`DocTypeToolingContext` exposes a shared `CustomFieldStore` so Core's own DocType workspaces participate. `NavigationShell.docTypeDetail` is wrapped in a new `DocTypeWorkspaceContainer` that owns the per-DocType custom-field reactive state.

Tests:
- `CustomFieldStoreTests` covers list / add / update / remove, uniqueness, scope-by-doctype, and the empty-vs-nil insert_after round-trip.
- `CustomizeWorkspaceSheetTests` covers key derivation edge cases (diacritics, punctuation, leading digits, multi-word) and FieldDefinition translation including the locked-key edit path.