### PR TITLE
feat(ui): highlight selected list row + mark required form fields

### DIFF
--- a/mercantis core/UIShell/GenericFormView.swift
+++ b/mercantis core/UIShell/GenericFormView.swift
@@ -95,15 +95,34 @@ public struct GenericFormView: View {
 
         if usesStackedLayout(field) {
             VStack(alignment: .leading, spacing: 6) {
-                Text(field.label)
+                fieldLabel(for: field)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                 fieldControl(for: field, isReadOnly: isReadOnly)
             }
         } else {
-            LabeledContent(field.label) {
+            LabeledContent {
                 fieldControl(for: field, isReadOnly: isReadOnly)
+            } label: {
+                fieldLabel(for: field)
             }
+        }
+    }
+
+    /// Field label with a red asterisk appended when the field is
+    /// required, plus an accessibility hint so VoiceOver announces it.
+    @ViewBuilder
+    private func fieldLabel(for field: FieldDefinition) -> some View {
+        if field.required {
+            HStack(spacing: 2) {
+                Text(field.label)
+                Text("*")
+                    .foregroundStyle(MercantisTheme.danger)
+                    .accessibilityHidden(true)
+            }
+            .accessibilityLabel(Text("\(field.label), required"))
+        } else {
+            Text(field.label)
         }
     }
 

--- a/mercantis core/UIShell/GenericListView.swift
+++ b/mercantis core/UIShell/GenericListView.swift
@@ -16,6 +16,7 @@ public struct GenericListView: View {
 
     let docType: DocType
     let documents: [Document]
+    let selectedDocumentID: String?
     let onSelect: ((Document) -> Void)?
     let onCreate: (() -> Void)?
 
@@ -26,11 +27,13 @@ public struct GenericListView: View {
     public init(
         docType: DocType,
         documents: [Document],
+        selectedDocumentID: String? = nil,
         onSelect: ((Document) -> Void)? = nil,
         onCreate: (() -> Void)? = nil
     ) {
         self.docType = docType
         self.documents = documents
+        self.selectedDocumentID = selectedDocumentID
         self.onSelect = onSelect
         self.onCreate = onCreate
     }
@@ -112,36 +115,55 @@ public struct GenericListView: View {
 
     private var documentTable: some View {
         List(processedDocuments) { doc in
+            let isSelected = doc.id == selectedDocumentID
             Button(action: { onSelect?(doc) }) {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack {
-                        Text(titleValue(for: doc))
-                            .font(.headline)
-                        Spacer()
-                        statusBadge(for: doc.status)
-                    }
+                HStack(alignment: .top, spacing: 8) {
+                    // Leading accent bar mirrors the sidebar's selected
+                    // treatment so users see at a glance which record is
+                    // being shown on the right pane.
+                    RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                        .fill(isSelected ? MercantisTheme.accent : Color.clear)
+                        .frame(width: 3)
 
-                    ForEach(displayFields, id: \.key) { field in
-                        let value = displayValue(for: field.key, in: doc)
-                        if value != "—" {
-                            HStack(spacing: 6) {
-                                Text(field.label)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                Text(value)
-                                    .font(.subheadline)
-                                    .lineLimit(field.type == .richText ? 1 : nil)
-                                    .truncationMode(.tail)
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text(titleValue(for: doc))
+                                .font(.headline)
+                                .fontWeight(isSelected ? .bold : .semibold)
+                                .foregroundStyle(isSelected ? MercantisTheme.accent : MercantisTheme.textPrimary)
+                            Spacer()
+                            statusBadge(for: doc.status)
+                        }
+
+                        ForEach(displayFields, id: \.key) { field in
+                            let value = displayValue(for: field.key, in: doc)
+                            if value != "—" {
+                                HStack(spacing: 6) {
+                                    Text(field.label)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    Text(value)
+                                        .font(.subheadline)
+                                        .lineLimit(field.type == .richText ? 1 : nil)
+                                        .truncationMode(.tail)
+                                }
                             }
                         }
-                    }
 
-                    Text(doc.id)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        Text(doc.id)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, 4)
+                .padding(.vertical, 6)
+                .padding(.horizontal, 4)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(isSelected ? MercantisTheme.accentFillSoft : Color.clear)
+                )
+                .contentShape(Rectangle())
+                .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
             }
             .buttonStyle(.plain)
         }

--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -277,6 +277,7 @@ public struct RecordCollectionHostView: View {
         GenericListView(
             docType: effectiveDocType,
             documents: documents,
+            selectedDocumentID: selectedDocument?.id,
             onSelect: selectDocument(_:),
             onCreate: handleCreateDocument
         )


### PR DESCRIPTION
Two small UX fixes flagged on the Hub Customer workspace:

1. In browse mode, the record list on the left didn't indicate which row was currently being shown on the right. With two "Kevin Busuttil" drafts it was impossible to tell them apart. `GenericListView` now takes a `selectedDocumentID:` and paints the matching row with the soft accent fill + leading accent bar already used by the sidebar's selected treatment, plus a bolder accent- tinted title and an `.isSelected` accessibility trait. `RecordCollectionHostView.listPane` threads `selectedDocument?.id` through automatically.

2. Required fields had no visual marker, so users couldn't tell that "Customer Type" was mandatory until Save bounced the form. Every `FieldDefinition.required == true` field in `GenericFormView` now shows a red asterisk after its label (both stacked layouts and `LabeledContent`), with the asterisk hidden from VoiceOver and the underlying label announced as "<label>, required" instead.