### PR TITLE
fix(child-table): hide built-in label & strip default field chrome in…

### DIFF
--- a/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
+++ b/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
@@ -224,6 +224,14 @@ private struct MercantisBuilderSelectionModifier: ViewModifier {
 private struct MercantisInputModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
+            // Strip the platform-default TextField chrome and external label.
+            // Without these, macOS Form contexts render the TextField's `title`
+            // argument as an external left-aligned label, which collapses into
+            // unreadable per-character columns inside narrow cells (e.g. child
+            // tables with many columns). Both modifiers are safe no-ops for
+            // non-TextField/labelled views.
+            .textFieldStyle(.plain)
+            .labelsHidden()
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
             .background(


### PR DESCRIPTION
… mercantisInput()

Child-table cells render TextFields inside a SwiftUI Form (GenericFormView uses .formStyle(.grouped) on macOS). The default TextField style in that context surfaces the `title` argument as an external left-aligned label. With many narrow columns (e.g. Sales Order line items) that label gets squished into per-character vertical columns, producing the unreadable grid seen in the New Sales Order sheet.

The shared mercantisInput() modifier now applies .textFieldStyle(.plain) and .labelsHidden(), so the wrapped TextField shows its placeholder inside the rounded background it already provides — fixing every child-table field and any other Form-hosted call site in one place. Both modifiers are safe no-ops on non-TextField / non-labelled views.