### PR TITLE
fix(child-table): align header label columns with data cell columns

### DIFF
--- a/mercantis core/UIShell/ChildTableField.swift
+++ b/mercantis core/UIShell/ChildTableField.swift
@@ -81,6 +81,11 @@ public struct ChildTableField: View {
         }
     }
 
+    // Shared between header and data rows so column edges line up exactly —
+    // any drift here multiplies across N columns and pushes the header out
+    // of register with its data cells.
+    private static let cellHPadding: CGFloat = 8
+
     // MARK: - Header
 
     private func headerRow(docType: DocType) -> some View {
@@ -93,9 +98,9 @@ public struct ChildTableField: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .frame(minWidth: minWidth(for: f), maxWidth: .infinity, alignment: alignment(for: f))
-                    .padding(.horizontal, 10)
+                    .padding(.horizontal, Self.cellHPadding)
             }
-            trailingCell { EmptyView() }
+            trailingCell { Color.clear }
         }
         .padding(.vertical, 8)
         .background(MercantisTheme.surfaceMuted)
@@ -114,8 +119,12 @@ public struct ChildTableField: View {
             }
             ForEach(docType.fields) { f in
                 childFieldCell(field: f, rowIdx: rowIdx)
-                    .frame(minWidth: minWidth(for: f), maxWidth: .infinity, alignment: alignment(for: f))
-                    .padding(.horizontal, 8)
+                    // No `alignment:` here — the control inside already
+                    // fills the cell via `.frame(maxWidth: .infinity)`, so
+                    // any text alignment happens via
+                    // `.multilineTextAlignment(...)` inside the control.
+                    .frame(minWidth: minWidth(for: f), maxWidth: .infinity)
+                    .padding(.horizontal, Self.cellHPadding)
             }
             trailingCell {
                 if !isReadOnly {
@@ -143,6 +152,11 @@ public struct ChildTableField: View {
 
     @ViewBuilder
     private func childFieldCell(field f: FieldDefinition, rowIdx: Int) -> some View {
+        // `.frame(maxWidth: .infinity)` on each control forces the visible
+        // chrome (rounded input background, date picker, toggle) to fill the
+        // cell allocation, so column edges line up with the header `Text`
+        // above. Without this, controls sit at their ideal content width and
+        // shift left/right relative to the column.
         switch f.type {
         case .number, .decimal, .currency:
             TextField(f.label, text: numberCellBinding(field: f, idx: rowIdx))
@@ -152,10 +166,12 @@ public struct ChildTableField: View {
                 .keyboardType(.decimalPad)
 #endif
                 .disabled(isReadOnly)
+                .frame(maxWidth: .infinity)
         case .boolean:
             Toggle("", isOn: boolCellBinding(field: f, idx: rowIdx))
                 .labelsHidden()
                 .disabled(isReadOnly)
+                .frame(maxWidth: .infinity)
         case .date, .datetime:
             DatePicker(
                 "",
@@ -164,10 +180,12 @@ public struct ChildTableField: View {
             )
             .labelsHidden()
             .disabled(isReadOnly)
+            .frame(maxWidth: .infinity, alignment: alignment(for: f))
         default:
             TextField(f.label, text: stringCellBinding(field: f, idx: rowIdx))
                 .mercantisInput()
                 .disabled(isReadOnly)
+                .frame(maxWidth: .infinity)
         }
     }
 


### PR DESCRIPTION
Two sources of column drift between header row and data rows:

1. Header used `.padding(.horizontal, 10)` per cell; data row used 8. Across 8 columns the 4 pt-per-cell delta accumulated to 32 pt of horizontal misalignment.

2. Header cells were `Text` inside `.frame(maxWidth: .infinity)`, which stretches the box to fill its column. Data cells were `TextField` / `DatePicker` / `Toggle` inside `.frame(maxWidth: .infinity, alignment: …)` — but those controls don't fill their frame by default; they sit at their ideal content width and `alignment:` only positions them within the cell. So the visible chrome (rounded TextField background, date picker) stopped well short of the cell edge, leaving header labels and data controls landing at different x positions.

Fix:

- Extract a shared `cellHPadding` constant (8 pt) used by both header and data rows so the per-cell budget can never drift again.
- Add `.frame(maxWidth: .infinity)` to every control inside `childFieldCell` so the chrome itself fills the cell. Text alignment (e.g. right-aligned currency) is now done via `.multilineTextAlignment(.trailing)` inside the TextField, not via the outer frame alignment — which means the rounded background still spans the full column.
- Drop the outer `alignment:` argument on the data row cells (no longer needed once controls fill their frame). DatePicker is the one exception — it stays a fixed-width widget on macOS, so it keeps the cell-level alignment to anchor it at the column's edge.