### PR TITLE
Resolve link field labels from target document metadata

### DIFF
--- a/Tests/MercantisCoreUITests/LinkLabelTests.swift
+++ b/Tests/MercantisCoreUITests/LinkLabelTests.swift
@@ -1,0 +1,89 @@
+//
+//  LinkLabelTests.swift
+//  MercantisCoreUITests
+//
+//  Unit coverage for `LinkLabel` — the shared display-label resolver for
+//  link fields. Link fields persist the target document's id; the label is
+//  resolved at render time from the target DocType's `titleField`. These
+//  tests pin that resolution (and its fallbacks) so the collapsed picker
+//  shows a human label rather than the raw key id.
+//
+
+import XCTest
+import MercantisCore
+import MercantisCoreUI
+
+final class LinkLabelTests: XCTestCase {
+
+    /// Minimal DocType carrying just a `titleField` — the only thing
+    /// `LinkLabel` reads from meta.
+    private func makeMeta(titleField: String) -> DocType {
+        DocType(
+            id: "Target",
+            name: "Target",
+            module: "Test",
+            appId: "app.mercantis.test",
+            isChildTable: false,
+            fields: [
+                FieldDefinition(key: titleField, label: titleField, type: .text, required: false)
+            ],
+            permissions: [],
+            syncPolicy: SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false),
+            indexes: [],
+            searchFields: [titleField],
+            titleField: titleField
+        )
+    }
+
+    private func makeDoc(id: String, fields: [String: FieldValue]) -> Document {
+        let now = Date()
+        return Document(
+            id: id,
+            docType: "Target",
+            company: "",
+            status: "",
+            createdAt: now,
+            updatedAt: now,
+            syncVersion: 0,
+            syncState: .local,
+            fields: fields,
+            children: [:]
+        )
+    }
+
+    /// The authoritative path: the target DocType declares `titleField`, so the
+    /// label is that field's value — not the id.
+    func testPrefersDeclaredTitleField() {
+        let meta = makeMeta(titleField: "group_name")
+        let doc = makeDoc(id: "CG-001", fields: ["group_name": .string("Commercial")])
+
+        XCTAssertEqual(LinkLabel.title(for: doc, meta: meta), "Commercial")
+    }
+
+    /// Without resolved meta, falls back to a conventional title key.
+    func testFallsBackToConventionalKeyWhenNoMeta() {
+        let doc = makeDoc(id: "ITEM-1", fields: ["item_name": .string("Widget")])
+
+        XCTAssertEqual(LinkLabel.title(for: doc, meta: nil), "Widget")
+    }
+
+    /// An empty/blank declared title field doesn't win — resolution continues
+    /// past it to a conventional key.
+    func testSkipsEmptyTitleField() {
+        let meta = makeMeta(titleField: "group_name")
+        let doc = makeDoc(id: "CG-002", fields: [
+            "group_name": .string(""),
+            "name": .string("Retail")
+        ])
+
+        XCTAssertEqual(LinkLabel.title(for: doc, meta: meta), "Retail")
+    }
+
+    /// Last resort: a document with no usable string field shows its id, which
+    /// is the pre-fix behaviour and the safe floor.
+    func testFallsBackToIdWhenNoLabelAvailable() {
+        let doc = makeDoc(id: "CG-003", fields: [:])
+
+        XCTAssertEqual(LinkLabel.title(for: doc, meta: nil), "CG-003")
+    }
+}

--- a/mercantis core/UIShell/CreateRecordSheet.swift
+++ b/mercantis core/UIShell/CreateRecordSheet.swift
@@ -16,6 +16,7 @@ struct CreateRecordSheet: View {
     @Binding var draft: Document
     let onCreate: (Document) throws -> Void
     let linkSearchProvider: ((String, String) -> [Document])?
+    let linkResolveProvider: ((String, String) -> Document?)?
     let childDocTypeProvider: ((String) -> DocType?)?
 
     @State private var errorMessage: String?
@@ -25,12 +26,14 @@ struct CreateRecordSheet: View {
         draft: Binding<Document>,
         onCreate: @escaping (Document) throws -> Void,
         linkSearchProvider: ((String, String) -> [Document])? = nil,
+        linkResolveProvider: ((String, String) -> Document?)? = nil,
         childDocTypeProvider: ((String) -> DocType?)? = nil
     ) {
         self.docType = docType
         self._draft = draft
         self.onCreate = onCreate
         self.linkSearchProvider = linkSearchProvider
+        self.linkResolveProvider = linkResolveProvider
         self.childDocTypeProvider = childDocTypeProvider
     }
 
@@ -52,6 +55,7 @@ struct CreateRecordSheet: View {
                 docType: docType,
                 document: $draft,
                 linkSearchProvider: linkSearchProvider,
+                linkResolveProvider: linkResolveProvider,
                 childDocTypeProvider: childDocTypeProvider
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/mercantis core/UIShell/GenericFormView.swift
+++ b/mercantis core/UIShell/GenericFormView.swift
@@ -38,6 +38,9 @@ public struct GenericFormView: View {
     let userRoles: Set<String>
     let expressionEvaluator: ExpressionEvaluator
     let linkSearchProvider: ((String, String) -> [Document])?
+    /// Resolves a single linked document by (targetDocType, id) so link fields
+    /// can render a human label for the current selection instead of its id.
+    let linkResolveProvider: ((String, String) -> Document?)?
     let childDocTypeProvider: ((String) -> DocType?)?
 
     public init(
@@ -46,6 +49,7 @@ public struct GenericFormView: View {
         userRoles: Set<String> = [],
         expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator(),
         linkSearchProvider: ((String, String) -> [Document])? = nil,
+        linkResolveProvider: ((String, String) -> Document?)? = nil,
         childDocTypeProvider: ((String) -> DocType?)? = nil
     ) {
         self.docType = docType
@@ -53,6 +57,7 @@ public struct GenericFormView: View {
         self.userRoles = userRoles
         self.expressionEvaluator = expressionEvaluator
         self.linkSearchProvider = linkSearchProvider
+        self.linkResolveProvider = linkResolveProvider
         self.childDocTypeProvider = childDocTypeProvider
     }
 
@@ -464,14 +469,20 @@ public struct GenericFormView: View {
         // W4: delegate to LinkPickerField. When linkSearchProvider is nil the
         // picker falls back to plain text entry (no behaviour change for callers
         // that haven't wired a provider yet).
+        let target = field.linkedDocType ?? ""
         let provider: ((String, String) -> [Document])? = linkSearchProvider.map { base in
-            { _, query in base(field.linkedDocType ?? "", query) }
+            { _, query in base(target, query) }
+        }
+        let resolve: ((String) -> Document?)? = linkResolveProvider.map { base in
+            { id in base(target, id) }
         }
         return LinkPickerField(
-            targetDocType: field.linkedDocType ?? "Link",
+            targetDocType: target.isEmpty ? "Link" : target,
             value: stringBinding(for: field),
             isReadOnly: isReadOnly,
-            searchProvider: provider
+            targetMeta: childDocTypeProvider?(target),
+            searchProvider: provider,
+            resolveDocument: resolve
         )
     }
 

--- a/mercantis core/UIShell/LinkLabel.swift
+++ b/mercantis core/UIShell/LinkLabel.swift
@@ -1,0 +1,56 @@
+//
+//  LinkLabel.swift
+//  mercantis core
+//
+//  Display-label resolution for FieldType.link fields. (ADR-030 follow-up)
+//
+//  Link fields persist the target document's ID as the single source of
+//  truth — no denormalised display string is stored, so labels never go
+//  stale when the linked record is renamed. The human-facing label is
+//  resolved here, at render time, driven by each DocType's declared
+//  `titleField`. Centralising this (rather than guessing per-app or
+//  per-view) means every link field across every app renders consistently.
+//
+
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+/// Resolves the human-facing display label for a linked document.
+public enum LinkLabel {
+
+    /// Display title for `doc`, preferring the target DocType's declared
+    /// `titleField`. Falls back to a small set of conventional title keys
+    /// (for targets whose meta wasn't resolved), then to the first non-empty
+    /// string field, then to the raw id as a last resort.
+    public static func title(for doc: Document, meta: DocType?) -> String {
+        // 1. Metadata-declared title field — the authoritative choice.
+        if let titleField = meta?.titleField,
+           let value = string(doc.fields[titleField]), !value.isEmpty {
+            return value
+        }
+        // 2. Conventional title keys — covers targets whose meta wasn't
+        //    resolved (e.g. no childDocTypeProvider wired).
+        let candidateKeys = ["customer_name", "supplier_name", "item_name",
+                             "lead_name", "first_name", "title", "name",
+                             "address_title", "label"]
+        for key in candidateKeys {
+            if let value = string(doc.fields[key]), !value.isEmpty {
+                return value
+            }
+        }
+        // 3. First non-empty string field that isn't the id itself.
+        for (_, value) in doc.fields {
+            if let s = string(value), !s.isEmpty, s != doc.id {
+                return s
+            }
+        }
+        // 4. Last resort: the raw id.
+        return doc.id
+    }
+
+    private static func string(_ value: FieldValue?) -> String? {
+        if case .string(let s)? = value { return s }
+        return nil
+    }
+}

--- a/mercantis core/UIShell/LinkPickerField.swift
+++ b/mercantis core/UIShell/LinkPickerField.swift
@@ -28,7 +28,15 @@ public struct LinkPickerField: View {
     let targetDocType: String
     @Binding var value: String
     let isReadOnly: Bool
+    /// Resolved metadata for the target DocType, used to pick its `titleField`
+    /// when rendering display labels. `nil` falls back to convention-based
+    /// label resolution (see `LinkLabel`).
+    let targetMeta: DocType?
     let searchProvider: ((String, String) -> [Document])?
+    /// Fetches the currently-linked document by its stored id so the collapsed
+    /// field can show a human label instead of the raw id. `nil` falls back to
+    /// displaying the stored id verbatim.
+    let resolveDocument: ((String) -> Document?)?
 
     @State private var isPickerPresented = false
     @State private var searchQuery = ""
@@ -39,17 +47,32 @@ public struct LinkPickerField: View {
         targetDocType: String,
         value: Binding<String>,
         isReadOnly: Bool,
-        searchProvider: ((String, String) -> [Document])?
+        targetMeta: DocType? = nil,
+        searchProvider: ((String, String) -> [Document])?,
+        resolveDocument: ((String) -> Document?)? = nil
     ) {
         self.targetDocType = targetDocType
         self._value = value
         self.isReadOnly = isReadOnly
+        self.targetMeta = targetMeta
         self.searchProvider = searchProvider
+        self.resolveDocument = resolveDocument
+    }
+
+    /// Human-facing label for the current selection. Resolves the stored id to
+    /// its target document and reads the title field; falls back to the raw id
+    /// when no resolver is wired or the target can't be found.
+    private var displayLabel: String {
+        guard !value.isEmpty else { return "" }
+        if let resolveDocument, let doc = resolveDocument(value) {
+            return LinkLabel.title(for: doc, meta: targetMeta)
+        }
+        return value
     }
 
     public var body: some View {
         if isReadOnly {
-            Text(value.isEmpty ? "—" : value)
+            Text(value.isEmpty ? "—" : displayLabel)
                 .foregroundStyle(.secondary)
         } else if searchProvider == nil {
             // No provider: plain text entry (backwards-compatible fallback).
@@ -78,7 +101,7 @@ public struct LinkPickerField: View {
             isPickerPresented = true
         } label: {
             HStack {
-                Text(value.isEmpty ? "Select \(targetDocType)…" : value)
+                Text(value.isEmpty ? "Select \(targetDocType)…" : displayLabel)
                     .foregroundStyle(value.isEmpty ? .tertiary : .primary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Image(systemName: "chevron.up.chevron.down")
@@ -261,25 +284,10 @@ public struct LinkPickerField: View {
         lastSearchError = nil
     }
 
-    /// Best-effort human label for a result row. Prefers a string field
-    /// whose key matches common title-field conventions, then falls back
-    /// to the first non-empty string field, then to the id.
+    /// Human label for a result row, resolved from the target DocType's
+    /// declared `titleField` (with convention/id fallbacks). Shared with the
+    /// collapsed-field label via `LinkLabel` so both render identically.
     private func primaryLabel(for doc: Document) -> String {
-        // Try common title-field names first, in order of preference.
-        let candidateKeys = ["customer_name", "supplier_name", "item_name",
-                             "lead_name", "first_name", "title", "name",
-                             "address_title", "label"]
-        for key in candidateKeys {
-            if case .string(let value)? = doc.fields[key], !value.isEmpty {
-                return value
-            }
-        }
-        // Fall back to the first non-empty string field.
-        for (_, value) in doc.fields {
-            if case .string(let s) = value, !s.isEmpty, s != doc.id {
-                return s
-            }
-        }
-        return doc.id
+        LinkLabel.title(for: doc, meta: targetMeta)
     }
 }

--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -41,6 +41,7 @@ public struct RecordCollectionHostView: View {
     let detailHeader: ((Document) -> AnyView)?
     let externalCreateTrigger: Binding<Bool>?
     let linkSearchProvider: ((String, String) -> [Document])?
+    let linkResolveProvider: ((String, String) -> Document?)?
     let childDocTypeProvider: ((String) -> DocType?)?
     let detailEditor: ((DocType, Binding<Document>) -> AnyView)?
 
@@ -78,6 +79,7 @@ public struct RecordCollectionHostView: View {
         detailHeader: ((Document) -> AnyView)? = nil,
         externalCreateTrigger: Binding<Bool>? = nil,
         linkSearchProvider: ((String, String) -> [Document])? = nil,
+        linkResolveProvider: ((String, String) -> Document?)? = nil,
         childDocTypeProvider: ((String) -> DocType?)? = nil,
         detailEditor: ((DocType, Binding<Document>) -> AnyView)? = nil
     ) {
@@ -104,6 +106,7 @@ public struct RecordCollectionHostView: View {
         self.detailHeader = detailHeader
         self.externalCreateTrigger = externalCreateTrigger
         self.linkSearchProvider = linkSearchProvider
+        self.linkResolveProvider = linkResolveProvider
         self.childDocTypeProvider = childDocTypeProvider
         self.detailEditor = detailEditor
         _selectedViewMode = State(initialValue: configuration.defaultViewMode)
@@ -125,6 +128,7 @@ public struct RecordCollectionHostView: View {
                 ),
                 onCreate: performCreate(_:),
                 linkSearchProvider: linkSearchProvider,
+                linkResolveProvider: linkResolveProvider,
                 childDocTypeProvider: childDocTypeProvider
             )
         }
@@ -310,6 +314,7 @@ public struct RecordCollectionHostView: View {
                         docType: effectiveDocType,
                         document: selectedDocumentBinding,
                         linkSearchProvider: linkSearchProvider,
+                        linkResolveProvider: linkResolveProvider,
                         childDocTypeProvider: childDocTypeProvider
                     )
                     .disabled(!allowsDetailEditing)


### PR DESCRIPTION
## Summary
Implement consistent human-facing label resolution for link fields across the UI. Link fields store only the target document's ID, so labels are now resolved at render time using the target DocType's declared `titleField`, with fallbacks to conventional field names and the raw ID.

## Key Changes
- **New `LinkLabel` utility** (`LinkLabel.swift`): Centralizes label resolution logic with a clear fallback hierarchy:
  1. Target DocType's declared `titleField` (if non-empty)
  2. Conventional title field names (customer_name, supplier_name, item_name, etc.)
  3. First non-empty string field
  4. Raw document ID as last resort

- **Enhanced `LinkPickerField`**: 
  - Added `targetMeta` parameter to access the target DocType's metadata
  - Added `resolveDocument` closure to fetch linked documents by ID
  - Updated both collapsed field display and search results to use `LinkLabel.title()` for consistent rendering
  - Refactored `primaryLabel()` to delegate to `LinkLabel` instead of duplicating logic

- **Updated `GenericFormView`**:
  - Added `linkResolveProvider` parameter to enable document resolution
  - Passes target metadata and resolver to `LinkPickerField` instances

- **Updated `RecordCollectionHostView` and `CreateRecordSheet`**:
  - Added `linkResolveProvider` parameter and threaded it through to child views

- **Comprehensive test coverage** (`LinkLabelTests.swift`):
  - Tests declared title field preference
  - Tests fallback to conventional keys when metadata unavailable
  - Tests skipping empty title fields
  - Tests ID fallback when no label is available

## Implementation Details
- Label resolution is deferred to render time, ensuring labels stay current when linked records are renamed
- The same resolution logic is used for both collapsed field display and search result rows, guaranteeing consistent rendering
- Graceful degradation: when `resolveDocument` is not wired, the field displays the raw ID (backwards compatible)
- When target metadata is unavailable, conventional field name fallbacks ensure reasonable labels for common DocTypes

https://claude.ai/code/session_011ZXBMKg3y8DSpXnU2GeRxM