### PR TITLE
fix(ui): render link pickers for .link fields inside child tables

### DIFF
--- a/Tests/MercantisCoreUITests/GenericFormViewSmokeTests.swift
+++ b/Tests/MercantisCoreUITests/GenericFormViewSmokeTests.swift
@@ -204,7 +204,7 @@ final class GenericFormViewSmokeTests: XCTestCase {
         let document = TestHarness.makeSalesOrderDocument(items: rows)
         try harness.engine.save(document)
 
-        let fetched = try harness.engine.fetch(id: document.id, docType: docType.id)
+        let fetched = try XCTUnwrap(harness.engine.fetch(docType: docType.id, id: document.id))
         XCTAssertEqual(fetched.children["items"]?.count, 2)
     }
 
@@ -234,6 +234,74 @@ final class GenericFormViewSmokeTests: XCTestCase {
         rows.remove(at: 0)
         XCTAssertEqual(rows.count, 1)
         XCTAssertEqual(rows[0].fields["item_code"], .string("Y"))
+    }
+
+    // MARK: - Child-table link field
+
+    /// A child table whose row contains a `.link` field (`item → Item`) must
+    /// instantiate with both the child-doctype and link providers wired —
+    /// proving the child-row link picker path compiles end-to-end rather than
+    /// falling through to a plain text field.
+    func testChildTableLinkFieldRendersWithWiredProviders() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        // Target DocType for the child-row link + one record to resolve to.
+        let itemTarget = TestHarness.makeItemDocType()
+        try harness.registry.register(itemTarget)
+        try harness.engine.save(TestHarness.makeItemDocument(id: "ITEM-001", name: "Widget"))
+
+        // Child DocType carrying the `.link` column, and its parent.
+        let childWithLink = TestHarness.makeSalesItemDocTypeWithLink()
+        try harness.registry.register(childWithLink)
+        let parent = TestHarness.makeSalesOrderDocTypeLinkingChild()
+        try harness.registry.register(parent)
+
+        var document = TestHarness.makeSalesOrderWithLinkedItemRow(itemId: "ITEM-001")
+        try harness.engine.save(document)
+
+        let binding = Binding<Document>(get: { document }, set: { document = $0 })
+
+        let form = GenericFormView(
+            docType: parent,
+            document: binding,
+            linkSearchProvider: { targetDocType, _ in
+                (try? harness.engine.list(docType: targetDocType)) ?? []
+            },
+            linkResolveProvider: { targetDocType, id in
+                try? harness.engine.fetch(docType: targetDocType, id: id)
+            },
+            childDocTypeProvider: { id in id == childWithLink.id ? childWithLink : nil }
+        )
+        XCTAssertNotNil(form)
+    }
+
+    /// `ChildTableField` instantiates directly with link providers and a
+    /// read-only flag — exercising the child-table public init the
+    /// child-row link work added (and the read-only label path).
+    func testChildTableFieldInitWithLinkProvidersReadOnly() throws {
+        let harness = try TestHarness.make()
+        defer { harness.cleanUp() }
+
+        let childWithLink = TestHarness.makeSalesItemDocTypeWithLink()
+        var rows = [TestHarness.makeLinkedItemRow(itemId: "ITEM-001")]
+        let binding = Binding<[ChildRow]>(get: { rows }, set: { rows = $0 })
+
+        let field = FieldDefinition(
+            key: "items", label: "Items", type: .table,
+            required: false, childDocType: childWithLink.id
+        )
+
+        let table = ChildTableField(
+            field: field,
+            childDocType: childWithLink,
+            rows: binding,
+            isReadOnly: true,
+            linkSearchProvider: { _, _ in [] },
+            linkResolveProvider: { _, _ in nil },
+            childDocTypeProvider: { _ in childWithLink }
+        )
+        XCTAssertNotNil(table)
     }
 
     func testGenericListViewInstantiatesAgainstInMemoryDocumentEngine() throws {
@@ -568,6 +636,103 @@ private enum TestHarness {
                 "qty": .int(qty),
                 "rate": .double(rate)
             ]
+        )
+    }
+
+    // MARK: - Child-table link fixtures (item → Item)
+
+    private static let systemManagerPermission = PermissionRule(
+        role: "System Manager",
+        canRead: true, canWrite: true, canCreate: true,
+        canDelete: true, canSubmit: true, canAmend: true
+    )
+
+    /// Link-target master DocType.
+    static func makeItemDocType() -> DocType {
+        DocType(
+            id: "Item",
+            name: "Item",
+            module: "Selling",
+            appId: "app.mercantis.test",
+            isChildTable: false,
+            fields: [
+                FieldDefinition(key: "item_name", label: "Item Name", type: .text, required: true)
+            ],
+            permissions: [systemManagerPermission],
+            syncPolicy: SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false),
+            indexes: [],
+            searchFields: ["item_name"],
+            titleField: "item_name"
+        )
+    }
+
+    static func makeItemDocument(id: String, name: String) -> Document {
+        let now = Date()
+        return Document(
+            id: id, docType: "Item", company: "", status: "",
+            createdAt: now, updatedAt: now, syncVersion: 0, syncState: .local,
+            fields: ["item_name": .string(name)], children: [:]
+        )
+    }
+
+    /// Child DocType with a `.link` field (`item → Item`).
+    static func makeSalesItemDocTypeWithLink() -> DocType {
+        DocType(
+            id: "SalesItem",
+            name: "Sales Item",
+            module: "Selling",
+            appId: "app.mercantis.test",
+            isChildTable: true,
+            fields: [
+                FieldDefinition(key: "item", label: "Item", type: .link,
+                                required: true, linkedDocType: "Item"),
+                FieldDefinition(key: "qty", label: "Qty", type: .decimal, required: true),
+                FieldDefinition(key: "rate", label: "Rate", type: .currency, required: false)
+            ],
+            permissions: [systemManagerPermission],
+            syncPolicy: SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false),
+            indexes: [],
+            searchFields: ["item"],
+            titleField: "item"
+        )
+    }
+
+    /// Parent DocType whose `items` table points at the link-bearing child.
+    static func makeSalesOrderDocTypeLinkingChild() -> DocType {
+        DocType(
+            id: "SalesOrderL",
+            name: "Sales Order",
+            module: "Selling",
+            appId: "app.mercantis.test",
+            isChildTable: false,
+            fields: [
+                FieldDefinition(key: "customer", label: "Customer", type: .text, required: true),
+                FieldDefinition(key: "items", label: "Items", type: .table,
+                                required: false, childDocType: "SalesItem")
+            ],
+            permissions: [systemManagerPermission],
+            syncPolicy: SyncPolicy(conflictResolution: .lastWriteWins, immutableAfterSubmit: false),
+            indexes: [],
+            searchFields: ["customer"],
+            titleField: "customer"
+        )
+    }
+
+    static func makeLinkedItemRow(itemId: String) -> ChildRow {
+        ChildRow(
+            id: UUID().uuidString,
+            rowIndex: 0,
+            fields: ["item": .string(itemId), "qty": .double(1), "rate": .double(0)]
+        )
+    }
+
+    static func makeSalesOrderWithLinkedItemRow(itemId: String) -> Document {
+        let now = Date()
+        return Document(
+            id: UUID().uuidString, docType: "SalesOrderL", company: "", status: "",
+            createdAt: now, updatedAt: now, syncVersion: 0, syncState: .local,
+            fields: ["customer": .string("Test Customer")],
+            children: ["items": [makeLinkedItemRow(itemId: itemId)]]
         )
     }
 }

--- a/mercantis core/UIShell/ChildTableField.swift
+++ b/mercantis core/UIShell/ChildTableField.swift
@@ -22,6 +22,16 @@ public struct ChildTableField: View {
     let childDocType: DocType?
     @Binding var rows: [ChildRow]
     let isReadOnly: Bool
+    /// Link providers for `.link` fields inside child rows. Mirror the ones
+    /// `GenericFormView` passes to top-level `LinkPickerField`s so a child-row
+    /// link cell renders the same searchable picker rather than a plain text
+    /// field. All optional: when `nil`, link cells degrade to plain text entry
+    /// exactly as before (backwards-compatible for unwired callers).
+    let linkSearchProvider: ((String, String) -> [Document])?
+    let linkResolveProvider: ((String, String) -> Document?)?
+    /// Resolves target-DocType metadata so the picker can read the target's
+    /// `titleField` for display labels.
+    let childDocTypeProvider: ((String) -> DocType?)?
 
     @State private var popoverRowID: String?
 
@@ -29,12 +39,18 @@ public struct ChildTableField: View {
         field: FieldDefinition,
         childDocType: DocType?,
         rows: Binding<[ChildRow]>,
-        isReadOnly: Bool
+        isReadOnly: Bool,
+        linkSearchProvider: ((String, String) -> [Document])? = nil,
+        linkResolveProvider: ((String, String) -> Document?)? = nil,
+        childDocTypeProvider: ((String) -> DocType?)? = nil
     ) {
         self.field = field
         self.childDocType = childDocType
         self._rows = rows
         self.isReadOnly = isReadOnly
+        self.linkSearchProvider = linkSearchProvider
+        self.linkResolveProvider = linkResolveProvider
+        self.childDocTypeProvider = childDocTypeProvider
     }
 
     public var body: some View {
@@ -181,12 +197,37 @@ public struct ChildTableField: View {
             .labelsHidden()
             .disabled(isReadOnly)
             .frame(maxWidth: .infinity, alignment: alignment(for: f))
+        case .link where linkSearchProvider != nil || isReadOnly:
+            // Render the same searchable picker used for top-level link
+            // fields. We only take this branch when a search provider is
+            // wired (so editing works) or when read-only (so we can still
+            // show a resolved label); otherwise fall through to plain text
+            // so unwired callers keep their previous behaviour.
+            linkCell(field: f, rowIdx: rowIdx)
+                .frame(maxWidth: .infinity)
         default:
             TextField(f.label, text: stringCellBinding(field: f, idx: rowIdx))
                 .mercantisInput()
                 .disabled(isReadOnly)
                 .frame(maxWidth: .infinity)
         }
+    }
+
+    /// Builds a `LinkPickerField` bound to `rows[rowIdx].fields[field.key]`,
+    /// resolving the target DocType from `field.linkedDocType` and reusing the
+    /// injected providers (scoped to that target). Shared shape with
+    /// `GenericFormView.linkField` so child-row links behave identically.
+    @ViewBuilder
+    private func linkCell(field f: FieldDefinition, rowIdx: Int) -> some View {
+        let target = f.linkedDocType ?? ""
+        LinkPickerField(
+            targetDocType: target.isEmpty ? "Link" : target,
+            value: stringCellBinding(field: f, idx: rowIdx),
+            isReadOnly: isReadOnly,
+            targetMeta: childDocTypeProvider?(target),
+            searchProvider: linkSearchProvider.map { base in { _, query in base(target, query) } },
+            resolveDocument: linkResolveProvider.map { base in { id in base(target, id) } }
+        )
     }
 
     // MARK: - Row actions / popover
@@ -223,6 +264,9 @@ public struct ChildTableField: View {
                     }
                 ),
                 isReadOnly: isReadOnly,
+                linkSearchProvider: linkSearchProvider,
+                linkResolveProvider: linkResolveProvider,
+                childDocTypeProvider: childDocTypeProvider,
                 onRemove: {
                     popoverRowID = nil
                     guard rowIdx < rows.count else { return }
@@ -409,6 +453,9 @@ private struct ChildRowEditor: View {
     let rowIndex: Int
     @Binding var row: ChildRow
     let isReadOnly: Bool
+    let linkSearchProvider: ((String, String) -> [Document])?
+    let linkResolveProvider: ((String, String) -> Document?)?
+    let childDocTypeProvider: ((String) -> DocType?)?
     let onRemove: () -> Void
     let onDone: () -> Void
 
@@ -524,6 +571,18 @@ private struct ChildRowEditor: View {
                         .stroke(MercantisTheme.border, lineWidth: 1)
                 )
                 .disabled(isReadOnly)
+        case .link where linkSearchProvider != nil || isReadOnly:
+            // Same searchable picker as the inline grid, bound to this row's
+            // field. Falls through to plain text when no provider is wired.
+            let target = field.linkedDocType ?? ""
+            LinkPickerField(
+                targetDocType: target.isEmpty ? "Link" : target,
+                value: stringBinding(for: field),
+                isReadOnly: isReadOnly,
+                targetMeta: childDocTypeProvider?(target),
+                searchProvider: linkSearchProvider.map { base in { _, query in base(target, query) } },
+                resolveDocument: linkResolveProvider.map { base in { id in base(target, id) } }
+            )
         default:
             TextField(field.label, text: stringBinding(for: field))
                 .mercantisInput()

--- a/mercantis core/UIShell/GenericFormView.swift
+++ b/mercantis core/UIShell/GenericFormView.swift
@@ -495,7 +495,13 @@ public struct GenericFormView: View {
                 get: { document.children[field.key, default: []] },
                 set: { document.children[field.key] = $0 }
             ),
-            isReadOnly: false
+            isReadOnly: false,
+            // Thread the same link providers used for top-level link fields so
+            // `.link` columns inside child rows render the searchable picker
+            // instead of a plain text field. (Child-table link support.)
+            linkSearchProvider: linkSearchProvider,
+            linkResolveProvider: linkResolveProvider,
+            childDocTypeProvider: childDocTypeProvider
         )
     }
 


### PR DESCRIPTION
Child-table cells fell through to a plain TextField for FieldType.link because GenericFormView.tableField never forwarded its link providers to ChildTableField, and neither the inline grid (childFieldCell) nor the row popover editor (ChildRowEditor.control) had a .link branch.

- ChildTableField: add optional linkSearchProvider / linkResolveProvider / childDocTypeProvider (defaulted to nil for backward compatibility), and a .link branch in both the inline cell and the popover editor that renders the existing public LinkPickerField, scoped to field.linkedDocType.
- GenericFormView.tableField: forward its existing providers into ChildTableField so child-row links behave like top-level links.
- Read-only: link cells show a resolved label (or a dash); unwired callers (no search provider) keep the plain-text fallback — no behaviour change.
- Tests: add a child DocType with a .link field (SalesItem.item -> Item), cover the wired-provider form path and a read-only ChildTableField init. Fix a pre-existing fetch(id:docType:) label-order call that didn't match the engine's fetch(docType:id:) signature.

Generic Core-level fix — no Hub-specific DocTypes referenced.

https://claude.ai/code/session_01DkoshpkrnuSPB8eSdQC7YS