### PR TITLE
feat(ui): richer metadata-driven DocType list/filter UX + child-table link pickers

### DIFF
--- a/Tests/MercantisCoreUITests/RecordListViewTests.swift
+++ b/Tests/MercantisCoreUITests/RecordListViewTests.swift
@@ -1,0 +1,165 @@
+//
+//  RecordListViewTests.swift
+//  MercantisCoreUITests
+//
+//  Unit coverage for the headless list-view model (RecordListFilter /
+//  RecordListViewDefinition / DateRangePreset) that drives GenericListView's
+//  filter bar, plus a smoke test that GenericListView instantiates with the
+//  new saved-view / link-provider surface.
+//
+
+import XCTest
+import SwiftUI
+import MercantisCore
+import MercantisCoreUI
+
+final class RecordListViewTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func doc(
+        id: String,
+        status: String = "",
+        docStatus: Int = 0,
+        fields: [String: FieldValue] = [:],
+        updatedAt: Date = Date()
+    ) -> Document {
+        Document(
+            id: id, docType: "SalesInvoice", company: "", status: status,
+            createdAt: Date(), updatedAt: updatedAt, syncVersion: 0, syncState: .local,
+            docStatus: docStatus, fields: fields, children: [:]
+        )
+    }
+
+    // MARK: - RecordListFilter: predicates
+
+    func testEqualityOnSystemColumnAndField() {
+        let d = doc(id: "A", status: "Paid", docStatus: 1, fields: ["customer": .string("Acme")])
+        XCTAssertTrue(RecordListFilter.matches(ListFilter("status", .eq(.string("Paid"))), d))
+        XCTAssertFalse(RecordListFilter.matches(ListFilter("status", .eq(.string("Draft"))), d))
+        XCTAssertTrue(RecordListFilter.matches(ListFilter("docStatus", .eq(.int(1))), d))
+        XCTAssertTrue(RecordListFilter.matches(ListFilter("customer", .eq(.string("Acme"))), d))
+    }
+
+    func testNumericComparisonsWithIntDoubleCoercion() {
+        let d = doc(id: "A", fields: ["outstanding_amount": .double(150)])
+        XCTAssertTrue(RecordListFilter.matches(ListFilter("outstanding_amount", .gt(.double(0))), d))
+        XCTAssertTrue(RecordListFilter.matches(ListFilter("outstanding_amount", .gte(.int(150))), d))
+        XCTAssertFalse(RecordListFilter.matches(ListFilter("outstanding_amount", .lt(.double(100))), d))
+        XCTAssertTrue(RecordListFilter.matches(ListFilter("outstanding_amount", .between(.int(100), .int(200))), d))
+    }
+
+    func testBooleanIsNotCoercedToNumber() {
+        let d = doc(id: "A", fields: ["is_stock_item": .bool(true)])
+        XCTAssertTrue(RecordListFilter.matches(ListFilter("is_stock_item", .eq(.bool(true))), d))
+        XCTAssertFalse(RecordListFilter.matches(ListFilter("is_stock_item", .eq(.bool(false))), d))
+        // .bool(true) must NOT equal .int(1)
+        XCTAssertFalse(RecordListFilter.matches(ListFilter("is_stock_item", .eq(.int(1))), d))
+    }
+
+    func testLikeAndInAndNullness() {
+        let d = doc(id: "A", fields: ["customer": .string("Acme Corp")])
+        XCTAssertTrue(RecordListFilter.matches(ListFilter("customer", .like("%cme%")), d))
+        XCTAssertTrue(RecordListFilter.matches(ListFilter("customer", .in([.string("Acme Corp"), .string("X")])), d))
+        XCTAssertFalse(RecordListFilter.matches(ListFilter("customer", .in([.string("X")])), d))
+        // Empty string and missing key both read as null-ish.
+        XCTAssertTrue(RecordListFilter.matches(ListFilter("missing", .isNull), d))
+        XCTAssertTrue(RecordListFilter.matches(ListFilter("customer", .isNotNull), d))
+    }
+
+    func testMatchesAllIsAndSemantics() {
+        let d = doc(id: "A", status: "Submitted", docStatus: 1, fields: ["outstanding_amount": .double(50)])
+        let preds = [
+            ListFilter("docStatus", .eq(.int(1))),
+            ListFilter("outstanding_amount", .gt(.double(0)))
+        ]
+        XCTAssertTrue(RecordListFilter.matchesAll(preds, d))
+        let preds2 = preds + [ListFilter("status", .eq(.string("Paid")))]
+        XCTAssertFalse(RecordListFilter.matchesAll(preds2, d))
+    }
+
+    // MARK: - RecordListFilter: sorting
+
+    func testSortByUpdatedDescendingAndTitleAscending() {
+        let old = doc(id: "old", fields: ["customer": .string("Bravo")], updatedAt: Date(timeIntervalSince1970: 1000))
+        let new = doc(id: "new", fields: ["customer": .string("Alpha")], updatedAt: Date(timeIntervalSince1970: 2000))
+        let byUpdatedDesc = [old, new].sorted {
+            RecordListFilter.areInIncreasingOrder($0, $1, by: [ListSort(fieldKey: "updatedAt", direction: .descending)])
+        }
+        XCTAssertEqual(byUpdatedDesc.map(\.id), ["new", "old"])
+
+        let byCustomerAsc = [old, new].sorted {
+            RecordListFilter.areInIncreasingOrder($0, $1, by: [ListSort(fieldKey: "customer", direction: .ascending)])
+        }
+        XCTAssertEqual(byCustomerAsc.map(\.id), ["new", "old"]) // Alpha < Bravo
+    }
+
+    // MARK: - DateRangePreset
+
+    func testDateRangePresetProducesBetweenPredicate() {
+        let preset = DateRangePreset.thisMonth
+        let predicate = preset.predicate(fieldKey: "createdAt")
+        XCTAssertEqual(predicate.fieldKey, "createdAt")
+        if case .between(let lo, let hi) = predicate.op,
+           case .date(let start) = lo, case .date(let end) = hi {
+            XCTAssertLessThanOrEqual(start, end)
+        } else {
+            XCTFail("Expected a between(date, date) predicate")
+        }
+    }
+
+    func testTodayRangeContainsNow() {
+        let now = Date()
+        let r = DateRangePreset.today.range(now: now)
+        XCTAssertLessThanOrEqual(r.start, now)
+        XCTAssertGreaterThanOrEqual(r.end, now)
+    }
+
+    // MARK: - RecordListViewDefinition
+
+    func testAllViewHasNoPredicates() {
+        let all = RecordListViewDefinition.all()
+        XCTAssertEqual(all.id, "all")
+        XCTAssertTrue(all.predicates.isEmpty)
+        XCTAssertTrue(all.isBuiltIn)
+    }
+
+    // MARK: - GenericListView smoke (new surface)
+
+    func testGenericListViewInstantiatesWithSavedViewsAndProviders() {
+        let docType = DocType(
+            id: "SalesInvoice", name: "Sales Invoice", module: "Selling",
+            appId: "app.test", isChildTable: false, isSubmittable: true,
+            fields: [
+                FieldDefinition(key: "customer", label: "Customer", type: .link,
+                                required: true, linkedDocType: "Customer"),
+                FieldDefinition(key: "outstanding_amount", label: "Outstanding", type: .currency, required: false)
+            ],
+            permissions: [],
+            syncPolicy: SyncPolicy(conflictResolution: .versionChecked, immutableAfterSubmit: true),
+            indexes: [], searchFields: ["customer"], titleField: "customer"
+        )
+        let documents = [
+            doc(id: "INV-1", status: "Paid", docStatus: 1, fields: ["customer": .string("Acme")]),
+            doc(id: "INV-2", status: "Submitted", docStatus: 1, fields: ["outstanding_amount": .double(99)])
+        ]
+        let views: [RecordListViewDefinition] = [
+            .all(),
+            RecordListViewDefinition(id: "outstanding", label: "Outstanding",
+                                     predicates: [ListFilter("outstanding_amount", .gt(.double(0)))])
+        ]
+        let list = GenericListView(
+            docType: docType,
+            documents: documents,
+            selectedDocumentID: nil,
+            onSelect: { _ in },
+            onCreate: { },
+            listViews: views,
+            preferenceKey: "test.SalesInvoice",
+            linkSearchProvider: { _, _ in [] },
+            linkResolveProvider: { _, _ in nil },
+            linkTargetMetaProvider: { _ in nil }
+        )
+        XCTAssertNotNil(list)
+    }
+}

--- a/mercantis core/DocumentEngine/RecordListView.swift
+++ b/mercantis core/DocumentEngine/RecordListView.swift
@@ -1,0 +1,304 @@
+//
+//  RecordListView.swift
+//  mercantis core
+//
+//  Generic, metadata-driven list-view model for DocType workspaces.
+//
+//  This is the headless half of the richer list/filter UX: the UI layer
+//  (`MercantisCoreUI.GenericListView`) renders these definitions, but the
+//  model itself lives in `MercantisCore` so it can be authored by any
+//  consumer (e.g. Hub's `HubListViews`) and unit-tested without SwiftUI.
+//
+//  It deliberately reuses the existing `ListFilter` / `ListSort` predicate
+//  model rather than introducing a competing one, so a saved view's
+//  predicates can be pushed straight into `DocumentEngine.list(...)` when a
+//  consumer opts into engine-backed reloading.
+//
+
+import Foundation
+
+/// A named, reusable list view over a DocType — the "All / Draft / Unpaid /
+/// Overdue" tabs an ERP user expects. Built-in views are authored by the app
+/// (Hub); user-saved views can be persisted with `isBuiltIn == false`.
+public struct RecordListViewDefinition: Identifiable, Sendable {
+    public let id: String
+    public let label: String
+    /// Optional SF Symbol name for the view chip.
+    public let systemImage: String?
+    /// Predicates AND-ed together to scope the view. Empty = no scoping ("All").
+    public let predicates: [ListFilter]
+    /// Optional default search text applied when the view is selected.
+    public let searchText: String?
+    /// Optional sort order applied when the view is selected.
+    public let sort: [ListSort]
+    /// `true` for app-provided views, `false` for user-saved ones.
+    public let isBuiltIn: Bool
+
+    public init(
+        id: String,
+        label: String,
+        systemImage: String? = nil,
+        predicates: [ListFilter] = [],
+        searchText: String? = nil,
+        sort: [ListSort] = [],
+        isBuiltIn: Bool = true
+    ) {
+        self.id = id
+        self.label = label
+        self.systemImage = systemImage
+        self.predicates = predicates
+        self.searchText = searchText
+        self.sort = sort
+        self.isBuiltIn = isBuiltIn
+    }
+
+    /// The canonical "All records" view, prepended by the UI when a DocType
+    /// declares built-in views.
+    public static func all(label: String = "All", systemImage: String? = "tray.full") -> RecordListViewDefinition {
+        RecordListViewDefinition(id: "all", label: label, systemImage: systemImage)
+    }
+}
+
+/// A structured query a consumer can hand to `DocumentEngine.list(...)`.
+/// Currently produced by the UI so engine-backed reloading can be wired in
+/// without reshaping the filter state.
+public struct RecordListQuery: Sendable {
+    public var searchText: String
+    public var predicates: [ListFilter]
+    public var sort: [ListSort]
+    public var limit: Int?
+    public var offset: Int
+
+    public init(
+        searchText: String = "",
+        predicates: [ListFilter] = [],
+        sort: [ListSort] = [],
+        limit: Int? = nil,
+        offset: Int = 0
+    ) {
+        self.searchText = searchText
+        self.predicates = predicates
+        self.sort = sort
+        self.limit = limit
+        self.offset = offset
+    }
+}
+
+/// Date-range presets that translate into `ListFilter.between` predicates over
+/// a date field. Ranges are inclusive on both ends.
+public enum DateRangePreset: String, CaseIterable, Sendable, Identifiable {
+    case today
+    case yesterday
+    case thisWeek
+    case thisMonth
+    case thisQuarter
+    case thisYear
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .today: return "Today"
+        case .yesterday: return "Yesterday"
+        case .thisWeek: return "This Week"
+        case .thisMonth: return "This Month"
+        case .thisQuarter: return "This Quarter"
+        case .thisYear: return "This Year"
+        }
+    }
+
+    /// Inclusive `[start, end]` range for the preset, relative to `now`.
+    public func range(now: Date = Date(), calendar: Calendar = .current) -> (start: Date, end: Date) {
+        let startOfToday = calendar.startOfDay(for: now)
+        let endOfToday = calendar.date(byAdding: DateComponents(day: 1, second: -1), to: startOfToday) ?? now
+        switch self {
+        case .today:
+            return (startOfToday, endOfToday)
+        case .yesterday:
+            let startOfYesterday = calendar.date(byAdding: .day, value: -1, to: startOfToday) ?? startOfToday
+            let endOfYesterday = calendar.date(byAdding: DateComponents(second: -1), to: startOfToday) ?? startOfToday
+            return (startOfYesterday, endOfYesterday)
+        case .thisWeek:
+            let start = calendar.dateInterval(of: .weekOfYear, for: now)?.start ?? startOfToday
+            return (start, endOfToday)
+        case .thisMonth:
+            let start = calendar.dateInterval(of: .month, for: now)?.start ?? startOfToday
+            return (start, endOfToday)
+        case .thisQuarter:
+            let start = Self.startOfQuarter(now: now, calendar: calendar)
+            return (start, endOfToday)
+        case .thisYear:
+            let start = calendar.dateInterval(of: .year, for: now)?.start ?? startOfToday
+            return (start, endOfToday)
+        }
+    }
+
+    /// A `between` predicate over `fieldKey` for this preset.
+    public func predicate(fieldKey: String, now: Date = Date(), calendar: Calendar = .current) -> ListFilter {
+        let r = range(now: now, calendar: calendar)
+        return ListFilter(fieldKey, .between(.date(r.start), .date(r.end)))
+    }
+
+    private static func startOfQuarter(now: Date, calendar: Calendar) -> Date {
+        let comps = calendar.dateComponents([.year, .month], from: now)
+        let month = comps.month ?? 1
+        let quarterFirstMonth = ((month - 1) / 3) * 3 + 1
+        var start = DateComponents()
+        start.year = comps.year
+        start.month = quarterFirstMonth
+        start.day = 1
+        return calendar.date(from: start) ?? calendar.startOfDay(for: now)
+    }
+}
+
+/// In-memory evaluator for `ListFilter` / `ListSort` against `Document`s.
+///
+/// `DocumentEngine.list(...)` already pushes predicates to SQL where possible;
+/// this evaluator is the client-side counterpart the list UI uses to filter an
+/// already-loaded `[Document]` (and to keep saved-view semantics consistent
+/// with the engine). Operator semantics mirror the engine's intent: comparisons
+/// against a missing/`null` value fail rather than match.
+public enum RecordListFilter {
+
+    /// Resolves the value a predicate's `fieldKey` refers to — either a
+    /// `documents`-table system column or a user field.
+    public static func value(for key: String, in doc: Document) -> FieldValue? {
+        switch key {
+        case "id":        return .string(doc.id)
+        case "status":    return .string(doc.status)
+        case "docStatus": return .int(doc.docStatus)
+        case "company":   return .string(doc.company)
+        case "createdAt": return .date(doc.createdAt)
+        case "updatedAt": return .date(doc.updatedAt)
+        default:          return doc.fields[key]
+        }
+    }
+
+    /// Evaluates one predicate against one document.
+    public static func matches(_ predicate: ListFilter, _ doc: Document) -> Bool {
+        let v = value(for: predicate.fieldKey, in: doc)
+        switch predicate.op {
+        case .isNull:
+            return isNullish(v)
+        case .isNotNull:
+            return !isNullish(v)
+        case .eq(let target):
+            return equal(v, target)
+        case .neq(let target):
+            return !equal(v, target)
+        case .gt(let target):
+            return (compare(v, target)).map { $0 > 0 } ?? false
+        case .gte(let target):
+            return (compare(v, target)).map { $0 >= 0 } ?? false
+        case .lt(let target):
+            return (compare(v, target)).map { $0 < 0 } ?? false
+        case .lte(let target):
+            return (compare(v, target)).map { $0 <= 0 } ?? false
+        case .between(let lo, let hi):
+            guard let c1 = compare(v, lo), let c2 = compare(v, hi) else { return false }
+            return c1 >= 0 && c2 <= 0
+        case .in(let options):
+            return options.contains { equal(v, $0) }
+        case .like(let pattern):
+            guard let s = string(v) else { return false }
+            return likeMatch(s, pattern: pattern)
+        }
+    }
+
+    /// `true` when every predicate matches (AND semantics).
+    public static func matchesAll(_ predicates: [ListFilter], _ doc: Document) -> Bool {
+        predicates.allSatisfy { matches($0, doc) }
+    }
+
+    /// Stable ordering comparator across an ordered `[ListSort]` chain.
+    public static func areInIncreasingOrder(_ a: Document, _ b: Document, by sorts: [ListSort]) -> Bool {
+        for sort in sorts {
+            let lhs = value(for: sort.fieldKey, in: a)
+            let rhs = value(for: sort.fieldKey, in: b)
+            // Equal or incomparable on this key — fall through to the next sort.
+            guard let c = compare(lhs, rhs), c != 0 else { continue }
+            return sort.direction == .ascending ? c < 0 : c > 0
+        }
+        return false
+    }
+
+    // MARK: - Primitive helpers
+
+    private static func isNullish(_ v: FieldValue?) -> Bool {
+        switch v {
+        case .none, .null: return true
+        case .string(let s): return s.isEmpty
+        default: return false
+        }
+    }
+
+    private static func string(_ v: FieldValue?) -> String? {
+        switch v {
+        case .string(let s): return s
+        case .int(let i): return "\(i)"
+        case .double(let d): return "\(d)"
+        case .bool(let b): return b ? "true" : "false"
+        default: return nil
+        }
+    }
+
+    private static func double(_ v: FieldValue?) -> Double? {
+        switch v {
+        case .int(let i): return Double(i)
+        case .double(let d): return d
+        case .string(let s): return Double(s)
+        default: return nil
+        }
+    }
+
+    private static func date(_ v: FieldValue?) -> Date? {
+        switch v {
+        case .date(let d), .dateTime(let d): return d
+        default: return nil
+        }
+    }
+
+    /// Type-aware equality with numeric coercion (`int` vs `double`).
+    private static func equal(_ a: FieldValue?, _ b: FieldValue) -> Bool {
+        // Bool is compared structurally — never coerced to a number, so
+        // `.bool(true)` never equals `.int(1)`.
+        if case .bool(let bb) = b {
+            if case .bool(let ab)? = a { return ab == bb }
+            return false
+        }
+        if let da = double(a), let db = double(b) { return da == db }
+        if let dateA = date(a), let dateB = date(b) { return dateA == dateB }
+        if let sa = string(a), let sb = string(b) { return sa == sb }
+        return false
+    }
+
+    /// Three-way comparison, or `nil` when the pair isn't comparable.
+    private static func compare(_ a: FieldValue?, _ b: FieldValue?) -> Int? {
+        if let da = double(a), let db = double(b) {
+            return da < db ? -1 : (da > db ? 1 : 0)
+        }
+        if let dateA = date(a), let dateB = date(b) {
+            return dateA < dateB ? -1 : (dateA > dateB ? 1 : 0)
+        }
+        if let sa = string(a), let sb = string(b) {
+            let r = sa.localizedCaseInsensitiveCompare(sb)
+            return r == .orderedSame ? 0 : (r == .orderedAscending ? -1 : 1)
+        }
+        return nil
+    }
+
+    /// Case-insensitive SQL `LIKE` matcher (`%` = any run, `_` = any char).
+    private static func likeMatch(_ value: String, pattern: String) -> Bool {
+        var regex = "^"
+        for ch in pattern {
+            switch ch {
+            case "%": regex += ".*"
+            case "_": regex += "."
+            default:
+                regex += NSRegularExpression.escapedPattern(for: String(ch))
+            }
+        }
+        regex += "$"
+        return value.range(of: regex, options: [.regularExpression, .caseInsensitive]) != nil
+    }
+}

--- a/mercantis core/UIShell/FieldFilterEditor.swift
+++ b/mercantis core/UIShell/FieldFilterEditor.swift
@@ -1,0 +1,226 @@
+//
+//  FieldFilterEditor.swift
+//  mercantis core
+//
+//  Type-aware popover for building a single `ListFilter` predicate over one
+//  DocType field, used by `GenericListView`'s "Filter" menu. Each field type
+//  exposes only the operators that make sense for it (A.3); link fields reuse
+//  `LinkPickerField` so filtering a link feels exactly like editing one (E).
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+struct FieldFilterEditor: View {
+    let field: FieldDefinition
+    let linkSearchProvider: ((String, String) -> [Document])?
+    let linkResolveProvider: ((String, String) -> Document?)?
+    let linkTargetMeta: DocType?
+    /// Hands back the built predicate plus a human-readable chip label.
+    let onApply: (ListFilter, String) -> Void
+    let onCancel: () -> Void
+
+    // Shared editing state — only the fields relevant to `field.type` are used.
+    @State private var textValue = ""
+    @State private var textOp: TextOp = .contains
+    @State private var numberValue = ""
+    @State private var numberValue2 = ""
+    @State private var numberOp: NumberOp = .eq
+    @State private var boolValue = true
+    @State private var selectValue = ""
+    @State private var linkValue = ""
+    @State private var datePreset: DateRangePreset = .thisMonth
+    @State private var useCustomRange = false
+    @State private var customStart = Calendar.current.startOfDay(for: Date())
+    @State private var customEnd = Date()
+
+    private enum TextOp: String, CaseIterable, Identifiable {
+        case contains, equals
+        var id: String { rawValue }
+        var label: String { self == .contains ? "contains" : "equals" }
+    }
+
+    private enum NumberOp: String, CaseIterable, Identifiable {
+        case eq, gt, lt, between
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .eq: return "equals"
+            case .gt: return "greater than"
+            case .lt: return "less than"
+            case .between: return "between"
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Filter by \(field.label)")
+                .font(.headline)
+
+            editor
+
+            HStack {
+                Button("Cancel", action: onCancel)
+                    .buttonStyle(.bordered)
+                Spacer()
+                Button("Apply", action: apply)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canApply)
+            }
+        }
+        .padding(16)
+        .frame(width: 320)
+    }
+
+    @ViewBuilder
+    private var editor: some View {
+        switch field.type {
+        case .text, .email, .phone:
+            Picker("", selection: $textOp) {
+                ForEach(TextOp.allCases) { Text($0.label).tag($0) }
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+            TextField(field.label, text: $textValue)
+                .textFieldStyle(.roundedBorder)
+
+        case .select, .status:
+            Picker("", selection: $selectValue) {
+                Text("—").tag("")
+                ForEach(field.options ?? [], id: \.self) { Text($0).tag($0) }
+            }
+            .labelsHidden()
+
+        case .boolean:
+            Picker("", selection: $boolValue) {
+                Text("Yes").tag(true)
+                Text("No").tag(false)
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+
+        case .link:
+            LinkPickerField(
+                targetDocType: (field.linkedDocType?.isEmpty == false) ? field.linkedDocType! : "Link",
+                value: $linkValue,
+                isReadOnly: false,
+                targetMeta: linkTargetMeta,
+                searchProvider: linkSearchProvider.map { base in
+                    { _, query in base(field.linkedDocType ?? "", query) }
+                },
+                resolveDocument: linkResolveProvider.map { base in
+                    { id in base(field.linkedDocType ?? "", id) }
+                }
+            )
+
+        case .number, .decimal, .currency:
+            Picker("", selection: $numberOp) {
+                ForEach(NumberOp.allCases) { Text($0.label).tag($0) }
+            }
+            .labelsHidden()
+            HStack {
+                TextField("Value", text: $numberValue)
+                    .textFieldStyle(.roundedBorder)
+                if numberOp == .between {
+                    Text("and").foregroundStyle(.secondary)
+                    TextField("Value", text: $numberValue2)
+                        .textFieldStyle(.roundedBorder)
+                }
+            }
+
+        case .date, .datetime:
+            Picker("", selection: $useCustomRange) {
+                Text("Preset").tag(false)
+                Text("Custom").tag(true)
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+            if useCustomRange {
+                DatePicker("From", selection: $customStart, displayedComponents: .date)
+                DatePicker("To", selection: $customEnd, displayedComponents: .date)
+            } else {
+                Picker("", selection: $datePreset) {
+                    ForEach(DateRangePreset.allCases) { Text($0.label).tag($0) }
+                }
+                .labelsHidden()
+            }
+
+        default:
+            TextField(field.label, text: $textValue)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    private var canApply: Bool {
+        switch field.type {
+        case .text, .email, .phone: return !textValue.trimmingCharacters(in: .whitespaces).isEmpty
+        case .select, .status: return !selectValue.isEmpty
+        case .link: return !linkValue.isEmpty
+        case .number, .decimal, .currency:
+            if numberOp == .between { return Double(numberValue) != nil && Double(numberValue2) != nil }
+            return Double(numberValue) != nil
+        default: return true
+        }
+    }
+
+    private func apply() {
+        guard let (predicate, display) = buildPredicate() else { return }
+        onApply(predicate, display)
+    }
+
+    private func buildPredicate() -> (ListFilter, String)? {
+        let label = field.label
+        switch field.type {
+        case .text, .email, .phone:
+            let v = textValue.trimmingCharacters(in: .whitespaces)
+            switch textOp {
+            case .contains:
+                return (ListFilter(field.key, .like("%\(v)%")), "\(label) contains “\(v)”")
+            case .equals:
+                return (ListFilter(field.key, .eq(.string(v))), "\(label) = \(v)")
+            }
+
+        case .select, .status:
+            return (ListFilter(field.key, .eq(.string(selectValue))), "\(label): \(selectValue)")
+
+        case .boolean:
+            return (ListFilter(field.key, .eq(.bool(boolValue))), "\(label): \(boolValue ? "Yes" : "No")")
+
+        case .link:
+            let display = linkResolveProvider?(field.linkedDocType ?? "", linkValue)
+                .map { LinkLabel.title(for: $0, meta: linkTargetMeta) } ?? linkValue
+            return (ListFilter(field.key, .eq(.string(linkValue))), "\(label): \(display)")
+
+        case .number, .decimal, .currency:
+            guard let a = Double(numberValue) else { return nil }
+            switch numberOp {
+            case .eq: return (ListFilter(field.key, .eq(.double(a))), "\(label) = \(numberValue)")
+            case .gt: return (ListFilter(field.key, .gt(.double(a))), "\(label) > \(numberValue)")
+            case .lt: return (ListFilter(field.key, .lt(.double(a))), "\(label) < \(numberValue)")
+            case .between:
+                guard let b = Double(numberValue2) else { return nil }
+                return (ListFilter(field.key, .between(.double(a), .double(b))), "\(label): \(numberValue)–\(numberValue2)")
+            }
+
+        case .date, .datetime:
+            if useCustomRange {
+                let end = Calendar.current.date(byAdding: DateComponents(day: 1, second: -1),
+                                                to: Calendar.current.startOfDay(for: customEnd)) ?? customEnd
+                let start = Calendar.current.startOfDay(for: customStart)
+                let f = DateFormatter(); f.dateStyle = .short
+                return (ListFilter(field.key, .between(.date(start), .date(end))),
+                        "\(label): \(f.string(from: start))–\(f.string(from: customEnd))")
+            } else {
+                return (datePreset.predicate(fieldKey: field.key), "\(label): \(datePreset.label)")
+            }
+
+        default:
+            let v = textValue.trimmingCharacters(in: .whitespaces)
+            guard !v.isEmpty else { return nil }
+            return (ListFilter(field.key, .like("%\(v)%")), "\(label) contains “\(v)”")
+        }
+    }
+}

--- a/mercantis core/UIShell/GenericListView.swift
+++ b/mercantis core/UIShell/GenericListView.swift
@@ -4,6 +4,13 @@
 //
 //  Created by Kevin Busuttil on 12/04/2026.
 //
+//  Metadata-driven DocType list with a native macOS filter bar: search,
+//  built-in/saved views, type-aware field filters (incl. link & date
+//  presets), sortable columns, active-filter count, distinct empty states,
+//  and per-DocType persistence. Built on Core's `RecordListViewDefinition` /
+//  `ListFilter` / `ListSort` model so the same predicates the UI builds can
+//  be pushed into `DocumentEngine.list(...)` by an engine-backed consumer.
+//
 
 import SwiftUI
 #if canImport(MercantisCore)
@@ -19,11 +26,29 @@ public struct GenericListView: View {
     let selectedDocumentID: String?
     let onSelect: ((Document) -> Void)?
     let onCreate: (() -> Void)?
+    /// Built-in / saved views (e.g. Hub's "Unpaid", "Overdue"). When empty the
+    /// view synthesises status chips from the loaded data so every DocType
+    /// still gets quick status filtering.
+    let listViews: [RecordListViewDefinition]
+    /// Stable key for persisting the selected view + sort per DocType.
+    let preferenceKey: String?
+    /// Link providers reused for link-field filters — same pattern as forms.
+    let linkSearchProvider: ((String, String) -> [Document])?
+    let linkResolveProvider: ((String, String) -> Document?)?
+    let linkTargetMetaProvider: ((String) -> DocType?)?
 
     @State private var searchText = ""
-    @State private var selectedStatus = "All"
-    @State private var sortMode: SortMode = .updatedDescending
+    @State private var selectedViewID: String = "all"
+    @State private var fieldFilters: [ActiveFieldFilter] = []
+    @State private var sortFieldKey: String = "updatedAt"
+    @State private var sortAscending: Bool = false
+    @State private var addingFilterField: FieldDefinition?
+    @State private var didRestore = false
 
+    // MARK: - Inits
+
+    /// Backward-compatible init — existing callers compile unchanged and get
+    /// the synthesised status chips for free (no saved views, no link filters).
     public init(
         docType: DocType,
         documents: [Document],
@@ -31,16 +56,48 @@ public struct GenericListView: View {
         onSelect: ((Document) -> Void)? = nil,
         onCreate: (() -> Void)? = nil
     ) {
+        self.init(
+            docType: docType,
+            documents: documents,
+            selectedDocumentID: selectedDocumentID,
+            onSelect: onSelect,
+            onCreate: onCreate,
+            listViews: [],
+            preferenceKey: nil,
+            linkSearchProvider: nil,
+            linkResolveProvider: nil,
+            linkTargetMetaProvider: nil
+        )
+    }
+
+    /// Full init exposing saved views, persistence, and link-filter providers.
+    public init(
+        docType: DocType,
+        documents: [Document],
+        selectedDocumentID: String? = nil,
+        onSelect: ((Document) -> Void)? = nil,
+        onCreate: (() -> Void)? = nil,
+        listViews: [RecordListViewDefinition] = [],
+        preferenceKey: String? = nil,
+        linkSearchProvider: ((String, String) -> [Document])? = nil,
+        linkResolveProvider: ((String, String) -> Document?)? = nil,
+        linkTargetMetaProvider: ((String) -> DocType?)? = nil
+    ) {
         self.docType = docType
         self.documents = documents
         self.selectedDocumentID = selectedDocumentID
         self.onSelect = onSelect
         self.onCreate = onCreate
+        self.listViews = listViews
+        self.preferenceKey = preferenceKey
+        self.linkSearchProvider = linkSearchProvider
+        self.linkResolveProvider = linkResolveProvider
+        self.linkTargetMetaProvider = linkTargetMetaProvider
     }
 
     public var body: some View {
         VStack(spacing: 0) {
-            controlsBar
+            filterBar
 
             if processedDocuments.isEmpty {
                 emptyState
@@ -49,41 +106,86 @@ public struct GenericListView: View {
             }
         }
         .background(MercantisTheme.background)
+        .onAppear(perform: restorePreferencesOnce)
+        .onChange(of: selectedViewID) { _, _ in persistPreferences() }
+        .onChange(of: sortFieldKey) { _, _ in persistPreferences() }
+        .onChange(of: sortAscending) { _, _ in persistPreferences() }
     }
 
-    private var controlsBar: some View {
+    // MARK: - Filter bar
+
+    private var filterBar: some View {
         VStack(spacing: 8) {
+            // Row 1 — search + sort + active-filter count + clear.
             HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
-                TextField("Search \(docType.name)…", text: $searchText)
-                if !searchText.isEmpty {
-                    Button(action: { searchText = "" }) {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.secondary)
+                    TextField("Search \(docType.name)…", text: $searchText)
+                        .textFieldStyle(.plain)
+                    if !searchText.isEmpty {
+                        Button(action: { searchText = "" }) {
+                            Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 5)
+                .background(MercantisTheme.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                addFilterMenu
+                sortMenu
+
+                if hasActiveFilters {
+                    Button {
+                        clearAllFilters()
+                    } label: {
+                        Label("Clear (\(activeFilterCount))", systemImage: "xmark.circle")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.borderless)
                 }
             }
 
-            HStack(spacing: 10) {
-                Picker("Status", selection: $selectedStatus) {
-                    ForEach(statusOptions, id: \.self) { status in
-                        Text(status).tag(status)
+            // Row 2 — view chips (saved views or synthesised status chips).
+            if viewChips.count > 1 {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(viewChips) { view in
+                            chip(
+                                label: view.label,
+                                systemImage: view.systemImage,
+                                isSelected: selectedViewID == view.id
+                            ) {
+                                selectView(view)
+                            }
+                        }
                     }
+                    .padding(.horizontal, 1)
                 }
-                .pickerStyle(.menu)
+            }
 
-                Picker("Sort", selection: $sortMode) {
-                    ForEach(SortMode.allCases, id: \.self) { mode in
-                        Text(mode.title).tag(mode)
+            // Row 3 — active field-filter chips.
+            if !fieldFilters.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(fieldFilters) { filter in
+                            removableChip(filter)
+                        }
                     }
+                    .padding(.horizontal, 1)
                 }
-                .pickerStyle(.menu)
+            }
 
+            // Row 4 — result count.
+            HStack {
+                Text(resultCountText)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
                 Spacer()
             }
-            .font(.caption)
         }
         .padding(10)
         .background(MercantisTheme.surfaceMuted)
@@ -92,35 +194,156 @@ public struct GenericListView: View {
         .padding(.vertical, 8)
     }
 
+    private var addFilterMenu: some View {
+        Menu {
+            ForEach(filterableFields, id: \.key) { field in
+                Button {
+                    addingFilterField = field
+                } label: {
+                    Label(field.label, systemImage: symbol(for: field.type))
+                }
+            }
+        } label: {
+            Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
+                .font(.caption)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .popover(item: $addingFilterField) { field in
+            FieldFilterEditor(
+                field: field,
+                linkSearchProvider: linkSearchProvider,
+                linkResolveProvider: linkResolveProvider,
+                linkTargetMeta: field.linkedDocType.flatMap { linkTargetMetaProvider?($0) },
+                onApply: { predicate, display in
+                    applyFieldFilter(field: field, predicate: predicate, display: display)
+                    addingFilterField = nil
+                },
+                onCancel: { addingFilterField = nil }
+            )
+        }
+    }
+
+    private var sortMenu: some View {
+        Menu {
+            ForEach(sortOptions, id: \.fieldKey) { option in
+                Button {
+                    if sortFieldKey == option.fieldKey {
+                        sortAscending.toggle()
+                    } else {
+                        sortFieldKey = option.fieldKey
+                        sortAscending = option.defaultAscending
+                    }
+                } label: {
+                    if sortFieldKey == option.fieldKey {
+                        Label(option.label, systemImage: sortAscending ? "chevron.up" : "chevron.down")
+                    } else {
+                        Text(option.label)
+                    }
+                }
+            }
+        } label: {
+            Label(currentSortLabel, systemImage: "arrow.up.arrow.down")
+                .font(.caption)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private func chip(label: String, systemImage: String?, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if let systemImage { Image(systemName: systemImage).imageScale(.small) }
+                Text(label)
+            }
+            .font(.caption)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(isSelected ? MercantisTheme.accent : MercantisTheme.surface)
+            .foregroundStyle(isSelected ? Color.white : MercantisTheme.textPrimary)
+            .clipShape(Capsule())
+            .overlay(Capsule().stroke(MercantisTheme.border, lineWidth: isSelected ? 0 : 1))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func removableChip(_ filter: ActiveFieldFilter) -> some View {
+        HStack(spacing: 4) {
+            Text(filter.display)
+                .font(.caption)
+            Button {
+                fieldFilters.removeAll { $0.id == filter.id }
+            } label: {
+                Image(systemName: "xmark.circle.fill").imageScale(.small)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(MercantisTheme.accentFillSoft)
+        .foregroundStyle(MercantisTheme.textPrimary)
+        .clipShape(Capsule())
+        .overlay(Capsule().stroke(MercantisTheme.accentBorder, lineWidth: 1))
+    }
+
+    // MARK: - Empty states (three distinct cases)
+
     @ViewBuilder
     private var emptyState: some View {
         Spacer()
-        VStack(spacing: 10) {
-            Image(systemName: "tray")
-                .font(.title2)
-                .foregroundStyle(.secondary)
-            Text("No \(docType.name) records")
-                .font(.headline)
-            Text("Adjust filters or create a new record.")
-                .foregroundStyle(.secondary)
-            if let onCreate {
-                Button("Create \(docType.name)") {
-                    onCreate()
-                }
-                .buttonStyle(MercantisPrimaryButtonStyle())
-            }
+        if documents.isEmpty {
+            emptyBox(
+                icon: "tray",
+                title: "No \(docType.name) yet",
+                message: "Create your first \(docType.name) to get started.",
+                actionTitle: onCreate != nil ? "Create \(docType.name)" : nil,
+                action: onCreate
+            )
+        } else if !searchText.trimmingCharacters(in: .whitespaces).isEmpty {
+            emptyBox(
+                icon: "magnifyingglass",
+                title: "No records found for “\(searchText)”",
+                message: "Try a different search term.",
+                actionTitle: "Clear Search",
+                action: { searchText = "" }
+            )
+        } else {
+            emptyBox(
+                icon: "line.3.horizontal.decrease.circle",
+                title: "No \(docType.name) match these filters",
+                message: "Adjust or clear the active filters to see more records.",
+                actionTitle: "Clear Filters",
+                action: { clearAllFilters() }
+            )
         }
         Spacer()
     }
+
+    private func emptyBox(icon: String, title: String, message: String, actionTitle: String?, action: (() -> Void)?) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text(title).font(.headline)
+            Text(message)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+                    .buttonStyle(MercantisPrimaryButtonStyle())
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Document table (row rendering unchanged)
 
     private var documentTable: some View {
         List(processedDocuments) { doc in
             let isSelected = doc.id == selectedDocumentID
             Button(action: { onSelect?(doc) }) {
                 HStack(alignment: .top, spacing: 8) {
-                    // Leading accent bar mirrors the sidebar's selected
-                    // treatment so users see at a glance which record is
-                    // being shown on the right pane.
                     RoundedRectangle(cornerRadius: 1.5, style: .continuous)
                         .fill(isSelected ? MercantisTheme.accent : Color.clear)
                         .frame(width: 3)
@@ -176,40 +399,160 @@ public struct GenericListView: View {
         return Array(source.prefix(3))
     }
 
-    private var statusOptions: [String] {
-        let statuses = Set(documents.map(\.status).filter { !$0.isEmpty })
-        return ["All"] + statuses.sorted()
+    // MARK: - Views (saved or synthesised)
+
+    /// The chip row: app-provided views prefixed with "All", or — when none
+    /// are supplied — synthesised status chips so every DocType still gets
+    /// quick status filtering (A.2).
+    private var viewChips: [RecordListViewDefinition] {
+        if !listViews.isEmpty {
+            if listViews.contains(where: { $0.id == "all" }) { return listViews }
+            return [.all()] + listViews
+        }
+        return synthesisedStatusViews
+    }
+
+    private var synthesisedStatusViews: [RecordListViewDefinition] {
+        var views: [RecordListViewDefinition] = [.all()]
+        if docType.isSubmittable {
+            views.append(RecordListViewDefinition(
+                id: "draft", label: "Draft", systemImage: "pencil",
+                predicates: [ListFilter("docStatus", .eq(.int(0)))]
+            ))
+            views.append(RecordListViewDefinition(
+                id: "submitted", label: "Submitted", systemImage: "checkmark.seal",
+                predicates: [ListFilter("docStatus", .eq(.int(1)))]
+            ))
+            views.append(RecordListViewDefinition(
+                id: "cancelled", label: "Cancelled", systemImage: "xmark.seal",
+                predicates: [ListFilter("docStatus", .eq(.int(2)))]
+            ))
+        }
+        // Distinct workflow statuses present in the data that aren't already
+        // covered by the docStatus chips above.
+        let covered: Set<String> = ["Draft", "Submitted", "Cancelled"]
+        let statuses = Set(documents.map(\.status)).subtracting(covered).filter { !$0.isEmpty }
+        for status in statuses.sorted() {
+            views.append(RecordListViewDefinition(
+                id: "status:\(status)", label: status,
+                predicates: [ListFilter("status", .eq(.string(status)))]
+            ))
+        }
+        return views
+    }
+
+    private var selectedView: RecordListViewDefinition? {
+        viewChips.first { $0.id == selectedViewID }
+    }
+
+    private func selectView(_ view: RecordListViewDefinition) {
+        selectedViewID = view.id
+        if let s = view.searchText { searchText = s }
+        if !view.sort.isEmpty, let first = view.sort.first {
+            sortFieldKey = first.fieldKey
+            sortAscending = first.direction == .ascending
+        }
+    }
+
+    // MARK: - Field filters
+
+    /// Fields a user can filter on — every declared field except table/image/
+    /// attachment/formula which have no meaningful list predicate.
+    private var filterableFields: [FieldDefinition] {
+        docType.fields.filter { f in
+            switch f.type {
+            case .table, .image, .attachment, .formula, .richText: return false
+            default: return true
+            }
+        }
+    }
+
+    private func applyFieldFilter(field: FieldDefinition, predicate: ListFilter, display: String) {
+        // One active filter per field key — re-adding replaces.
+        fieldFilters.removeAll { $0.fieldKey == field.key }
+        fieldFilters.append(ActiveFieldFilter(fieldKey: field.key, display: display, predicate: predicate))
+    }
+
+    private func clearAllFilters() {
+        fieldFilters.removeAll()
+        searchText = ""
+        selectedViewID = "all"
+    }
+
+    private var hasActiveFilters: Bool { activeFilterCount > 0 }
+
+    private var activeFilterCount: Int {
+        var count = fieldFilters.count
+        if selectedViewID != "all" { count += 1 }
+        if !searchText.trimmingCharacters(in: .whitespaces).isEmpty { count += 1 }
+        return count
+    }
+
+    // MARK: - Sorting
+
+    private struct SortOption {
+        let label: String
+        let fieldKey: String
+        let defaultAscending: Bool
+    }
+
+    private var sortOptions: [SortOption] {
+        var options: [SortOption] = [
+            SortOption(label: "Updated", fieldKey: "updatedAt", defaultAscending: false),
+            SortOption(label: "Created", fieldKey: "createdAt", defaultAscending: false),
+            SortOption(label: "Title", fieldKey: docType.titleField, defaultAscending: true),
+            SortOption(label: "Status", fieldKey: "status", defaultAscending: true)
+        ]
+        // Searchable / indexed fields make good sort keys too.
+        let extraKeys = Set(docType.searchFields).union(docType.indexes.map(\.fieldKey))
+        for key in extraKeys where key != docType.titleField {
+            if let f = docType.fields.first(where: { $0.key == key }) {
+                options.append(SortOption(label: f.label, fieldKey: key, defaultAscending: true))
+            }
+        }
+        return options
+    }
+
+    private var currentSortLabel: String {
+        let base = sortOptions.first { $0.fieldKey == sortFieldKey }?.label ?? "Updated"
+        return base
+    }
+
+    private var activeSort: [ListSort] {
+        [ListSort(fieldKey: sortFieldKey, direction: sortAscending ? .ascending : .descending)]
+    }
+
+    // MARK: - Pipeline
+
+    /// Combined predicate set: selected view + active field filters.
+    private var activePredicates: [ListFilter] {
+        (selectedView?.predicates ?? []) + fieldFilters.map(\.predicate)
     }
 
     private var processedDocuments: [Document] {
         let lower = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let predicates = activePredicates
+
         let filtered = documents.filter { doc in
-            let statusMatches = selectedStatus == "All" || doc.status == selectedStatus
-            let searchMatches: Bool
-            if lower.isEmpty {
-                searchMatches = true
-            } else {
-                searchMatches = doc.id.lowercased().contains(lower)
-                    || titleValue(for: doc).lowercased().contains(lower)
-                    || docType.searchFields.contains(where: { key in
-                        displayValue(for: key, in: doc).lowercased().contains(lower)
-                    })
-            }
-            return statusMatches && searchMatches
+            guard RecordListFilter.matchesAll(predicates, doc) else { return false }
+            guard !lower.isEmpty else { return true }
+            return doc.id.lowercased().contains(lower)
+                || titleValue(for: doc).lowercased().contains(lower)
+                || docType.searchFields.contains(where: { key in
+                    displayValue(for: key, in: doc).lowercased().contains(lower)
+                })
         }
 
-        return filtered.sorted { lhs, rhs in
-            switch sortMode {
-            case .updatedDescending:
-                return lhs.updatedAt > rhs.updatedAt
-            case .updatedAscending:
-                return lhs.updatedAt < rhs.updatedAt
-            case .titleAscending:
-                return titleValue(for: lhs).localizedCaseInsensitiveCompare(titleValue(for: rhs)) == .orderedAscending
-            case .titleDescending:
-                return titleValue(for: lhs).localizedCaseInsensitiveCompare(titleValue(for: rhs)) == .orderedDescending
-            }
+        return filtered.sorted { RecordListFilter.areInIncreasingOrder($0, $1, by: activeSort) }
+    }
+
+    private var resultCountText: String {
+        let shown = processedDocuments.count
+        let total = documents.count
+        if shown == total {
+            return "\(total) record\(total == 1 ? "" : "s")"
         }
+        return "\(shown) of \(total) records"
     }
 
     private func titleValue(for doc: Document) -> String {
@@ -258,20 +601,55 @@ public struct GenericListView: View {
             .background(MercantisTheme.primary.opacity(0.12))
             .clipShape(Capsule())
     }
-}
 
-private enum SortMode: String, CaseIterable {
-    case updatedDescending
-    case updatedAscending
-    case titleAscending
-    case titleDescending
-
-    var title: String {
-        switch self {
-        case .updatedDescending: return "Updated ↓"
-        case .updatedAscending: return "Updated ↑"
-        case .titleAscending: return "Title A→Z"
-        case .titleDescending: return "Title Z→A"
+    private func symbol(for type: FieldType) -> String {
+        switch type {
+        case .link: return "link"
+        case .date, .datetime: return "calendar"
+        case .boolean: return "checkmark.square"
+        case .select, .status: return "list.bullet"
+        case .number, .decimal, .currency: return "number"
+        default: return "textformat"
         }
     }
+
+    // MARK: - Persistence
+
+    private var viewStorageKey: String? { preferenceKey.map { "recordList.\($0).view" } }
+    private var sortStorageKey: String? { preferenceKey.map { "recordList.\($0).sort" } }
+
+    private func restorePreferencesOnce() {
+        guard !didRestore else { return }
+        didRestore = true
+        if let key = viewStorageKey,
+           let saved = UserDefaults.standard.string(forKey: key),
+           viewChips.contains(where: { $0.id == saved }) {
+            selectedViewID = saved
+        }
+        if let key = sortStorageKey,
+           let raw = UserDefaults.standard.string(forKey: key) {
+            // Stored as "fieldKey|asc" / "fieldKey|desc".
+            let parts = raw.split(separator: "|")
+            if let first = parts.first { sortFieldKey = String(first) }
+            sortAscending = parts.count > 1 && parts[1] == "asc"
+        }
+    }
+
+    private func persistPreferences() {
+        guard didRestore else { return }
+        if let key = viewStorageKey {
+            UserDefaults.standard.set(selectedViewID, forKey: key)
+        }
+        if let key = sortStorageKey {
+            UserDefaults.standard.set("\(sortFieldKey)|\(sortAscending ? "asc" : "desc")", forKey: key)
+        }
+    }
+}
+
+/// An active, user-applied field filter shown as a removable chip.
+private struct ActiveFieldFilter: Identifiable {
+    let id = UUID()
+    let fieldKey: String
+    let display: String
+    let predicate: ListFilter
 }

--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -44,6 +44,9 @@ public struct RecordCollectionHostView: View {
     let linkResolveProvider: ((String, String) -> Document?)?
     let childDocTypeProvider: ((String) -> DocType?)?
     let detailEditor: ((DocType, Binding<Document>) -> AnyView)?
+    /// Optional built-in / saved list views (e.g. Hub's "Unpaid", "Overdue").
+    /// When empty the list synthesises status chips from the loaded data.
+    let listViews: [RecordListViewDefinition]
 
     @State private var selectedDocument: Document?
     @State private var selectedDocumentID: String?
@@ -81,7 +84,8 @@ public struct RecordCollectionHostView: View {
         linkSearchProvider: ((String, String) -> [Document])? = nil,
         linkResolveProvider: ((String, String) -> Document?)? = nil,
         childDocTypeProvider: ((String) -> DocType?)? = nil,
-        detailEditor: ((DocType, Binding<Document>) -> AnyView)? = nil
+        detailEditor: ((DocType, Binding<Document>) -> AnyView)? = nil,
+        listViews: [RecordListViewDefinition] = []
     ) {
         self.preferenceKey = preferenceKey
         self.docType = docType
@@ -109,6 +113,7 @@ public struct RecordCollectionHostView: View {
         self.linkResolveProvider = linkResolveProvider
         self.childDocTypeProvider = childDocTypeProvider
         self.detailEditor = detailEditor
+        self.listViews = listViews
         _selectedViewMode = State(initialValue: configuration.defaultViewMode)
     }
 
@@ -283,7 +288,12 @@ public struct RecordCollectionHostView: View {
             documents: documents,
             selectedDocumentID: selectedDocument?.id,
             onSelect: selectDocument(_:),
-            onCreate: handleCreateDocument
+            onCreate: handleCreateDocument,
+            listViews: listViews,
+            preferenceKey: preferenceKey,
+            linkSearchProvider: linkSearchProvider,
+            linkResolveProvider: linkResolveProvider,
+            linkTargetMetaProvider: childDocTypeProvider
         )
     }
 


### PR DESCRIPTION
## Summary

Two Core UI improvements on this branch, both generic and metadata-driven (no Hub-specific DocTypes referenced):

1. **Child-table link pickers** (`67dbb87`) — `.link` fields inside child tables now render the searchable `LinkPickerField` instead of a plain text field.
2. **Richer DocType list/filter UX** (`ececa15`) — replaces `GenericListView`'s minimal search+status+sort with a native filter bar built on the existing `ListFilter`/`ListSort` model, plus a reusable saved-views concept apps populate per DocType.

## 1 — Child-table link pickers

**Root cause:** `GenericFormView.tableField(...)` never forwarded its link providers to `ChildTableField`, and neither the inline grid (`childFieldCell`) nor the row popover (`ChildRowEditor.control`) had a `.link` branch, so child-row links fell through to plain text.

**Fix:**
- `ChildTableField`: optional `linkSearchProvider` / `linkResolveProvider` / `childDocTypeProvider` (defaulted nil), and a `.link` branch in both the inline cell and the popover editor that renders the existing public `LinkPickerField`, scoped to `field.linkedDocType`.
- `GenericFormView.tableField`: forwards its existing providers down.
- Read-only shows a resolved label (or dash); unwired callers keep the plain-text fallback — no behaviour change.

## 2 — DocType list/filter UX

**Core model (MercantisCore, headless):** `RecordListView.swift` adds `RecordListViewDefinition` (id/label/icon/predicates/searchText/sort/isBuiltIn), `RecordListQuery`, `DateRangePreset` (→ `between` predicates), and `RecordListFilter` — an in-memory `ListFilter`/`ListSort` evaluator (eq/neq/gt/gte/lt/lte/between/in/like/isNull/isNotNull, numeric coercion, bool kept distinct from int, case-insensitive LIKE). One predicate model shared by UI and engine.

**Core UI (MercantisCoreUI):**
- `GenericListView`: search + view chips (saved views, or status chips synthesised from `docStatus`/workflow status when none supplied) + type-aware field filters + sort menu (title/updated/created/status/searchable fields) + active-filter count/clear + "x of y records" + three distinct empty states. Existing 4-arg init preserved; new capabilities are opt-in. Selected view + sort persisted per DocType in `UserDefaults`.
- `FieldFilterEditor`: per-field predicate builder; link fields reuse `LinkPickerField`; dates use presets or a custom range.
- `RecordCollectionHostView`: optional `listViews` param, threaded into the list with the existing link providers.

Filtering stays in-memory over the loaded array (fine for local SME data); the `RecordListQuery`/`ListFilter` shape lets engine-backed reload slot in later.

## Tests

- `RecordListViewTests` — predicate/sort/date-preset semantics + a `GenericListView` smoke test against the new surface.
- `GenericFormViewSmokeTests` — child DocType with a `.link` field (`SalesItem.item → Item`), wired-provider form path, read-only `ChildTableField` init. Also fixes a pre-existing `fetch(id:docType:)` call that didn't match the engine's `fetch(docType:id:)` signature.

## Backward compatibility

- `GenericListView`'s original 4-arg init is preserved and delegates to the full init.
- All new `ChildTableField` / `RecordCollectionHostView` params default to nil/empty — existing callers compile unchanged.

## Verification notes

Not built here — this was prepared in a Linux container with no Swift/Xcode toolchain. Verified by inspection: brace balance even on all files, `FieldType`/`FieldValue`/`FieldDefinition`/`DocType` API names cross-checked, `FieldDefinition: Identifiable` confirmed for `popover(item:)`, project uses a file-system-synchronized group so new files auto-join targets. **A clean `swift test` / Xcode build on macOS is still required.**

```
swift test --filter RecordListViewTests
swift test --filter MercantisCoreUITests
```

https://claude.ai/code/session_01DkoshpkrnuSPB8eSdQC7YS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkoshpkrnuSPB8eSdQC7YS)_