### PR TITLE
Add brand identity, adaptive colours, and status badges

### DIFF
--- a/Docs/VISUAL-POLISH-PASS.md
+++ b/Docs/VISUAL-POLISH-PASS.md
@@ -1,0 +1,171 @@
+# Mercantis — Visual Polish Pass (Brand, Status & Surfaces)
+
+_Last updated: 2026-05-31_
+
+This pass moves Mercantis from a "clean technical app" toward a "polished
+business product" **without** redesigning the UI or making it colourful. It
+refines the design tokens so the product has a recognisable identity, scannable
+operational states, and finished-feeling surfaces — while staying a native
+macOS business platform, not a web ERP.
+
+The work is token-first: Core owns the colour decisions; Hub consumes them
+instead of defining one-off colours.
+
+---
+
+## 1. Brand colour decisions
+
+Defined in `mercantis core/UIShell/DesignTokens/MercantisTheme.swift` and
+exposed publicly on `MercantisTheme` so Hub (and any third-party consumer of
+`MercantisCoreUI`) can use them.
+
+| Token | Light | Dark | Use |
+|---|---|---|---|
+| `brandPrimary` | `#295CC7` | `#3366D9` | Primary buttons, product identity (sidebar logo square, hero header chip) |
+| `brandPrimaryHover` | lighter | lighter | Optional hover state |
+| `brandPrimaryPressed` | darker | darker | Primary button pressed state |
+| `brandPrimarySoft` | `brandPrimary @ 12%` | — | Tinted cards / identity chips / soft fills |
+| `brandPrimaryBorder` | `brandPrimary @ 32%` | — | Hairline ring on tinted surfaces |
+| `brandSecondary` | blue-teal | blue-teal | Sparing secondary accent |
+| `brandAccent` | cyan | cyan | Rare highlight (focus glints) |
+
+**Direction:** a deep, trustworthy blue-indigo. Not bright, not SaaS. All brand
+colours are **adaptive** (light/dark) via `MercantisTheme.adaptive(light:dark:)`,
+which builds a dynamic `NSColor`/`UIColor` — the package ships no asset catalog.
+
+**Contrast:** `brandPrimary` is tuned so **white text clears WCAG AA** in both
+appearances (≈6.1:1 light, ≈5.2:1 dark). If you ever darken/brighten it, re-check
+white-on-brand contrast stays ≥ 4.5:1.
+
+### What still uses the system accent
+
+`MercantisTheme.accent` is **still `Color.accentColor`** on purpose. Native
+selection, list selection tint, and standard control tint continue to respect
+the user's macOS accent choice. Only **product identity and the primary action**
+were moved to the brand colour. Do **not** globally override `.tint` to brand —
+that would recolour native selection and break the native feel.
+
+---
+
+## 2. Semantic status mapping
+
+Defined as `MercantisStatusTone` + the `MercantisStatusBadge` view.
+
+`MercantisStatusTone(status:)` classifies free-form ERP status strings
+(case/space/punctuation-tolerant) into a small business palette. Each tone maps
+to a semantic colour **and** an SF Symbol, so colour is never the only signal.
+
+| Status (examples) | Tone | Colour | Glyph |
+|---|---|---|---|
+| Draft, Open, New | `.draft` | muted/grey | `pencil.line` |
+| Submitted, Approved, Confirmed | `.submitted` | info/blue | `paperplane.fill` |
+| Paid | `.paid` | success/green | `checkmark.seal.fill` |
+| Unpaid | `.unpaid` | warning | `exclamationmark.circle` |
+| Overdue | `.overdue` | danger | `exclamationmark.triangle.fill` |
+| Cancelled, Rejected, Failed | `.cancelled` | danger | `xmark.circle` |
+| Closed | `.closed` | muted | `lock.fill` |
+| Completed, Done, Delivered | `.completed` | success/green | `checkmark.circle.fill` |
+| In Progress, Processing, Partly Paid | `.inProgress` | info | `clock` |
+| Stopped, On Hold, Pending | `.stopped` | warning | `pause.circle` |
+| Ordered, To Order | `.ordered` | info | `shippingbox.fill` |
+| Lost, Expired, Void | `.lost` | danger | `xmark.bin` |
+| Reconciled, Settled, Cleared | `.reconciled` | success/green | `checkmark.seal` |
+| Active, Enabled, Live | `.active` | success/green | `circle.fill` |
+| Inactive, Disabled, Archived | `.inactive` | muted | `circle` |
+| _anything unmatched_ | `.neutral` | muted | `circle.dashed` |
+
+**Rules:**
+1. Badges always show **text**.
+2. Colour is **never** the only indicator (glyph + text always present).
+3. Fills are soft tonal + hairline ring → readable in light **and** dark.
+4. Unknown statuses degrade gracefully to `.neutral`.
+5. Badges stay subtle and business-like — they must not shout.
+
+**Applied to:** `GenericListView` row badges, the Hub record/detail lifecycle
+header (`HubDocumentEditor`), and Hub error/snapshot states.
+
+---
+
+## 3. Module colour usage rules
+
+Module tones (`MercantisModuleTone` → `MercantisTheme.moduleTint/Fill/Border`)
+are now **adaptive** so they read in light mode without going neon in dark mode.
+
+- CRM blue · Selling green · Buying orange · Stock purple · Accounting indigo ·
+  Manufacturing rust · Setup slate · Platform cyan.
+- Use them **only** as accents: sidebar icon chips, low-opacity fills, badges,
+  selected indicators, dashboard accents.
+- **Never** fill a whole module page, sidebar, or large surface with module
+  colour. Keep fills ≤ ~12% opacity (see `moduleFill`).
+
+---
+
+## 4. Light / dark mode notes
+
+- Brand, semantic (success/warning/danger/info) and module colours are all
+  adaptive; dark variants are brighter but kept slightly desaturated.
+- Surfaces/borders/text use native `NSColor`/`UIColor` dynamic colours.
+- Primary button keeps white text in both modes (AA-safe).
+- Status badge fill + ring read in both modes.
+- Verify with `#Preview("Status badges")` in `MercantisTheme.swift` in both
+  appearances.
+
+---
+
+## 5. Buttons
+
+`MercantisPrimaryButtonStyle` / `MercantisSecondaryButtonStyle` /
+`MercantisDestructiveButtonStyle` are now `public` with a `public init()`:
+
+- **Primary:** brand fill, white label, distinct pressed state, dimmed (`0.45`)
+  when disabled. Compact macOS sizing.
+- **Secondary:** native, calm, hairline-bordered; does not compete with primary.
+- **Destructive:** restrained danger (soft fill + danger label + ring), not a
+  loud solid red.
+
+Use these for **product** actions. Leave deep builder/tooling sheets on native
+`.bordered`/`.borderedProminent` where a fully native control is more
+appropriate — don't force every control into brand colour.
+
+---
+
+## 6. Cards & surfaces
+
+- `.mercantisCard(padding:tinted:)` is the canonical card: consistent corner
+  radius (`MercantisSpacing.cardCornerRadius`), native surface fill, hairline
+  border, optional brand tint. Prefer it over bespoke card chrome.
+- Keep shadows out; lean on borders + native materials for depth.
+- Consistent corner radius and padding across cards/tiles/headers.
+
+---
+
+## 7. What NOT to do in future UI work
+
+- ❌ Don't globally set `.tint` to the brand colour (breaks native selection).
+- ❌ Don't replace `MercantisTheme.accent` (system accent) wholesale — it's
+  intentional for native selection/control tint.
+- ❌ Don't use raw `.red` / `.green` / `.orange` / `Color.accentColor` in Hub —
+  consume `MercantisTheme` tokens / `MercantisStatusBadge` instead.
+- ❌ Don't over-colour the sidebar or fill module pages with saturated colour.
+- ❌ Don't use colour as the only status indicator — always text + glyph.
+- ❌ Don't add heavy gradients, glassmorphism, or web-dashboard decoration.
+- ❌ Don't hard-code ERP domain logic in Core; status **mapping** is generic and
+  string-driven, not domain-coupled.
+
+---
+
+## 8. File map
+
+**Core (`MercantisCoreUI`):**
+- `UIShell/DesignTokens/MercantisTheme.swift` — brand palette, adaptive helper,
+  semantic + module tones, `MercantisStatusTone`, `MercantisStatusBadge`,
+  public button styles, `.mercantisCard`.
+- `UIShell/GenericListView.swift` — row status badge → `MercantisStatusBadge`.
+- `UIShell/Components/WorkspaceHeroHeader.swift` — brand identity chip.
+- `UIShell/Components/MercantisSidebarComponents.swift` — brand logo square.
+
+**Hub (`MercantisCoreUI` consumer):**
+- `UI/RootView.swift` — lifecycle/workflow status badges, semantic error styling.
+- `UI/Home/HubHomeView.swift` — brand identity, semantic checklist/banner,
+  brand-tinted card surface, brand primary CTA.
+- `UI/Dashboards/HubDashboardView.swift` — semantic error tile, brand shortcut.

--- a/mercantis core/UIShell/Components/MercantisSidebarComponents.swift
+++ b/mercantis core/UIShell/Components/MercantisSidebarComponents.swift
@@ -244,7 +244,9 @@ public struct MercantisSidebarBrandHeader: View {
     public var body: some View {
         HStack(spacing: 10) {
             RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .fill(tint ?? MercantisTheme.accent)
+                // Brand colour by default so the product identity square is
+                // recognisably Mercantis rather than the user's system accent.
+                .fill(tint ?? MercantisTheme.brandPrimary)
                 .frame(width: 28, height: 28)
                 .overlay {
                     Image(systemName: systemImage)

--- a/mercantis core/UIShell/Components/WorkspaceHeroHeader.swift
+++ b/mercantis core/UIShell/Components/WorkspaceHeroHeader.swift
@@ -103,13 +103,19 @@ public struct WorkspaceHeroHeader: View {
     }
 
     private var iconBadge: some View {
+        // Brand-tinted identity chip so every workspace header reads as part
+        // of the Mercantis product rather than a generic accent-coloured view.
         Image(systemName: symbol)
             .font(.system(size: 18, weight: .semibold))
-            .foregroundStyle(MercantisTheme.accent)
+            .foregroundStyle(MercantisTheme.brandPrimary)
             .frame(width: 36, height: 36)
             .background(
-                RoundedRectangle(cornerRadius: MercantisSpacing.controlCornerRadius)
-                    .fill(MercantisTheme.accentFillSoft)
+                RoundedRectangle(cornerRadius: MercantisSpacing.controlCornerRadius, style: .continuous)
+                    .fill(MercantisTheme.brandPrimarySoft)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: MercantisSpacing.controlCornerRadius, style: .continuous)
+                    .stroke(MercantisTheme.brandPrimaryBorder, lineWidth: 0.5)
             )
     }
 }

--- a/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
+++ b/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
@@ -8,8 +8,9 @@ import AppKit
 import UIKit
 #endif
 
-enum MercantisSemanticTone {
+public enum MercantisSemanticTone: Sendable {
     case accent
+    case brand
     case success
     case warning
     case danger
@@ -33,46 +34,128 @@ public enum MercantisModuleTone: Hashable, Sendable {
     case neutral
 }
 
-enum MercantisTheme {
-    static let accent = Color.accentColor
-    static let accentFillSoft = Color.accentColor.opacity(0.12)
-    static let accentBorder = Color.accentColor.opacity(0.34)
-    static let softFillOpacity = 0.14
-    static let warningFillOpacity = 0.16
-    static let success = Color(red: 22 / 255, green: 163 / 255, blue: 74 / 255)
-    static let warning = Color(red: 202 / 255, green: 138 / 255, blue: 4 / 255)
-    static let danger = Color(red: 220 / 255, green: 38 / 255, blue: 38 / 255)
-    static let info = Color(red: 67 / 255, green: 56 / 255, blue: 202 / 255)
-    static let selectionBackground = accentFillSoft
-    static let selectionForeground = accent
-    static let mutedBadge = Color.secondary.opacity(0.16)
-    static let inspectorHighlight = Color.accentColor.opacity(0.08)
-    static let subtleSeparatorOpacity = 0.15
-    static let primary = accent
-    static let primaryPressed = Color.accentColor.opacity(0.88)
+public enum MercantisTheme {
+
+    // MARK: - Adaptive colour helper
+
+    /// Builds a light/dark adaptive `Color` from sRGB component tuples so the
+    /// design system can ship brand and module colours that resolve per
+    /// appearance without an asset catalog (the package has no `.xcassets`).
+    /// Falls back to the light variant on platforms without a dynamic API.
+    static func adaptive(
+        light: (Double, Double, Double),
+        dark: (Double, Double, Double)
+    ) -> Color {
+        #if os(macOS)
+        return Color(nsColor: NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            let c = isDark ? dark : light
+            return NSColor(srgbRed: c.0, green: c.1, blue: c.2, alpha: 1)
+        })
+        #elseif os(iOS)
+        return Color(uiColor: UIColor { traits in
+            let c = traits.userInterfaceStyle == .dark ? dark : light
+            return UIColor(red: c.0, green: c.1, blue: c.2, alpha: 1)
+        })
+        #else
+        return Color(red: light.0, green: light.1, blue: light.2)
+        #endif
+    }
+
+    // MARK: - Brand palette
+
+    /// Mercantis brand primary — a deep, trustworthy blue-indigo. Used for
+    /// primary buttons and product identity (header / logo square, hero
+    /// chrome). Tuned so white text clears WCAG AA in both appearances
+    /// (≈6.1:1 light, ≈5.2:1 dark).
+    public static let brandPrimary = adaptive(
+        light: (0.16, 0.36, 0.78),
+        dark:  (0.20, 0.40, 0.85)
+    )
+    public static let brandPrimaryHover = adaptive(
+        light: (0.20, 0.42, 0.84),
+        dark:  (0.27, 0.49, 0.93)
+    )
+    public static let brandPrimaryPressed = adaptive(
+        light: (0.12, 0.30, 0.66),
+        dark:  (0.16, 0.34, 0.74)
+    )
+    /// Low-opacity brand fill for tinted cards, identity chips, and selected
+    /// indicators where the system accent would feel non-native.
+    public static let brandPrimarySoft = brandPrimary.opacity(0.12)
+    public static let brandPrimaryBorder = brandPrimary.opacity(0.32)
+    /// Secondary brand tone (blue-teal) for sparing accents / illustrations.
+    public static let brandSecondary = adaptive(
+        light: (0.05, 0.45, 0.55),
+        dark:  (0.22, 0.63, 0.73)
+    )
+    /// Optional brighter highlight, used very sparingly (e.g. focus glints).
+    public static let brandAccent = adaptive(
+        light: (0.00, 0.50, 0.62),
+        dark:  (0.32, 0.74, 0.84)
+    )
+
+    // MARK: - System accent (native selection / control tint)
+
+    /// The system accent is intentionally retained for selection and native
+    /// control tint so the app still respects the user's macOS accent choice.
+    /// Product identity uses `brandPrimary` instead.
+    public static let accent = Color.accentColor
+    public static let accentFillSoft = Color.accentColor.opacity(0.12)
+    public static let accentBorder = Color.accentColor.opacity(0.34)
+
+    public static let softFillOpacity = 0.14
+    public static let warningFillOpacity = 0.16
+    public static let success = adaptive(
+        light: (0.13, 0.60, 0.32),
+        dark:  (0.27, 0.74, 0.46)
+    )
+    public static let warning = adaptive(
+        light: (0.72, 0.50, 0.05),
+        dark:  (0.92, 0.70, 0.25)
+    )
+    public static let danger = adaptive(
+        light: (0.78, 0.18, 0.18),
+        dark:  (0.94, 0.38, 0.38)
+    )
+    public static let info = adaptive(
+        light: (0.18, 0.36, 0.78),
+        dark:  (0.40, 0.58, 0.96)
+    )
+    public static let selectionBackground = accentFillSoft
+    public static let selectionForeground = accent
+    public static let mutedBadge = Color.secondary.opacity(0.16)
+    public static let inspectorHighlight = brandPrimary.opacity(0.08)
+    public static let subtleSeparatorOpacity = 0.15
+    /// `primary` now resolves to the Mercantis brand so any legacy call-site
+    /// that styled "the primary action colour" inherits product identity.
+    public static let primary = brandPrimary
+    public static let primaryPressed = brandPrimaryPressed
 
     #if os(macOS)
-    static let background = Color(NSColor.windowBackgroundColor)
-    static let surface = Color(NSColor.controlBackgroundColor)
-    static let surfaceElevated = Color(NSColor.textBackgroundColor)
-    static let surfaceMuted = Color(NSColor.underPageBackgroundColor)
-    static let border = Color(NSColor.separatorColor)
-    static let textPrimary = Color(NSColor.labelColor)
-    static let textMuted = Color(NSColor.secondaryLabelColor)
+    public static let background = Color(NSColor.windowBackgroundColor)
+    public static let surface = Color(NSColor.controlBackgroundColor)
+    public static let surfaceElevated = Color(NSColor.textBackgroundColor)
+    public static let surfaceMuted = Color(NSColor.underPageBackgroundColor)
+    public static let border = Color(NSColor.separatorColor)
+    public static let textPrimary = Color(NSColor.labelColor)
+    public static let textMuted = Color(NSColor.secondaryLabelColor)
     #else
-    static let background = Color(UIColor.systemGroupedBackground)
-    static let surface = Color(UIColor.secondarySystemGroupedBackground)
-    static let surfaceElevated = Color(UIColor.systemBackground)
-    static let surfaceMuted = Color(UIColor.tertiarySystemBackground)
-    static let border = Color(UIColor.separator)
-    static let textPrimary = Color(UIColor.label)
-    static let textMuted = Color(UIColor.secondaryLabel)
+    public static let background = Color(UIColor.systemGroupedBackground)
+    public static let surface = Color(UIColor.secondarySystemGroupedBackground)
+    public static let surfaceElevated = Color(UIColor.systemBackground)
+    public static let surfaceMuted = Color(UIColor.tertiarySystemBackground)
+    public static let border = Color(UIColor.separator)
+    public static let textPrimary = Color(UIColor.label)
+    public static let textMuted = Color(UIColor.secondaryLabel)
     #endif
 
-    static func tint(for tone: MercantisSemanticTone) -> Color {
+    public static func tint(for tone: MercantisSemanticTone) -> Color {
         switch tone {
         case .accent:
             accent
+        case .brand:
+            brandPrimary
         case .success:
             success
         case .warning:
@@ -86,10 +169,12 @@ enum MercantisTheme {
         }
     }
 
-    static func fillSoft(for tone: MercantisSemanticTone) -> Color {
+    public static func fillSoft(for tone: MercantisSemanticTone) -> Color {
         switch tone {
         case .accent:
             accentFillSoft
+        case .brand:
+            brandPrimarySoft
         case .success:
             success.opacity(softFillOpacity)
         case .warning:
@@ -103,75 +188,134 @@ enum MercantisTheme {
         }
     }
 
-    static func moduleTint(_ tone: MercantisModuleTone) -> Color {
+    /// Module tints are adaptive so they read clearly in light mode without
+    /// turning neon in dark mode (dark variants are lifted in brightness but
+    /// kept slightly desaturated).
+    public static func moduleTint(_ tone: MercantisModuleTone) -> Color {
         switch tone {
-        case .crm:        return Color(red: 0.20, green: 0.47, blue: 0.96) // blue
-        case .selling:    return Color(red: 0.13, green: 0.64, blue: 0.40) // green
-        case .buying:     return Color(red: 0.90, green: 0.49, blue: 0.13) // orange
-        case .stock:      return Color(red: 0.55, green: 0.34, blue: 0.85) // purple
-        case .accounting:    return Color(red: 0.31, green: 0.27, blue: 0.80) // indigo
-        case .manufacturing: return Color(red: 0.83, green: 0.32, blue: 0.36) // rust red
-        case .setup:         return Color(red: 0.42, green: 0.45, blue: 0.50) // slate gray
-        case .platform:   return Color(red: 0.10, green: 0.60, blue: 0.74) // cyan
-        case .system:     return Color(red: 0.42, green: 0.45, blue: 0.50)
-        case .neutral:    return textMuted
+        case .crm:           return adaptive(light: (0.20, 0.47, 0.92), dark: (0.42, 0.62, 0.97)) // blue
+        case .selling:       return adaptive(light: (0.13, 0.60, 0.40), dark: (0.32, 0.74, 0.52)) // green
+        case .buying:        return adaptive(light: (0.86, 0.49, 0.14), dark: (0.94, 0.64, 0.34)) // orange
+        case .stock:         return adaptive(light: (0.52, 0.34, 0.82), dark: (0.68, 0.52, 0.92)) // purple
+        case .accounting:    return adaptive(light: (0.31, 0.29, 0.78), dark: (0.50, 0.48, 0.92)) // indigo
+        case .manufacturing: return adaptive(light: (0.80, 0.32, 0.36), dark: (0.92, 0.48, 0.50)) // rust red
+        case .setup:         return adaptive(light: (0.42, 0.45, 0.50), dark: (0.60, 0.64, 0.70)) // slate gray
+        case .platform:      return adaptive(light: (0.10, 0.58, 0.72), dark: (0.32, 0.74, 0.86)) // cyan
+        case .system:        return adaptive(light: (0.42, 0.45, 0.50), dark: (0.60, 0.64, 0.70))
+        case .neutral:       return textMuted
         }
     }
 
-    static func moduleFill(_ tone: MercantisModuleTone) -> Color {
+    public static func moduleFill(_ tone: MercantisModuleTone) -> Color {
         moduleTint(tone).opacity(0.12)
     }
 
-    static func moduleBorder(_ tone: MercantisModuleTone) -> Color {
+    public static func moduleBorder(_ tone: MercantisModuleTone) -> Color {
         moduleTint(tone).opacity(0.22)
     }
 }
 
-struct MercantisPrimaryButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .font(.system(size: 13, weight: .semibold))
-            .foregroundStyle(Color.white)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 8)
-            .background(configuration.isPressed ? MercantisTheme.primaryPressed : MercantisTheme.accent)
-            .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                    .stroke(MercantisTheme.accentBorder.opacity(configuration.isPressed ? 0.7 : 1), lineWidth: 1)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 6))
+/// Primary action button — Mercantis brand fill, white label, distinct
+/// pressed state, and a dimmed disabled state. macOS-appropriate sizing
+/// (compact, not web-scale).
+public struct MercantisPrimaryButtonStyle: ButtonStyle {
+    public init() {}
+
+    public func makeBody(configuration: Configuration) -> some View {
+        Body(configuration: configuration)
+    }
+
+    private struct Body: View {
+        let configuration: ButtonStyleConfiguration
+        @Environment(\.isEnabled) private var isEnabled
+
+        var body: some View {
+            configuration.label
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Color.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(fill)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(Color.white.opacity(0.10), lineWidth: 0.5)
+                )
+                .opacity(isEnabled ? 1 : 0.45)
+                .contentShape(Rectangle())
+                .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+        }
+
+        private var fill: Color {
+            configuration.isPressed
+                ? MercantisTheme.brandPrimaryPressed
+                : MercantisTheme.brandPrimary
+        }
     }
 }
 
-struct MercantisSecondaryButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .font(.system(size: 13, weight: .semibold))
-            .foregroundStyle(MercantisTheme.textPrimary)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(MercantisTheme.surfaceMuted)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                    .stroke(MercantisTheme.border, lineWidth: 1)
-            )
-            .opacity(configuration.isPressed ? 0.85 : 1)
+/// Secondary action button — native, calm, hairline-bordered. Reads as a
+/// standard macOS push button without competing with the primary action.
+public struct MercantisSecondaryButtonStyle: ButtonStyle {
+    public init() {}
+
+    public func makeBody(configuration: Configuration) -> some View {
+        Body(configuration: configuration)
+    }
+
+    private struct Body: View {
+        let configuration: ButtonStyleConfiguration
+        @Environment(\.isEnabled) private var isEnabled
+
+        var body: some View {
+            configuration.label
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(MercantisTheme.textPrimary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(MercantisTheme.surfaceMuted)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(MercantisTheme.border, lineWidth: 1)
+                )
+                .opacity(isEnabled ? (configuration.isPressed ? 0.7 : 1) : 0.45)
+        }
     }
 }
 
-struct MercantisDestructiveButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .font(.system(size: 13, weight: .semibold))
-            .foregroundStyle(MercantisTheme.danger)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 8)
-            .background(MercantisTheme.danger.opacity(0.12))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .opacity(configuration.isPressed ? 0.85 : 1)
+/// Destructive action button — danger tone kept restrained (soft fill +
+/// danger label) rather than a loud solid red, in keeping with the calm
+/// business tone.
+public struct MercantisDestructiveButtonStyle: ButtonStyle {
+    public init() {}
+
+    public func makeBody(configuration: Configuration) -> some View {
+        Body(configuration: configuration)
+    }
+
+    private struct Body: View {
+        let configuration: ButtonStyleConfiguration
+        @Environment(\.isEnabled) private var isEnabled
+
+        var body: some View {
+            configuration.label
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(MercantisTheme.danger)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(MercantisTheme.danger.opacity(configuration.isPressed ? 0.20 : 0.12))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(MercantisTheme.danger.opacity(0.28), lineWidth: 1)
+                )
+                .opacity(isEnabled ? 1 : 0.45)
+        }
     }
 }
 
@@ -265,16 +409,24 @@ private struct MercantisPickerModifier: ViewModifier {
 }
 
 private struct MercantisCardModifier: ViewModifier {
+    var padding: CGFloat? = nil
+    var tinted: Bool = false
+
     func body(content: Content) -> some View {
-        content
-            .padding()
+        let radius = MercantisSpacing.cardCornerRadius
+        return content
+            .padding(padding ?? MercantisSpacing.l)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(MercantisTheme.surface)
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .fill(tinted ? AnyShapeStyle(MercantisTheme.brandPrimarySoft) : AnyShapeStyle(MercantisTheme.surface))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(MercantisTheme.border.opacity(0.8), lineWidth: 1)
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .stroke(
+                        tinted ? MercantisTheme.brandPrimaryBorder : MercantisTheme.border.opacity(0.8),
+                        lineWidth: 1
+                    )
             )
             .accessibilityElement(children: .contain)
     }
@@ -307,7 +459,7 @@ struct MercantisSectionHeading: View {
     }
 }
 
-extension View {
+public extension View {
     func mercantisSemanticBadge(tone: MercantisSemanticTone = .muted) -> some View {
         modifier(MercantisSemanticBadgeModifier(tone: tone))
     }
@@ -324,11 +476,216 @@ extension View {
         modifier(MercantisInputModifier())
     }
 
-    func mercantisCard() -> some View {
-        modifier(MercantisCardModifier())
+    /// Standard Core card surface — consistent corner radius, native surface
+    /// fill, hairline border. Pass `tinted: true` for a subtle brand-tinted
+    /// card (e.g. a highlighted call-to-action), or a custom `padding` (use
+    /// `0` for rows that manage their own insets).
+    func mercantisCard(padding: CGFloat? = nil, tinted: Bool = false) -> some View {
+        modifier(MercantisCardModifier(padding: padding, tinted: tinted))
     }
 
     func mercantisPicker() -> some View {
         modifier(MercantisPickerModifier())
     }
 }
+
+// MARK: - Semantic ERP status tones
+
+/// Maps the free-form status strings ERP documents carry (Draft, Submitted,
+/// Paid, Overdue, Completed, …) onto a small, business-like semantic palette
+/// so operational states can be scanned at a glance. Colour is never the only
+/// signal — each tone also carries an SF Symbol, and badges always show text.
+///
+/// Unknown / unmapped statuses fall back to a neutral tone so a new workflow
+/// state still renders sensibly rather than blank.
+public enum MercantisStatusTone: Sendable, Hashable {
+    case draft
+    case submitted
+    case paid
+    case unpaid
+    case overdue
+    case cancelled
+    case closed
+    case completed
+    case inProgress
+    case stopped
+    case ordered
+    case lost
+    case reconciled
+    case active
+    case inactive
+    case neutral
+
+    /// Best-effort classification of an arbitrary status string. Matching is
+    /// case-insensitive and tolerant of spacing/punctuation (e.g. "In Progress",
+    /// "in-progress", "InProgress" all resolve to `.inProgress`).
+    public init(status raw: String) {
+        let s = raw
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let compact = s.replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "_", with: "")
+
+        switch compact {
+        case "draft", "open", "new":
+            self = .draft
+        case "tobill", "todeliver", "toreceive", "topay":
+            self = .inProgress
+        case "pending", "awaiting":
+            self = .stopped
+        case "submitted", "submit", "approved", "confirmed", "issued":
+            self = .submitted
+        case "paid":
+            self = .paid
+        case "overdue":
+            self = .overdue
+        case "unpaid":
+            self = .unpaid
+        case "cancelled", "canceled", "rejected", "returned", "failed", "error":
+            self = .cancelled
+        case "closed":
+            self = .closed
+        case "completed", "complete", "done", "delivered", "fulfilled", "received":
+            self = .completed
+        case "inprogress", "processing", "working", "partlypaid", "partiallypaid", "partlyordered":
+            self = .inProgress
+        case "stopped", "onhold", "hold", "suspended":
+            self = .stopped
+        case "ordered", "toorder", "ordering", "purchased":
+            self = .ordered
+        case "lost", "expired", "void":
+            self = .lost
+        case "reconciled", "settled", "cleared", "matched":
+            self = .reconciled
+        case "active", "enabled", "live":
+            self = .active
+        case "inactive", "disabled", "archived", "deactivated":
+            self = .inactive
+        default:
+            // Keyword fallbacks for compound statuses not matched exactly.
+            if s.contains("overdue") { self = .overdue }
+            else if s.contains("unpaid") { self = .unpaid }
+            else if s.contains("paid") { self = .paid }
+            else if s.contains("cancel") || s.contains("reject") { self = .cancelled }
+            else if s.contains("complete") || s.contains("done") { self = .completed }
+            else if s.contains("progress") { self = .inProgress }
+            else if s.contains("submit") || s.contains("approve") { self = .submitted }
+            else if s.contains("close") { self = .closed }
+            else if s.contains("active") { self = .active }
+            else if s.contains("draft") { self = .draft }
+            else { self = .neutral }
+        }
+    }
+
+    /// The underlying semantic tone used for the colour treatment.
+    public var semantic: MercantisSemanticTone {
+        switch self {
+        case .paid, .completed, .reconciled, .active:
+            return .success
+        case .submitted, .ordered, .inProgress:
+            return .info
+        case .unpaid, .stopped:
+            return .warning
+        case .overdue, .cancelled, .lost:
+            return .danger
+        case .draft, .closed, .inactive, .neutral:
+            return .muted
+        }
+    }
+
+    /// A glyph paired with the label so status is legible without relying on
+    /// colour alone (accessibility + fast scanning).
+    public var symbol: String {
+        switch self {
+        case .draft:      return "pencil.line"
+        case .submitted:  return "paperplane.fill"
+        case .paid:       return "checkmark.seal.fill"
+        case .unpaid:     return "exclamationmark.circle"
+        case .overdue:    return "exclamationmark.triangle.fill"
+        case .cancelled:  return "xmark.circle"
+        case .closed:     return "lock.fill"
+        case .completed:  return "checkmark.circle.fill"
+        case .inProgress: return "clock"
+        case .stopped:    return "pause.circle"
+        case .ordered:    return "shippingbox.fill"
+        case .lost:       return "xmark.bin"
+        case .reconciled: return "checkmark.seal"
+        case .active:     return "circle.fill"
+        case .inactive:   return "circle"
+        case .neutral:    return "circle.dashed"
+        }
+    }
+
+    /// Spoken description appended to the badge's accessibility label.
+    public var accessibilityDescription: String {
+        switch semantic {
+        case .success: return "positive status"
+        case .info:    return "in-progress status"
+        case .warning: return "attention status"
+        case .danger:  return "problem status"
+        case .muted, .accent, .brand: return "neutral status"
+        }
+    }
+}
+
+/// Reusable, business-like status badge. Always shows text, pairs the label
+/// with a tone glyph, and uses a soft tonal fill + hairline ring that reads
+/// in both light and dark mode. Subtle by design — it should not shout.
+public struct MercantisStatusBadge: View {
+    private let text: String
+    private let tone: MercantisStatusTone
+    private let showsSymbol: Bool
+
+    /// Builds a badge by classifying a raw status string. Empty strings render
+    /// as "Draft" so unsaved records still read sensibly.
+    public init(_ status: String, showsSymbol: Bool = true) {
+        let trimmed = status.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.text = trimmed.isEmpty ? "Draft" : trimmed
+        self.tone = MercantisStatusTone(status: trimmed)
+        self.showsSymbol = showsSymbol
+    }
+
+    /// Builds a badge with an explicit tone (e.g. when the caller already
+    /// derived the state from a typed lifecycle value rather than a string).
+    public init(text: String, tone: MercantisStatusTone, showsSymbol: Bool = true) {
+        self.text = text
+        self.tone = tone
+        self.showsSymbol = showsSymbol
+    }
+
+    public var body: some View {
+        let colour = MercantisTheme.tint(for: tone.semantic)
+        return HStack(spacing: 4) {
+            if showsSymbol {
+                Image(systemName: tone.symbol)
+                    .font(.system(size: 9, weight: .semibold))
+            }
+            Text(text)
+        }
+        .font(.caption2.weight(.semibold))
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .foregroundStyle(colour)
+        .background(MercantisTheme.fillSoft(for: tone.semantic), in: Capsule())
+        .overlay(Capsule().stroke(colour.opacity(0.22), lineWidth: 0.5))
+        .accessibilityElement()
+        .accessibilityLabel(Text("\(text), \(tone.accessibilityDescription)"))
+    }
+}
+
+#if DEBUG
+#Preview("Status badges") {
+    VStack(alignment: .leading, spacing: 8) {
+        ForEach(
+            ["Draft", "Submitted", "Paid", "Unpaid", "Overdue",
+             "Cancelled", "Completed", "In Progress", "Stopped",
+             "Ordered", "Lost", "Reconciled", "Active", "Inactive", "Closed"],
+            id: \.self
+        ) { status in
+            MercantisStatusBadge(status)
+        }
+    }
+    .padding()
+}
+#endif

--- a/mercantis core/UIShell/GenericListView.swift
+++ b/mercantis core/UIShell/GenericListView.swift
@@ -594,12 +594,10 @@ public struct GenericListView: View {
     }
 
     private func statusBadge(for status: String) -> some View {
-        Text(status.isEmpty ? "Draft" : status)
-            .font(.caption2)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(MercantisTheme.primary.opacity(0.12))
-            .clipShape(Capsule())
+        // Semantic, business-like status treatment: colour + glyph + text so
+        // operational states (Draft / Submitted / Paid / Overdue / …) can be
+        // scanned at a glance and never rely on colour alone.
+        MercantisStatusBadge(status)
     }
 
     private func symbol(for type: FieldType) -> String {


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive visual polish pass to Mercantis, moving from a clean technical app toward a polished business product. The changes are token-first: Core owns the colour decisions and exposes them publicly so Hub can consume them instead of defining one-off colours.

## Key Changes

- **Brand colour palette**: Added `brandPrimary`, `brandPrimaryHover`, `brandPrimaryPressed`, `brandPrimarySoft`, `brandPrimaryBorder`, `brandSecondary`, and `brandAccent` tokens. All brand colours are adaptive (light/dark) via a new `MercantisTheme.adaptive(light:dark:)` helper that builds dynamic `NSColor`/`UIColor` without requiring an asset catalog.

- **Adaptive semantic colours**: Updated `success`, `warning`, `danger`, and `info` to use the adaptive helper so they read clearly in light mode without turning neon in dark mode.

- **Adaptive module tones**: All module tints (`crm`, `selling`, `buying`, `stock`, `accounting`, `manufacturing`, `setup`, `platform`, `system`) now have light/dark variants tuned for readability in both appearances.

- **Status tone mapping**: Introduced `MercantisStatusTone` enum that classifies free-form ERP status strings (Draft, Submitted, Paid, Overdue, Cancelled, etc.) into a business-like semantic palette. Matching is case-insensitive and tolerant of spacing/punctuation.

- **Status badge component**: Added `MercantisStatusBadge` view that pairs status text with a semantic colour, SF Symbol glyph, and soft tonal fill + hairline ring. Colour is never the only signal — each tone carries a distinct glyph for accessibility and fast scanning.

- **Public button styles**: Made `MercantisPrimaryButtonStyle`, `MercantisSecondaryButtonStyle`, and `MercantisDestructiveButtonStyle` public with `public init()`. Refactored internals to use a private `Body` struct for better composition. Primary button now uses `brandPrimary` instead of system accent. All buttons now properly handle disabled state (`0.45` opacity) and have improved animations.

- **Enhanced card modifier**: `.mercantisCard()` now accepts optional `padding` and `tinted` parameters. Tinted cards use `brandPrimarySoft` fill and `brandPrimaryBorder` for subtle brand-tinted surfaces.

- **Semantic tone addition**: Added `.brand` case to `MercantisSemanticTone` enum and updated `tint(for:)` and `fillSoft(for:)` methods to handle it.

- **Public API expansion**: Made `MercantisTheme` enum public and exposed all colour tokens, helper methods, and view extensions as public. Added comprehensive documentation comments explaining colour usage and design rationale.

- **Integration updates**: Updated `WorkspaceHeroHeader` to use `brandPrimary` for the identity chip, and `GenericListView` to use `MercantisStatusBadge` for row status indicators.

- **Documentation**: Added `Docs/VISUAL-POLISH-PASS.md` with detailed guidance on brand decisions, status mapping, module colour rules, light/dark mode notes, button usage, and what NOT to do in future UI work.

## Notable Implementation Details

- Brand colours are tuned so white text clears WCAG AA contrast in both light (≈6.1:1) and dark (≈5.2:1) modes.
- `MercantisTheme.accent` remains `Color.accentColor` intentionally — native selection and control tint continue to respect the user's macOS accent choice. Only product identity and primary actions use the brand colour.
- Status tone classification is generic and string-driven, not domain-coupled, so it can be reused across different ERP modules.
- All adaptive colours use platform-specific dynamic colour APIs (`NSColor(name:)` on macOS, `UIColor(traits:)` on iOS) with a fallback to the light variant on other platforms.

https://claude.ai/code/session_011tLacXcLiqFCymCtQGRVLg