### PR TITLE
Fix ButtonStyle conformance: rename nested Body to avoid associatedty…

### DIFF
--- a/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
+++ b/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
@@ -222,10 +222,10 @@ public struct MercantisPrimaryButtonStyle: ButtonStyle {
     public init() {}
 
     public func makeBody(configuration: Configuration) -> some View {
-        Body(configuration: configuration)
+        ButtonBody(configuration: configuration)
     }
 
-    private struct Body: View {
+    private struct ButtonBody: View {
         let configuration: ButtonStyleConfiguration
         @Environment(\.isEnabled) private var isEnabled
 
@@ -260,10 +260,10 @@ public struct MercantisSecondaryButtonStyle: ButtonStyle {
     public init() {}
 
     public func makeBody(configuration: Configuration) -> some View {
-        Body(configuration: configuration)
+        ButtonBody(configuration: configuration)
     }
 
-    private struct Body: View {
+    private struct ButtonBody: View {
         let configuration: ButtonStyleConfiguration
         @Environment(\.isEnabled) private var isEnabled
 
@@ -293,10 +293,10 @@ public struct MercantisDestructiveButtonStyle: ButtonStyle {
     public init() {}
 
     public func makeBody(configuration: Configuration) -> some View {
-        Body(configuration: configuration)
+        ButtonBody(configuration: configuration)
     }
 
-    private struct Body: View {
+    private struct ButtonBody: View {
         let configuration: ButtonStyleConfiguration
         @Environment(\.isEnabled) private var isEnabled
 


### PR DESCRIPTION
…pe clash

The nested view was named 'Body', which collided with ButtonStyle's associatedtype Body — Swift bound the associatedtype to the nested struct instead of makeBody's opaque return, breaking conformance and forcing the nested type public. Renamed to ButtonBody in all three button styles.