### PR TITLE
Retarget brand primary to deep indigo

### DIFF
--- a/Docs/VISUAL-POLISH-PASS.md
+++ b/Docs/VISUAL-POLISH-PASS.md
@@ -21,21 +21,30 @@ exposed publicly on `MercantisTheme` so Hub (and any third-party consumer of
 
 | Token | Light | Dark | Use |
 |---|---|---|---|
-| `brandPrimary` | `#295CC7` | `#3366D9` | Primary buttons, product identity (sidebar logo square, hero header chip) |
-| `brandPrimaryHover` | lighter | lighter | Optional hover state |
-| `brandPrimaryPressed` | darker | darker | Primary button pressed state |
+| `brandPrimary` | `#4338CA` (indigo-700) | `#4F46E5` (indigo-600) | Primary buttons, product identity (sidebar logo square, hero header chip) |
+| `brandPrimaryHover` | `#4F46E5` | `#6366F1` | Optional hover state |
+| `brandPrimaryPressed` | `#3730A3` (indigo-800) | `#4338CA` | Primary button pressed state |
 | `brandPrimarySoft` | `brandPrimary @ 12%` | — | Tinted cards / identity chips / soft fills |
 | `brandPrimaryBorder` | `brandPrimary @ 32%` | — | Hairline ring on tinted surfaces |
-| `brandSecondary` | blue-teal | blue-teal | Sparing secondary accent |
+| `brandSecondary` | blue-teal | blue-teal | Sparing secondary accent (the indigo's partner) |
 | `brandAccent` | cyan | cyan | Rare highlight (focus glints) |
 
-**Direction:** a deep, trustworthy blue-indigo. Not bright, not SaaS. All brand
-colours are **adaptive** (light/dark) via `MercantisTheme.adaptive(light:dark:)`,
-which builds a dynamic `NSColor`/`UIColor` — the package ships no asset catalog.
+**Direction:** a deep **indigo** — deliberately distinct from the stock macOS
+azure accent so Mercantis reads as its own product colour, while staying in the
+trustworthy blue-indigo enterprise family. Its partner is the blue-teal
+`brandSecondary`. Not bright, not SaaS. All brand colours are **adaptive**
+(light/dark) via `MercantisTheme.adaptive(light:dark:)`, which builds a dynamic
+`NSColor`/`UIColor` — the package ships no asset catalog.
 
-**Contrast:** `brandPrimary` is tuned so **white text clears WCAG AA** in both
-appearances (≈6.1:1 light, ≈5.2:1 dark). If you ever darken/brighten it, re-check
+**Contrast:** `brandPrimary` is tuned so **white text clears WCAG AAA** in both
+appearances (≈7.9:1 light, ≈6.3:1 dark). If you ever darken/brighten it, re-check
 white-on-brand contrast stays ≥ 4.5:1.
+
+**Note:** the Accounting module tone is also indigo-ish; since the brand now
+leans indigo, the two can look related in a side-by-side. They live in different
+contexts (brand on buttons/identity, module on small sidebar chips), so this is
+acceptable — but if it ever reads as muddy, nudge the Accounting module tone
+toward blue-violet to re-separate them.
 
 ### What still uses the system accent
 

--- a/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
+++ b/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
@@ -64,27 +64,30 @@ public enum MercantisTheme {
 
     // MARK: - Brand palette
 
-    /// Mercantis brand primary — a deep, trustworthy blue-indigo. Used for
-    /// primary buttons and product identity (header / logo square, hero
-    /// chrome). Tuned so white text clears WCAG AA in both appearances
-    /// (≈6.1:1 light, ≈5.2:1 dark).
+    /// Mercantis brand primary — a deep indigo. Chosen to read as a distinct
+    /// product colour rather than the stock macOS azure accent, while staying
+    /// in the trustworthy blue-indigo enterprise family. Used for primary
+    /// buttons and product identity (header / logo square, hero chrome).
+    /// White text clears WCAG AAA in both appearances (≈7.9:1 light, ≈6.3:1
+    /// dark).
     public static let brandPrimary = adaptive(
-        light: (0.16, 0.36, 0.78),
-        dark:  (0.20, 0.40, 0.85)
+        light: (0.263, 0.220, 0.792),
+        dark:  (0.310, 0.275, 0.898)
     )
     public static let brandPrimaryHover = adaptive(
-        light: (0.20, 0.42, 0.84),
-        dark:  (0.27, 0.49, 0.93)
+        light: (0.310, 0.275, 0.898),
+        dark:  (0.388, 0.400, 0.945)
     )
     public static let brandPrimaryPressed = adaptive(
-        light: (0.12, 0.30, 0.66),
-        dark:  (0.16, 0.34, 0.74)
+        light: (0.215, 0.188, 0.639),
+        dark:  (0.263, 0.220, 0.792)
     )
     /// Low-opacity brand fill for tinted cards, identity chips, and selected
     /// indicators where the system accent would feel non-native.
     public static let brandPrimarySoft = brandPrimary.opacity(0.12)
     public static let brandPrimaryBorder = brandPrimary.opacity(0.32)
-    /// Secondary brand tone (blue-teal) for sparing accents / illustrations.
+    /// Secondary brand tone (blue-teal) — the indigo's partner, for sparing
+    /// accents / illustrations.
     public static let brandSecondary = adaptive(
         light: (0.05, 0.45, 0.55),
         dark:  (0.22, 0.63, 0.73)


### PR DESCRIPTION
Nudge the brand off stock macOS azure so Mercantis reads as its own product colour rather than a cousin of the user's system accent. brandPrimary now uses a deep indigo (indigo-700 light / indigo-600 dark), paired with the existing blue-teal brandSecondary. White text clears WCAG AAA in both modes. Updates the palette doc accordingly.