### PR TITLE
Add DocumentDisplayPolicy for business-friendly status wording

### DIFF
--- a/Tests/MercantisCoreUITests/DocumentDisplayPolicyTests.swift
+++ b/Tests/MercantisCoreUITests/DocumentDisplayPolicyTests.swift
@@ -1,0 +1,147 @@
+//
+//  DocumentDisplayPolicyTests.swift
+//  MercantisCoreUITests
+//
+//  Exercises the generic, data-driven display-policy engine that lets a host
+//  present Core's lifecycle / workflow states with business-friendly,
+//  document-specific wording. The fixture mirrors the shape of the Mercantis
+//  Hub mapping (Submitted → Posted / Confirmed / Sent / Active / Released …)
+//  so these assertions guard the exact translations the product relies on.
+//
+
+import XCTest
+@testable import MercantisCore
+
+final class DocumentDisplayPolicyTests: XCTestCase {
+
+    // A representative policy mirroring the Hub wording.
+    private let policy = DocumentDisplayPolicy(mappings: [
+        "SalesInvoice": DocTypeDisplayMapping(
+            statuses: [
+                "Submitted": .init(label: "Posted", tone: .brand),
+                "Paid": .init(label: "Paid", tone: .success),
+            ],
+            actions: [
+                "Submit": .init(label: "Post Invoice", confirmation: "Posting locks fields and creates entries."),
+                "Cancel": .init(label: "Cancel Invoice", confirmation: "Reversal entries will be created."),
+            ]
+        ),
+        "SalesOrder": DocTypeDisplayMapping(
+            statuses: ["Submitted": .init(label: "Confirmed", tone: .brand)],
+            actions: ["Submit": .init(label: "Confirm Order")]
+        ),
+        "Quotation": DocTypeDisplayMapping(
+            statuses: ["Submitted": .init(label: "Sent", tone: .info)],
+            actions: ["Submit": .init(label: "Send Quote")]
+        ),
+        "StockEntry": DocTypeDisplayMapping(
+            statuses: [
+                "Submitted": .init(label: "Posted", tone: .brand),
+                "Cancelled": .init(label: "Reversed", tone: .danger),
+            ],
+            actions: ["Submit": .init(label: "Post Stock Movement", confirmation: "Updates stock history.")]
+        ),
+        "BOM": DocTypeDisplayMapping(
+            statuses: ["Submitted": .init(label: "Active", tone: .success)],
+            actions: ["Submit": .init(label: "Activate BOM")]
+        ),
+        "WorkOrder": DocTypeDisplayMapping(
+            statuses: [
+                "Submitted": .init(label: "Released", tone: .brand),
+                "InProgress": .init(label: "In Progress", tone: .info),
+            ],
+            actions: ["Submit": .init(label: "Release Work Order")]
+        ),
+        "PaymentEntry": DocTypeDisplayMapping(
+            statuses: ["Submitted": .init(label: "Posted", tone: .brand)],
+            actions: ["Submit": .init(label: "Post Payment")]
+        ),
+    ])
+
+    // MARK: - Status display mapping
+
+    func test_status_aliases_resolve_per_doctype() {
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "SalesInvoice", state: "Submitted").label, "Posted")
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "SalesOrder", state: "Submitted").label, "Confirmed")
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "Quotation", state: "Submitted").label, "Sent")
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "StockEntry", state: "Submitted").label, "Posted")
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "BOM", state: "Submitted").label, "Active")
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "WorkOrder", state: "Submitted").label, "Released")
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "WorkOrder", state: "InProgress").label, "In Progress")
+    }
+
+    func test_status_lookup_is_case_insensitive() {
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "SalesInvoice", state: "submitted").label, "Posted")
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "SalesInvoice", state: "SUBMITTED").label, "Posted")
+    }
+
+    func test_status_tones_are_carried_through() {
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "SalesInvoice", state: "Submitted").tone, .brand)
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "SalesInvoice", state: "Paid").tone, .success)
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "StockEntry", state: "Cancelled").tone, .danger)
+    }
+
+    // MARK: - Lifecycle (docStatus) mapping
+
+    func test_lifecycle_maps_docStatus_through_aliases() {
+        XCTAssertEqual(policy.lifecycleDisplay(docTypeId: "SalesInvoice", docStatus: 0).label, "Draft")
+        XCTAssertEqual(policy.lifecycleDisplay(docTypeId: "SalesInvoice", docStatus: 1).label, "Posted")
+        XCTAssertEqual(policy.lifecycleDisplay(docTypeId: "StockEntry", docStatus: 2).label, "Reversed")
+    }
+
+    // MARK: - Action label mapping
+
+    func test_action_aliases_resolve_per_doctype() {
+        XCTAssertEqual(policy.actionDisplay(docTypeId: "SalesInvoice", action: "Submit").label, "Post Invoice")
+        XCTAssertEqual(policy.actionDisplay(docTypeId: "PaymentEntry", action: "Submit").label, "Post Payment")
+        XCTAssertEqual(policy.actionDisplay(docTypeId: "StockEntry", action: "Submit").label, "Post Stock Movement")
+        XCTAssertEqual(policy.actionDisplay(docTypeId: "SalesOrder", action: "Submit").label, "Confirm Order")
+        XCTAssertEqual(policy.actionDisplay(docTypeId: "Quotation", action: "Submit").label, "Send Quote")
+        XCTAssertEqual(policy.actionDisplay(docTypeId: "BOM", action: "Submit").label, "Activate BOM")
+        XCTAssertEqual(policy.actionDisplay(docTypeId: "WorkOrder", action: "Submit").label, "Release Work Order")
+    }
+
+    func test_ledger_actions_carry_confirmation_copy() {
+        XCTAssertTrue(policy.actionDisplay(docTypeId: "SalesInvoice", action: "Submit").requiresConfirmation)
+        XCTAssertTrue(policy.actionDisplay(docTypeId: "SalesInvoice", action: "Cancel").requiresConfirmation)
+        // A plain transition without configured copy needs no confirmation.
+        XCTAssertFalse(policy.actionDisplay(docTypeId: "SalesOrder", action: "Submit").requiresConfirmation)
+    }
+
+    // MARK: - Safe fallbacks
+
+    func test_unknown_status_falls_back_to_raw_string() {
+        let display = policy.statusDisplay(docTypeId: "SalesInvoice", state: "SomeBespokeState")
+        XCTAssertEqual(display.label, "SomeBespokeState")
+    }
+
+    func test_unknown_doctype_falls_back_to_raw_string() {
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "Unmapped", state: "Whatever").label, "Whatever")
+        XCTAssertEqual(policy.actionDisplay(docTypeId: "Unmapped", action: "Frobnicate").label, "Frobnicate")
+    }
+
+    func test_empty_status_renders_as_draft() {
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "Unmapped", state: "").label, "Draft")
+        XCTAssertEqual(policy.statusDisplay(docTypeId: "Unmapped", state: "   ").label, "Draft")
+    }
+
+    func test_passthrough_policy_surfaces_everything_verbatim() {
+        let pass = DocumentDisplayPolicy.passthrough
+        XCTAssertEqual(pass.statusDisplay(docTypeId: "SalesInvoice", state: "Submitted").label, "Submitted")
+        XCTAssertEqual(pass.actionDisplay(docTypeId: "SalesInvoice", action: "Submit").label, "Submit")
+        XCTAssertFalse(pass.hasMapping(docTypeId: "SalesInvoice"))
+    }
+
+    // MARK: - Tone classification fallback
+
+    func test_tone_classification_is_sensible() {
+        XCTAssertEqual(DocumentStatusTone.classify("Paid"), .success)
+        XCTAssertEqual(DocumentStatusTone.classify("Overdue"), .warning)
+        XCTAssertEqual(DocumentStatusTone.classify("Cancelled"), .danger)
+        XCTAssertEqual(DocumentStatusTone.classify("Posted"), .brand)
+        XCTAssertEqual(DocumentStatusTone.classify("In Progress"), .info)
+        XCTAssertEqual(DocumentStatusTone.classify("Draft"), .muted)
+        // Unknown strings degrade to a neutral tone rather than crashing.
+        XCTAssertEqual(DocumentStatusTone.classify("Xyzzy"), .muted)
+    }
+}

--- a/mercantis core/Metadata/DocumentDisplayPolicy.swift
+++ b/mercantis core/Metadata/DocumentDisplayPolicy.swift
@@ -1,0 +1,188 @@
+//
+//  DocumentDisplayPolicy.swift
+//  mercantis core
+//
+//  A generic, data-driven mapping layer that lets a host application present
+//  Core's lifecycle (`docStatus`) and workflow (`Document.status`) using
+//  business-friendly, document-specific wording — without weakening any of
+//  Core's posting / audit / reversal discipline.
+//
+//  Core deliberately ships NO domain knowledge here: it only knows how to
+//  look a label up and how to fall back safely. The host (e.g. Mercantis Hub)
+//  injects the actual aliases. (B/C of the lifecycle-wording initiative.)
+//
+
+import Foundation
+
+/// Semantic tone for a status / lifecycle badge.
+///
+/// Kept SwiftUI-free so it lives in the headless `MercantisCore` library and
+/// stays unit-testable. The UI layer maps each case onto a concrete colour
+/// treatment. Colour is never the only signal — the label text always shows.
+public enum DocumentStatusTone: String, Codable, Sendable, CaseIterable {
+    case muted
+    case info
+    case brand
+    case success
+    case warning
+    case danger
+
+    /// Best-effort classification of an arbitrary status string. Used as the
+    /// fallback tone whenever a host hasn't configured an explicit alias, so
+    /// unknown statuses still get a sensible colour instead of crashing.
+    public static func classify(_ raw: String) -> DocumentStatusTone {
+        let compact = raw
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "_", with: "")
+
+        switch compact {
+        case "paid", "completed", "complete", "done", "reconciled", "settled",
+             "active", "accepted", "received", "delivered", "fulfilled":
+            return .success
+        case "submitted", "posted", "issued", "confirmed", "released", "ordered",
+             "approved":
+            return .brand
+        case "sent", "inprogress", "processing", "planned", "open", "recorded":
+            return .info
+        case "overdue", "stopped", "onhold", "hold", "unpaid", "suspended",
+             "pending":
+            return .warning
+        case "cancelled", "canceled", "reversed", "lost", "rejected", "failed",
+             "void", "expired", "error":
+            return .danger
+        case "draft", "new", "closed", "inactive", "disabled", "archived":
+            return .muted
+        default:
+            // Keyword fallbacks for compound statuses.
+            if compact.contains("overdue") || compact.contains("unpaid") { return .warning }
+            if compact.contains("paid") || compact.contains("complete") { return .success }
+            if compact.contains("cancel") || compact.contains("revers") || compact.contains("reject") { return .danger }
+            if compact.contains("post") || compact.contains("submit") || compact.contains("confirm") { return .brand }
+            if compact.contains("progress") || compact.contains("sent") { return .info }
+            if compact.contains("draft") || compact.contains("close") || compact.contains("inactive") { return .muted }
+            return .muted
+        }
+    }
+}
+
+/// The user-facing presentation of a single status / lifecycle state.
+public struct DocumentStatusDisplay: Equatable, Sendable {
+    /// Always-shown, business-friendly label (e.g. "Posted", "Confirmed").
+    public let label: String
+    /// Semantic tone for the badge colour treatment.
+    public let tone: DocumentStatusTone
+    /// Optional tooltip / help text explaining the state.
+    public let help: String?
+
+    public init(label: String, tone: DocumentStatusTone, help: String? = nil) {
+        self.label = label
+        self.tone = tone
+        self.help = help
+    }
+}
+
+/// The user-facing presentation of a lifecycle / workflow action (button).
+public struct DocumentActionDisplay: Equatable, Sendable {
+    /// Always-shown button label (e.g. "Post Invoice", "Confirm Order").
+    public let label: String
+    /// Optional confirmation copy shown before a ledger / stock-affecting
+    /// action runs. `nil` means "no confirmation step needed".
+    public let confirmation: String?
+
+    public var requiresConfirmation: Bool { confirmation != nil }
+
+    public init(label: String, confirmation: String? = nil) {
+        self.label = label
+        self.confirmation = confirmation
+    }
+}
+
+/// A single DocType's display mapping: workflow-state aliases plus action
+/// aliases. Lookups are case-insensitive on the raw key so a host can declare
+/// `"Submitted"` and still match `document.status == "submitted"`.
+public struct DocTypeDisplayMapping: Sendable {
+    /// Raw workflow-state string → business display. Keyed lower-cased.
+    public let statuses: [String: DocumentStatusDisplay]
+    /// Raw action name → business display. Keyed lower-cased.
+    public let actions: [String: DocumentActionDisplay]
+
+    public init(
+        statuses: [String: DocumentStatusDisplay] = [:],
+        actions: [String: DocumentActionDisplay] = [:]
+    ) {
+        self.statuses = Dictionary(
+            statuses.map { ($0.key.lowercased(), $0.value) },
+            uniquingKeysWith: { _, last in last }
+        )
+        self.actions = Dictionary(
+            actions.map { ($0.key.lowercased(), $0.value) },
+            uniquingKeysWith: { _, last in last }
+        )
+    }
+}
+
+/// Generic, data-driven display policy. Maps `(docTypeId, state/action)` onto
+/// business-friendly labels, tones and confirmation copy with safe fallbacks.
+///
+/// A pure value type — the host injects domain mappings rather than Core
+/// hard-coding them. When no mapping is found the raw string is surfaced
+/// verbatim (tone-classified), so an unconfigured or brand-new DocType never
+/// renders blank or crashes.
+public struct DocumentDisplayPolicy: Sendable {
+    private let mappings: [String: DocTypeDisplayMapping]
+
+    public init(mappings: [String: DocTypeDisplayMapping] = [:]) {
+        self.mappings = mappings
+    }
+
+    /// A no-op policy that surfaces every raw status / action verbatim. Used
+    /// as the default so Core components work with or without a host policy.
+    public static let passthrough = DocumentDisplayPolicy()
+
+    // MARK: - Status
+
+    /// Display for a workflow-state string. Falls back to the tone-classified
+    /// raw string when no alias is configured. Empty strings render as Draft.
+    public func statusDisplay(docTypeId: String, state: String) -> DocumentStatusDisplay {
+        let trimmed = state.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let mapped = mappings[docTypeId]?.statuses[trimmed.lowercased()] {
+            return mapped
+        }
+        let label = trimmed.isEmpty ? "Draft" : trimmed
+        return DocumentStatusDisplay(label: label, tone: DocumentStatusTone.classify(label))
+    }
+
+    /// Display for the Core `docStatus` lifecycle (0 Draft / 1 Submitted /
+    /// 2 Cancelled), resolved through the same DocType aliases so a submitted
+    /// invoice's lifecycle reads "Posted" rather than the raw "Submitted".
+    public func lifecycleDisplay(docTypeId: String, docStatus: Int) -> DocumentStatusDisplay {
+        let canonical: String
+        switch docStatus {
+        case 1:  canonical = "Submitted"
+        case 2:  canonical = "Cancelled"
+        default: canonical = "Draft"
+        }
+        return statusDisplay(docTypeId: docTypeId, state: canonical)
+    }
+
+    // MARK: - Actions
+
+    /// Display for a lifecycle / workflow action. Falls back to the raw action
+    /// string (e.g. "Submit") when no alias is configured.
+    public func actionDisplay(docTypeId: String, action: String) -> DocumentActionDisplay {
+        if let mapped = mappings[docTypeId]?.actions[action.lowercased()] {
+            return mapped
+        }
+        return DocumentActionDisplay(label: action)
+    }
+
+    /// Whether the host configured any mapping for this DocType. Useful for
+    /// callers that want to special-case fully-unmapped (e.g. master-data)
+    /// DocTypes.
+    public func hasMapping(docTypeId: String) -> Bool {
+        mappings[docTypeId] != nil
+    }
+}

--- a/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
+++ b/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
@@ -16,6 +16,31 @@ public enum MercantisSemanticTone: Sendable {
     case danger
     case info
     case muted
+
+    /// Bridges the SwiftUI-free `DocumentStatusTone` (declared in
+    /// `MercantisCore`) onto the design-system semantic tone so host-supplied
+    /// `DocumentDisplayPolicy` results can drive badge colours.
+    public init(documentTone: DocumentStatusTone) {
+        switch documentTone {
+        case .muted:   self = .muted
+        case .info:    self = .info
+        case .brand:   self = .brand
+        case .success: self = .success
+        case .warning: self = .warning
+        case .danger:  self = .danger
+        }
+    }
+
+    /// Spoken description for accessibility labels on status badges.
+    public var statusAccessibilityDescription: String {
+        switch self {
+        case .success: return "positive status"
+        case .info, .brand, .accent: return "in-progress status"
+        case .warning: return "attention status"
+        case .danger: return "problem status"
+        case .muted: return "neutral status"
+        }
+    }
 }
 
 /// Semantic colour identity for a navigation module / domain. Used by the
@@ -637,15 +662,18 @@ public enum MercantisStatusTone: Sendable, Hashable {
 /// in both light and dark mode. Subtle by design — it should not shout.
 public struct MercantisStatusBadge: View {
     private let text: String
-    private let tone: MercantisStatusTone
+    private let semantic: MercantisSemanticTone
+    private let symbol: String
     private let showsSymbol: Bool
 
     /// Builds a badge by classifying a raw status string. Empty strings render
     /// as "Draft" so unsaved records still read sensibly.
     public init(_ status: String, showsSymbol: Bool = true) {
         let trimmed = status.trimmingCharacters(in: .whitespacesAndNewlines)
+        let tone = MercantisStatusTone(status: trimmed)
         self.text = trimmed.isEmpty ? "Draft" : trimmed
-        self.tone = MercantisStatusTone(status: trimmed)
+        self.semantic = tone.semantic
+        self.symbol = tone.symbol
         self.showsSymbol = showsSymbol
     }
 
@@ -653,15 +681,27 @@ public struct MercantisStatusBadge: View {
     /// derived the state from a typed lifecycle value rather than a string).
     public init(text: String, tone: MercantisStatusTone, showsSymbol: Bool = true) {
         self.text = text
-        self.tone = tone
+        self.semantic = tone.semantic
+        self.symbol = tone.symbol
+        self.showsSymbol = showsSymbol
+    }
+
+    /// Builds a badge from a host-resolved `DocumentStatusDisplay`. The colour
+    /// comes from the display policy's semantic tone, while the glyph is still
+    /// derived from the (business) label so user-facing wording keeps a
+    /// recognisable icon. Colour is never the only signal — `label` always shows.
+    public init(display: DocumentStatusDisplay, showsSymbol: Bool = true) {
+        self.text = display.label
+        self.semantic = MercantisSemanticTone(documentTone: display.tone)
+        self.symbol = MercantisStatusTone(status: display.label).symbol
         self.showsSymbol = showsSymbol
     }
 
     public var body: some View {
-        let colour = MercantisTheme.tint(for: tone.semantic)
+        let colour = MercantisTheme.tint(for: semantic)
         return HStack(spacing: 4) {
             if showsSymbol {
-                Image(systemName: tone.symbol)
+                Image(systemName: symbol)
                     .font(.system(size: 9, weight: .semibold))
             }
             Text(text)
@@ -670,10 +710,10 @@ public struct MercantisStatusBadge: View {
         .padding(.horizontal, 7)
         .padding(.vertical, 3)
         .foregroundStyle(colour)
-        .background(MercantisTheme.fillSoft(for: tone.semantic), in: Capsule())
+        .background(MercantisTheme.fillSoft(for: semantic), in: Capsule())
         .overlay(Capsule().stroke(colour.opacity(0.22), lineWidth: 0.5))
         .accessibilityElement()
-        .accessibilityLabel(Text("\(text), \(tone.accessibilityDescription)"))
+        .accessibilityLabel(Text("\(text), \(semantic.statusAccessibilityDescription)"))
     }
 }
 

--- a/mercantis core/UIShell/GenericListView.swift
+++ b/mercantis core/UIShell/GenericListView.swift
@@ -36,6 +36,11 @@ public struct GenericListView: View {
     let linkSearchProvider: ((String, String) -> [Document])?
     let linkResolveProvider: ((String, String) -> Document?)?
     let linkTargetMetaProvider: ((String) -> DocType?)?
+    /// Host-injected business-wording layer. Defaults to `.passthrough` so
+    /// existing callers keep showing raw status strings. When a host supplies
+    /// a policy, row badges and synthesised status chips display
+    /// document-specific labels (e.g. "Posted" instead of "Submitted").
+    let displayPolicy: DocumentDisplayPolicy
 
     @State private var searchText = ""
     @State private var selectedViewID: String = "all"
@@ -81,7 +86,8 @@ public struct GenericListView: View {
         preferenceKey: String? = nil,
         linkSearchProvider: ((String, String) -> [Document])? = nil,
         linkResolveProvider: ((String, String) -> Document?)? = nil,
-        linkTargetMetaProvider: ((String) -> DocType?)? = nil
+        linkTargetMetaProvider: ((String) -> DocType?)? = nil,
+        displayPolicy: DocumentDisplayPolicy = .passthrough
     ) {
         self.docType = docType
         self.documents = documents
@@ -93,6 +99,7 @@ public struct GenericListView: View {
         self.linkSearchProvider = linkSearchProvider
         self.linkResolveProvider = linkResolveProvider
         self.linkTargetMetaProvider = linkTargetMetaProvider
+        self.displayPolicy = displayPolicy
     }
 
     public var body: some View {
@@ -355,7 +362,7 @@ public struct GenericListView: View {
                                 .fontWeight(isSelected ? .bold : .semibold)
                                 .foregroundStyle(isSelected ? MercantisTheme.accent : MercantisTheme.textPrimary)
                             Spacer()
-                            statusBadge(for: doc.status)
+                            statusBadge(for: doc)
                         }
 
                         ForEach(displayFields, id: \.key) { field in
@@ -415,16 +422,24 @@ public struct GenericListView: View {
     private var synthesisedStatusViews: [RecordListViewDefinition] {
         var views: [RecordListViewDefinition] = [.all()]
         if docType.isSubmittable {
+            // Chips keep their docStatus predicates but show the host's
+            // business wording (e.g. "Posted" instead of "Submitted").
             views.append(RecordListViewDefinition(
-                id: "draft", label: "Draft", systemImage: "pencil",
+                id: "draft",
+                label: displayPolicy.lifecycleDisplay(docTypeId: docType.id, docStatus: 0).label,
+                systemImage: "pencil",
                 predicates: [ListFilter("docStatus", .eq(.int(0)))]
             ))
             views.append(RecordListViewDefinition(
-                id: "submitted", label: "Submitted", systemImage: "checkmark.seal",
+                id: "submitted",
+                label: displayPolicy.lifecycleDisplay(docTypeId: docType.id, docStatus: 1).label,
+                systemImage: "checkmark.seal",
                 predicates: [ListFilter("docStatus", .eq(.int(1)))]
             ))
             views.append(RecordListViewDefinition(
-                id: "cancelled", label: "Cancelled", systemImage: "xmark.seal",
+                id: "cancelled",
+                label: displayPolicy.lifecycleDisplay(docTypeId: docType.id, docStatus: 2).label,
+                systemImage: "xmark.seal",
                 predicates: [ListFilter("docStatus", .eq(.int(2)))]
             ))
         }
@@ -434,7 +449,8 @@ public struct GenericListView: View {
         let statuses = Set(documents.map(\.status)).subtracting(covered).filter { !$0.isEmpty }
         for status in statuses.sorted() {
             views.append(RecordListViewDefinition(
-                id: "status:\(status)", label: status,
+                id: "status:\(status)",
+                label: displayPolicy.statusDisplay(docTypeId: docType.id, state: status).label,
                 predicates: [ListFilter("status", .eq(.string(status)))]
             ))
         }
@@ -593,11 +609,21 @@ public struct GenericListView: View {
             .joined(separator: " ")
     }
 
-    private func statusBadge(for status: String) -> some View {
+    private func statusBadge(for doc: Document) -> some View {
         // Semantic, business-like status treatment: colour + glyph + text so
-        // operational states (Draft / Submitted / Paid / Overdue / …) can be
-        // scanned at a glance and never rely on colour alone.
-        MercantisStatusBadge(status)
+        // operational states can be scanned at a glance and never rely on
+        // colour alone. The injected display policy maps raw workflow states
+        // (e.g. "Submitted") onto document-specific business wording
+        // (e.g. "Posted"); for submittable docs with no workflow string yet we
+        // fall back to the lifecycle (docStatus) label.
+        let display: DocumentStatusDisplay
+        let trimmed = doc.status.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty && docType.isSubmittable {
+            display = displayPolicy.lifecycleDisplay(docTypeId: docType.id, docStatus: doc.docStatus)
+        } else {
+            display = displayPolicy.statusDisplay(docTypeId: docType.id, state: doc.status)
+        }
+        return MercantisStatusBadge(display: display)
     }
 
     private func symbol(for type: FieldType) -> String {

--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -47,6 +47,10 @@ public struct RecordCollectionHostView: View {
     /// Optional built-in / saved list views (e.g. Hub's "Unpaid", "Overdue").
     /// When empty the list synthesises status chips from the loaded data.
     let listViews: [RecordListViewDefinition]
+    /// Host-injected business-wording layer forwarded to the list so row
+    /// badges / status chips show document-specific labels. Defaults to
+    /// `.passthrough` (raw status strings).
+    let displayPolicy: DocumentDisplayPolicy
 
     @State private var selectedDocument: Document?
     @State private var selectedDocumentID: String?
@@ -85,7 +89,8 @@ public struct RecordCollectionHostView: View {
         linkResolveProvider: ((String, String) -> Document?)? = nil,
         childDocTypeProvider: ((String) -> DocType?)? = nil,
         detailEditor: ((DocType, Binding<Document>) -> AnyView)? = nil,
-        listViews: [RecordListViewDefinition] = []
+        listViews: [RecordListViewDefinition] = [],
+        displayPolicy: DocumentDisplayPolicy = .passthrough
     ) {
         self.preferenceKey = preferenceKey
         self.docType = docType
@@ -114,6 +119,7 @@ public struct RecordCollectionHostView: View {
         self.childDocTypeProvider = childDocTypeProvider
         self.detailEditor = detailEditor
         self.listViews = listViews
+        self.displayPolicy = displayPolicy
         _selectedViewMode = State(initialValue: configuration.defaultViewMode)
     }
 
@@ -293,7 +299,8 @@ public struct RecordCollectionHostView: View {
             preferenceKey: preferenceKey,
             linkSearchProvider: linkSearchProvider,
             linkResolveProvider: linkResolveProvider,
-            linkTargetMetaProvider: childDocTypeProvider
+            linkTargetMetaProvider: childDocTypeProvider,
+            displayPolicy: displayPolicy
         )
     }
 


### PR DESCRIPTION
## Summary
Introduces a generic, data-driven display policy layer that allows host applications to present Core's lifecycle states and workflow statuses using business-friendly, document-specific wording without compromising posting/audit/reversal discipline.

## Key Changes

- **New `DocumentDisplayPolicy` type** (`DocumentDisplayPolicy.swift`):
  - Generic mapping engine that translates raw status strings and action names into user-facing labels, semantic tones, and confirmation copy
  - Supports per-DocType customization via `DocTypeDisplayMapping`
  - Includes safe fallbacks: unknown statuses surface verbatim with tone-classified colours; empty strings render as "Draft"
  - Provides `passthrough` policy for backward compatibility (no-op default)

- **New `DocumentStatusTone` enum**:
  - Six semantic tones (muted, info, brand, success, warning, danger) for badge colour treatment
  - Includes `classify(_:)` method for best-effort tone inference on arbitrary status strings
  - Handles compound statuses via keyword fallbacks

- **New display types**:
  - `DocumentStatusDisplay`: label + tone + optional help text for workflow states
  - `DocumentActionDisplay`: label + optional confirmation copy for lifecycle actions

- **Updated `MercantisStatusBadge`**:
  - New initializer accepting `DocumentStatusDisplay` to render host-supplied business wording
  - Bridges `DocumentStatusTone` to `MercantisSemanticTone` for colour treatment
  - Glyph still derived from business label for visual consistency

- **Updated `GenericListView` and `RecordCollectionHostView`**:
  - Accept optional `displayPolicy` parameter (defaults to `.passthrough`)
  - Synthesised status chips now show host-configured lifecycle labels (e.g. "Posted" instead of "Submitted")
  - Row status badges use the policy to resolve document-specific wording
  - Fallback to lifecycle display when workflow status is empty

- **Comprehensive test coverage** (`DocumentDisplayPolicyTests.swift`):
  - Validates per-DocType status/action aliases
  - Confirms case-insensitive lookups
  - Tests safe fallbacks for unknown DocTypes and statuses
  - Verifies tone classification heuristics
  - Mirrors Hub's actual wording (SalesInvoice→"Posted", SalesOrder→"Confirmed", etc.)

## Implementation Details

- Core deliberately ships no domain knowledge; the host injects mappings via `DocumentDisplayPolicy(mappings:)`
- All types are `Sendable` and SwiftUI-free in the headless library for testability
- Colour is never the only signal—business labels always display alongside tones
- Backward compatible: existing code works unchanged with the default passthrough policy

https://claude.ai/code/session_0119uxy4jUKYmPXH7xQidQpZ