### PR TITLE
Add HIG-compliant card & search components to design system

### DIFF
--- a/Docs/HIG-COMPLIANT-VISUAL-THEME.md
+++ b/Docs/HIG-COMPLIANT-VISUAL-THEME.md
@@ -1,0 +1,54 @@
+# MercantisCoreUI — HIG-Compliant Visual Theme (design-system layer)
+
+> The reusable, **app-agnostic** half of the Mercantis visual theme. Hub composes
+> these into screens; this document is the reference for the tokens and
+> primitives that ship in `MercantisCoreUI`. For full layout direction (dashboard
+> / document workspace / POS), see `mercantis.hub.app/Docs/HIG-COMPLIANT-VISUAL-THEME.md`.
+
+## Where things live
+
+- **Tokens:** `mercantis core/UIShell/DesignTokens/`
+  (`MercantisTheme`, `MercantisSpacing`, `MercantisTypography`, `MercantisMaterials`)
+- **Primitives:** `mercantis core/UIShell/Components/`
+- `UIShell/` is the `MercantisCoreUI` SwiftPM product. `Views/DesignSystem/` is
+  Core-app scaffolding only (not exported to Hub) — keep reusable work in
+  `UIShell/`.
+
+## Token rules
+
+All colours resolve per appearance via `MercantisTheme.adaptive(light:dark:)` (or
+native semantic colours). **No light-only constants.** Required groups:
+
+| Group | Tokens |
+|---|---|
+| Surfaces | `appBackground`, `sidebarBackground`, `surfaceCard`, `surfaceElevated`, `surfaceMuted` |
+| Lines / depth | `hairline`, `border`, `cardShadow` (soft in light, ~0 in dark) |
+| Brand | `brandPrimary` (indigo) + `…Hover/Pressed`, `brandPrimarySoft`, `brandPrimaryBorder` |
+| Status | `success`, `warning`, `danger`, `info` (small surfaces only) |
+| Text | `textPrimary`, `textSecondary`, `textTertiary` |
+| Tables | `tableRowHover`, `tableRowSelection`, `tableHeaderBackground` |
+| KPI | `kpiPositive`, `kpiNegative`, `kpiNeutral` |
+
+`Color.accentColor` stays the native selection/focus tint; `brandPrimary` is
+product identity & primary actions. Saturated colour is for status badges and
+KPI deltas only — never large fills.
+
+## Primitives
+
+`MercantisCard`, `MercantisMetricCard`, `MercantisPanelHeader`,
+`MercantisInspectorCard` / `MercantisInspectorRow`, `MercantisStatusBadge`,
+`MercantisToolbarSearchField`, `MercantisEmptyState`, and the sidebar family
+(`MercantisSidebarRow` / `…ModuleHeader` / `…GroupHeader` / `…BrandHeader`).
+
+Each is `public`, has a `#Preview`, and uses tokens (no inline hex). Pure
+formatting/classification logic (e.g. `MercantisMetricCard.formatDeltaPercent`,
+`Trend(change:)`) is unit-tested in `Tests/MercantisCoreUITests`.
+
+## Do / Don't (design system)
+
+- **Do** prefer the hairline border over shadows; use `cardShadow` for at most
+  one shallow layer on genuinely floating surfaces.
+- **Do** keep status text + SF Symbol together (never colour alone).
+- **Do** use monospaced digits for financial/KPI values.
+- **Don't** add custom fonts, light-only colours, heavy shadows/gradients, or
+  put reusable components in `Views/DesignSystem/` (Hub can't see them).

--- a/Tests/MercantisCoreUITests/MercantisMetricCardTests.swift
+++ b/Tests/MercantisCoreUITests/MercantisMetricCardTests.swift
@@ -1,0 +1,53 @@
+//
+//  MercantisMetricCardTests.swift
+//  MercantisCoreUITests
+//
+//  Pure-logic coverage for the KPI metric card's formatting/classification
+//  helpers. These back the dashboard's "delta chip" (e.g. +12.5% ▲) so the
+//  sign, rounding, and trend bucketing stay stable.
+//
+
+import XCTest
+import MercantisCoreUI
+
+final class MercantisMetricCardTests: XCTestCase {
+
+    // MARK: - Delta percentage formatting
+
+    func test_positive_fraction_gets_plus_sign() {
+        XCTAssertEqual(MercantisMetricCard.formatDeltaPercent(0.125), "+12.5%")
+    }
+
+    func test_negative_fraction_keeps_minus_sign() {
+        XCTAssertEqual(MercantisMetricCard.formatDeltaPercent(-0.032), "-3.2%")
+    }
+
+    func test_zero_has_no_sign() {
+        XCTAssertEqual(MercantisMetricCard.formatDeltaPercent(0), "0.0%")
+    }
+
+    func test_decimals_are_configurable() {
+        // Inputs chosen to avoid printf half-rounding ambiguity.
+        XCTAssertEqual(MercantisMetricCard.formatDeltaPercent(0.12378, decimals: 2), "+12.38%")
+        XCTAssertEqual(MercantisMetricCard.formatDeltaPercent(0.12, decimals: 0), "+12%")
+    }
+
+    func test_non_finite_returns_nil() {
+        XCTAssertNil(MercantisMetricCard.formatDeltaPercent(.nan))
+        XCTAssertNil(MercantisMetricCard.formatDeltaPercent(.infinity))
+    }
+
+    // MARK: - Trend classification
+
+    func test_trend_buckets_by_sign() {
+        if case .up = MercantisMetricCard.Trend(change: 10) {} else { XCTFail("expected up") }
+        if case .down = MercantisMetricCard.Trend(change: -10) {} else { XCTFail("expected down") }
+        if case .flat = MercantisMetricCard.Trend(change: 0) {} else { XCTFail("expected flat") }
+    }
+
+    func test_trend_epsilon_treats_tiny_change_as_flat() {
+        if case .flat = MercantisMetricCard.Trend(change: 0.000001) {} else {
+            XCTFail("sub-epsilon change should read as flat")
+        }
+    }
+}

--- a/mercantis core/UIShell/Components/MercantisCardComponents.swift
+++ b/mercantis core/UIShell/Components/MercantisCardComponents.swift
@@ -1,0 +1,453 @@
+import SwiftUI
+
+// MARK: - MercantisCard
+
+/// Standard rounded business card surface used across dashboards, inspector
+/// panels, and report sections.
+///
+/// Compared with the lightweight `.mercantisCard()` view modifier this is a
+/// first-class container: it owns padding *variants*, an optional brand tint,
+/// and an optional single soft shadow for floating surfaces. It deliberately
+/// favours a hairline border over heavy shadows so dense ERP screens stay calm
+/// (HIG: "use materials and subtle depth, not decorative drop shadows").
+public struct MercantisCard<Content: View>: View {
+
+    /// Padding rhythm. ERP grids want `.compact`; marketing-ish KPI rows want
+    /// `.standard`. `.none` hands inset control to the caller (e.g. a table
+    /// that draws its own row insets).
+    public enum Padding: Sendable {
+        case none, compact, standard, roomy
+
+        var value: CGFloat {
+            switch self {
+            case .none:     return 0
+            case .compact:  return MercantisSpacing.m
+            case .standard: return MercantisSpacing.l
+            case .roomy:    return MercantisSpacing.xl
+            }
+        }
+    }
+
+    private let padding: Padding
+    private let tinted: Bool
+    private let elevated: Bool
+    private let content: Content
+
+    public init(
+        padding: Padding = .standard,
+        tinted: Bool = false,
+        elevated: Bool = false,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.padding = padding
+        self.tinted = tinted
+        self.elevated = elevated
+        self.content = content()
+    }
+
+    public var body: some View {
+        let radius = MercantisSpacing.cardCornerRadius
+        content
+            .padding(padding.value)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .fill(tinted
+                          ? AnyShapeStyle(MercantisTheme.brandPrimarySoft)
+                          : AnyShapeStyle(MercantisTheme.surfaceCard))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .stroke(tinted ? MercantisTheme.brandPrimaryBorder : MercantisTheme.hairline,
+                            lineWidth: 1)
+            )
+            // A single shallow shadow only when explicitly elevated. The colour
+            // is adaptive and collapses to nothing in dark mode where the border
+            // already conveys separation.
+            .shadow(color: elevated ? MercantisTheme.cardShadow : .clear,
+                    radius: elevated ? 8 : 0, x: 0, y: elevated ? 3 : 0)
+            .accessibilityElement(children: .contain)
+    }
+}
+
+// MARK: - MercantisMetricCard
+
+/// Compact KPI / metric card matching the reference dashboard's top row
+/// (Total Sales, Gross Profit, Receivables, …).
+///
+/// Renders: optional icon, a muted uppercase-ish title, a large monospaced
+/// value, and an optional delta chip with a comparison caption. The delta tone
+/// (positive / negative / neutral) carries both colour *and* a directional
+/// arrow glyph so the trend never relies on colour alone.
+public struct MercantisMetricCard: View {
+
+    public enum Trend: Sendable {
+        case up, down, flat
+
+        /// Classifies a signed change into a trend bucket. Exactly-zero (within
+        /// a tiny epsilon) reads as flat.
+        public init(change: Double) {
+            if change > 0.00001 { self = .up }
+            else if change < -0.00001 { self = .down }
+            else { self = .flat }
+        }
+
+        var tint: Color {
+            switch self {
+            case .up:   return MercantisTheme.kpiPositive
+            case .down: return MercantisTheme.kpiNegative
+            case .flat: return MercantisTheme.kpiNeutral
+            }
+        }
+
+        var symbol: String {
+            switch self {
+            case .up:   return "arrow.up.right"
+            case .down: return "arrow.down.right"
+            case .flat: return "arrow.right"
+            }
+        }
+    }
+
+    private let title: String
+    private let value: String
+    private let delta: String?
+    private let trend: Trend
+    private let comparison: String?
+    private let systemImage: String?
+
+    public init(
+        title: String,
+        value: String,
+        delta: String? = nil,
+        trend: Trend = .flat,
+        comparison: String? = nil,
+        systemImage: String? = nil
+    ) {
+        self.title = title
+        self.value = value
+        self.delta = delta
+        self.trend = trend
+        self.comparison = comparison
+        self.systemImage = systemImage
+    }
+
+    public var body: some View {
+        MercantisCard(padding: .standard) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    if let systemImage {
+                        Image(systemName: systemImage)
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(MercantisTheme.brandPrimary)
+                    }
+                    Text(title)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(MercantisTheme.textSecondary)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+
+                Text(value)
+                    .font(.system(size: 24, weight: .semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(MercantisTheme.textPrimary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+
+                if delta != nil || comparison != nil {
+                    HStack(spacing: 5) {
+                        if let delta {
+                            HStack(spacing: 2) {
+                                Image(systemName: trend.symbol)
+                                    .font(.system(size: 9, weight: .bold))
+                                Text(delta)
+                                    .font(.system(size: 11, weight: .semibold))
+                                    .monospacedDigit()
+                            }
+                            .foregroundStyle(trend.tint)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(trend.tint.opacity(0.12), in: Capsule())
+                        }
+                        if let comparison {
+                            Text(comparison)
+                                .font(.system(size: 10))
+                                .foregroundStyle(MercantisTheme.textTertiary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(accessibilityLabel))
+    }
+
+    private var accessibilityLabel: String {
+        var parts = ["\(title), \(value)"]
+        if let delta {
+            let direction: String
+            switch trend {
+            case .up:   direction = "up"
+            case .down: direction = "down"
+            case .flat: direction = "unchanged"
+            }
+            parts.append("\(direction) \(delta)")
+        }
+        if let comparison { parts.append(comparison) }
+        return parts.joined(separator: ", ")
+    }
+
+    // MARK: Pure formatting helpers (unit-tested)
+
+    /// Formats a *fractional* change (0.125 → "+12.5%") as a signed percentage
+    /// string. `nil` for a non-finite input. Pure — safe to unit test.
+    public static func formatDeltaPercent(_ fraction: Double, decimals: Int = 1) -> String? {
+        guard fraction.isFinite else { return nil }
+        let pct = fraction * 100
+        let sign = pct > 0 ? "+" : (pct < 0 ? "" : "")
+        return "\(sign)\(String(format: "%.\(max(0, decimals))f", pct))%"
+    }
+}
+
+// MARK: - MercantisPanelHeader
+
+/// Title row for a dashboard widget / inspector / report section card.
+///
+/// Layout: `Title  (subtitle)            [trailing control]`. The title uses a
+/// card-title weight; the optional trailing slot hosts a small control such as
+/// a "See all" button or a period menu.
+public struct MercantisPanelHeader<Trailing: View>: View {
+    private let title: String
+    private let subtitle: String?
+    private let systemImage: String?
+    private let trailing: Trailing
+
+    public init(
+        _ title: String,
+        subtitle: String? = nil,
+        systemImage: String? = nil,
+        @ViewBuilder trailing: () -> Trailing
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.systemImage = systemImage
+        self.trailing = trailing()
+    }
+
+    public var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: MercantisSpacing.s) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(MercantisTheme.textSecondary)
+            }
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(MercantisTheme.textPrimary)
+                if let subtitle, !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundStyle(MercantisTheme.textSecondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: MercantisSpacing.s)
+            trailing
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isHeader)
+    }
+}
+
+public extension MercantisPanelHeader where Trailing == EmptyView {
+    /// Header without a trailing control.
+    init(_ title: String, subtitle: String? = nil, systemImage: String? = nil) {
+        self.init(title, subtitle: subtitle, systemImage: systemImage) { EmptyView() }
+    }
+}
+
+// MARK: - MercantisInspectorCard
+
+/// Right-side contextual card (customer / supplier / contact / summary) used in
+/// document workspaces. A titled `MercantisCard` with compact padding tuned for
+/// a narrow inspector column.
+public struct MercantisInspectorCard<Content: View>: View {
+    private let title: String
+    private let systemImage: String?
+    private let content: Content
+
+    public init(
+        _ title: String,
+        systemImage: String? = nil,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.systemImage = systemImage
+        self.content = content()
+    }
+
+    public var body: some View {
+        MercantisCard(padding: .compact) {
+            VStack(alignment: .leading, spacing: MercantisSpacing.s) {
+                MercantisPanelHeader(title, systemImage: systemImage)
+                content
+            }
+        }
+    }
+}
+
+/// A single `label : value` line for use inside `MercantisInspectorCard`.
+/// Numeric values can be right-aligned and monospaced via `isNumeric`.
+public struct MercantisInspectorRow: View {
+    private let label: String
+    private let value: String
+    private let isNumeric: Bool
+
+    public init(_ label: String, value: String, isNumeric: Bool = false) {
+        self.label = label
+        self.value = value
+        self.isNumeric = isNumeric
+    }
+
+    public var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: MercantisSpacing.s) {
+            Text(label)
+                .font(.system(size: 11))
+                .foregroundStyle(MercantisTheme.textSecondary)
+            Spacer(minLength: MercantisSpacing.s)
+            Text(value)
+                .font(.system(size: 12, weight: isNumeric ? .semibold : .regular))
+                .monospacedDigit()
+                .foregroundStyle(MercantisTheme.textPrimary)
+                .multilineTextAlignment(.trailing)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - MercantisEmptyState
+
+/// Soft, useful empty state for dashboards, lists, and reports. Replaces raw
+/// "no data" text with a centred SF Symbol, a short title, a one-line
+/// explanation, and an optional call-to-action.
+public struct MercantisEmptyState: View {
+    private let systemImage: String
+    private let title: String
+    private let message: String?
+    private let actionTitle: String?
+    private let action: (() -> Void)?
+
+    public init(
+        systemImage: String = "tray",
+        title: String,
+        message: String? = nil,
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
+    ) {
+        self.systemImage = systemImage
+        self.title = title
+        self.message = message
+        self.actionTitle = actionTitle
+        self.action = action
+    }
+
+    public var body: some View {
+        VStack(spacing: MercantisSpacing.s) {
+            Image(systemName: systemImage)
+                .font(.system(size: 26, weight: .regular))
+                .foregroundStyle(MercantisTheme.textTertiary)
+                .padding(.bottom, 2)
+
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(MercantisTheme.textPrimary)
+                .multilineTextAlignment(.center)
+
+            if let message {
+                Text(message)
+                    .font(.system(size: 11))
+                    .foregroundStyle(MercantisTheme.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+                    .buttonStyle(MercantisSecondaryButtonStyle())
+                    .padding(.top, 4)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, MercantisSpacing.xl)
+        .padding(.horizontal, MercantisSpacing.l)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#if DEBUG
+#Preview("Metric cards") {
+    LazyVGrid(columns: [GridItem(.adaptive(minimum: 180), spacing: 12)], spacing: 12) {
+        MercantisMetricCard(title: "Total Sales", value: "€48,250",
+                            delta: "+12.5%", trend: .up,
+                            comparison: "vs last month", systemImage: "eurosign.circle")
+        MercantisMetricCard(title: "Gross Profit", value: "€18,900",
+                            delta: "+4.1%", trend: .up,
+                            comparison: "vs last month", systemImage: "chart.line.uptrend.xyaxis")
+        MercantisMetricCard(title: "Receivables", value: "€9,430",
+                            delta: "-3.2%", trend: .down,
+                            comparison: "overdue €1,200", systemImage: "tray.and.arrow.down")
+        MercantisMetricCard(title: "Stock Value", value: "€72,100",
+                            systemImage: "shippingbox")
+        MercantisMetricCard(title: "Orders to Deliver", value: "14",
+                            delta: "0%", trend: .flat,
+                            comparison: "same as yesterday", systemImage: "shippingbox.and.arrow.backward")
+    }
+    .padding()
+    .frame(width: 720)
+}
+
+#Preview("Panel + inspector + empty") {
+    HStack(alignment: .top, spacing: 16) {
+        MercantisCard {
+            VStack(alignment: .leading, spacing: 12) {
+                MercantisPanelHeader("Recent Documents",
+                                     subtitle: "Last 7 days",
+                                     systemImage: "doc.text") {
+                    Button("See all") {}
+                        .buttonStyle(.link)
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                MercantisEmptyState(systemImage: "doc.text.magnifyingglass",
+                                    title: "No documents yet",
+                                    message: "Create a sales order or invoice and it will show up here.",
+                                    actionTitle: "New Document") {}
+            }
+        }
+        .frame(width: 360)
+
+        VStack(spacing: 12) {
+            MercantisInspectorCard("Customer", systemImage: "person.crop.circle") {
+                VStack(alignment: .leading, spacing: 4) {
+                    MercantisInspectorRow("Name", value: "Aurora Trading Ltd")
+                    MercantisInspectorRow("Email", value: "ap@aurora.example")
+                    MercantisInspectorRow("Terms", value: "Net 30")
+                }
+            }
+            MercantisInspectorCard("Summary", systemImage: "sum") {
+                VStack(alignment: .leading, spacing: 4) {
+                    MercantisInspectorRow("Subtotal", value: "€1,200.00", isNumeric: true)
+                    MercantisInspectorRow("Tax", value: "€216.00", isNumeric: true)
+                    Divider()
+                    MercantisInspectorRow("Total", value: "€1,416.00", isNumeric: true)
+                }
+            }
+        }
+        .frame(width: 260)
+    }
+    .padding()
+    .frame(width: 680)
+}
+#endif

--- a/mercantis core/UIShell/Components/MercantisToolbarSearchField.swift
+++ b/mercantis core/UIShell/Components/MercantisToolbarSearchField.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// Compact, native-feeling search field for dashboard / document-workspace
+/// toolbars and panel headers.
+///
+/// Intentionally smaller than a full-width form search box: a hairline-bordered
+/// capsule with a leading magnifier and a trailing clear button that appears
+/// only when there's text. Uses `.plain` field chrome so it sits cleanly inside
+/// a toolbar without the heavy default bezel, while remaining fully keyboard
+/// accessible (focus ring is preserved via the system focus state on the
+/// underlying `TextField`).
+public struct MercantisToolbarSearchField: View {
+    @Binding private var text: String
+    private let placeholder: String
+    private let width: CGFloat?
+    @FocusState private var isFocused: Bool
+
+    public init(
+        text: Binding<String>,
+        placeholder: String = "Search",
+        width: CGFloat? = 220
+    ) {
+        self._text = text
+        self.placeholder = placeholder
+        self.width = width
+    }
+
+    public var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(MercantisTheme.textSecondary)
+
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .focused($isFocused)
+                .onSubmit { /* caller observes `text` */ }
+
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                    isFocused = true
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(MercantisTheme.textTertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .frame(width: width)
+        .background(
+            Capsule(style: .continuous)
+                .fill(MercantisTheme.surfaceMuted)
+        )
+        .overlay(
+            Capsule(style: .continuous)
+                .stroke(isFocused ? MercantisTheme.accentBorder : MercantisTheme.hairline,
+                        lineWidth: 1)
+        )
+        .animation(.easeOut(duration: 0.12), value: isFocused)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(placeholder))
+    }
+}
+
+#if DEBUG
+private struct MercantisToolbarSearchFieldPreview: View {
+    @State private var query = ""
+    @State private var filled = "Aurora Trading"
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            MercantisToolbarSearchField(text: $query, placeholder: "Search documents")
+            MercantisToolbarSearchField(text: $filled, placeholder: "Search")
+        }
+        .padding()
+    }
+}
+
+#Preview("Toolbar search") {
+    MercantisToolbarSearchFieldPreview()
+}
+#endif

--- a/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
+++ b/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
@@ -168,6 +168,7 @@ public enum MercantisTheme {
     public static let border = Color(NSColor.separatorColor)
     public static let textPrimary = Color(NSColor.labelColor)
     public static let textMuted = Color(NSColor.secondaryLabelColor)
+    public static let textTertiary = Color(NSColor.tertiaryLabelColor)
     #else
     public static let background = Color(UIColor.systemGroupedBackground)
     public static let surface = Color(UIColor.secondarySystemGroupedBackground)
@@ -176,7 +177,79 @@ public enum MercantisTheme {
     public static let border = Color(UIColor.separator)
     public static let textPrimary = Color(UIColor.label)
     public static let textMuted = Color(UIColor.secondaryLabel)
+    public static let textTertiary = Color(UIColor.tertiaryLabel)
     #endif
+
+    // MARK: - Polished business surface & text tokens
+    //
+    // Named aliases that map the "clean business dashboard" vocabulary used by
+    // Hub screens (app background, sidebar, card surface, hairline, KPI
+    // indicators, table hover/selection) onto the native semantic colours
+    // above. Everything resolves per appearance — there is no light-only path.
+    // Call-sites should prefer these names so the design intent is explicit.
+
+    /// The full-window canvas behind dashboards, lists, and workspaces.
+    public static let appBackground = background
+    /// Sidebar canvas. Native sidebars apply their own translucent material via
+    /// `.listStyle(.sidebar)`; this token is the opaque fallback used when a
+    /// custom sidebar surface is drawn (e.g. POS category rail).
+    #if os(macOS)
+    public static let sidebarBackground = Color(NSColor.windowBackgroundColor)
+    #else
+    public static let sidebarBackground = Color(UIColor.systemGroupedBackground)
+    #endif
+    /// Standard card/panel fill (KPI cards, dashboard widgets, inspector cards).
+    public static let surfaceCard = surface
+    /// Secondary text alias (mirrors `textMuted`) for call-sites that think in
+    /// primary/secondary/tertiary terms.
+    public static let textSecondary = textMuted
+    /// Hairline border for cards, table rows, and separators — deliberately
+    /// lighter than the raw `border` so large card grids stay calm.
+    public static let hairline = border.opacity(0.7)
+    /// Soft card shadow colour. Used sparingly (one shallow layer) and only on
+    /// floating surfaces — never to outline every card. Kept very subtle in
+    /// light mode and effectively suppressed in dark mode where borders carry
+    /// elevation instead.
+    public static let cardShadow = adaptiveOpacity(light: 0.10, dark: 0.0)
+
+    // MARK: - Table tokens
+
+    /// Pointer-hover wash for table/list rows (very subtle, neutral). `.primary`
+    /// already inverts per appearance (near-black in light, near-white in dark),
+    /// so a single low opacity reads correctly in both.
+    public static let tableRowHover = Color.primary.opacity(0.05)
+    /// Selected-row background — reuses the native selection tint so the table
+    /// still respects the user's macOS accent.
+    public static let tableRowSelection = accentFillSoft
+    /// Header strip behind a table's column titles.
+    public static let tableHeaderBackground = surfaceMuted
+
+    // MARK: - KPI indicators
+
+    /// Positive delta (sales up, profit up). Success green.
+    public static let kpiPositive = success
+    /// Negative delta (receivables overdue, profit down). Danger red.
+    public static let kpiNegative = danger
+    /// Flat / unchanged delta.
+    public static let kpiNeutral = textMuted
+
+    /// Builds an adaptive black overlay whose *opacity* differs per appearance —
+    /// used for soft card shadows that should soften (or vanish) in dark mode
+    /// where hairline borders carry elevation instead.
+    static func adaptiveOpacity(light: Double, dark: Double) -> Color {
+        #if os(macOS)
+        return Color(nsColor: NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            return NSColor(srgbRed: 0, green: 0, blue: 0, alpha: isDark ? dark : light)
+        })
+        #elseif os(iOS)
+        return Color(uiColor: UIColor { traits in
+            UIColor(white: 0, alpha: traits.userInterfaceStyle == .dark ? dark : light)
+        })
+        #else
+        return Color.black.opacity(light)
+        #endif
+    }
 
     public static func tint(for tone: MercantisSemanticTone) -> Color {
         switch tone {


### PR DESCRIPTION
## Summary
Introduces a cohesive set of reusable UI components and refined design tokens that implement Apple's Human Interface Guidelines for business dashboards, inspector panels, and document workspaces. These primitives form the foundation for Hub's visual theme and are exported as part of the `MercantisCoreUI` SwiftPM product.

## Key Changes

**New Components** (`MercantisCardComponents.swift`):
- `MercantisCard` — Standard rounded surface with padding variants (none/compact/standard/roomy), optional brand tint, and subtle elevation shadow
- `MercantisMetricCard` — Compact KPI card with icon, title, large monospaced value, and trend delta chip (includes `Trend` enum with directional arrows and `formatDeltaPercent()` formatter)
- `MercantisPanelHeader` — Title row for dashboard widgets with optional icon, subtitle, and trailing control slot
- `MercantisInspectorCard` & `MercantisInspectorRow` — Right-side contextual cards for document workspaces with label/value pairs
- `MercantisEmptyState` — Soft empty-state placeholder with icon, title, message, and optional CTA
- `MercantisToolbarSearchField` — Compact capsule search field with magnifier, clear button, and focus ring

**Design Tokens** (`MercantisTheme.swift`):
- Added `textTertiary` semantic colour (native tertiary label)
- Introduced "polished business surface" token aliases: `appBackground`, `sidebarBackground`, `surfaceCard`, `textSecondary`, `hairline`, `cardShadow`
- Added table tokens: `tableRowHover`, `tableRowSelection`, `tableHeaderBackground`
- Added KPI indicators: `kpiPositive`, `kpiNegative`, `kpiNeutral`
- Implemented `adaptiveOpacity()` helper for appearance-aware shadows (soft in light mode, suppressed in dark mode)

**Documentation & Tests**:
- Added `Docs/HIG-COMPLIANT-VISUAL-THEME.md` — Design system reference covering token rules, primitives, and do/don't guidelines
- Added `MercantisMetricCardTests.swift` — Unit tests for delta percentage formatting and trend classification logic

## Notable Implementation Details

- **Hairline borders over shadows**: Cards use 0.7-opacity borders instead of heavy drop shadows to keep dense ERP screens calm (per HIG guidance)
- **Appearance-aware shadows**: `cardShadow` uses adaptive opacity (10% light, ~0% dark) so elevation is conveyed by borders in dark mode
- **Monospaced digits**: Financial/KPI values use `.monospacedDigit()` for alignment and clarity
- **Accessibility**: All components combine children and include semantic labels; trend indicators pair colour with directional arrows (never colour alone)
- **Pure formatting helpers**: `formatDeltaPercent()` and `Trend(change:)` are unit-tested, side-effect-free functions safe for reuse
- **Previews**: All components include `#Preview` blocks for design validation

All colours resolve per appearance via native semantic colours — no light-only constants.

https://claude.ai/code/session_01KJjNBn425w8RjhLeQzpVW6