### PR TITLE
Fix blue-on-blue contrast regression in sidebar selection

### DIFF
--- a/Tests/MercantisCoreUITests/SidebarSelectionContrastTests.swift
+++ b/Tests/MercantisCoreUITests/SidebarSelectionContrastTests.swift
@@ -1,0 +1,83 @@
+//
+//  SidebarSelectionContrastTests.swift
+//  MercantisCoreUITests
+//
+//  Guards the sidebar selected-row contrast contract (the "blue-on-blue"
+//  regression where a selected row kept its accent/module-tinted foreground on
+//  top of the strong accent selection background, leaving the label nearly
+//  invisible).
+//
+//  The view layer derives every selected-row colour from
+//  `MercantisTheme.sidebarRowEmphasis(isSelected:isEmphasized:)`, so exercising
+//  that pure resolver proves the decision logic without needing to render.
+//
+
+import XCTest
+import SwiftUI
+import MercantisCoreUI
+
+final class SidebarSelectionContrastTests: XCTestCase {
+
+    // MARK: - Emphasis resolution
+
+    func test_unselected_row_is_normal() {
+        XCTAssertEqual(
+            MercantisTheme.sidebarRowEmphasis(isSelected: false, isEmphasized: false),
+            .normal
+        )
+        // Prominence is irrelevant when the row isn't selected.
+        XCTAssertEqual(
+            MercantisTheme.sidebarRowEmphasis(isSelected: false, isEmphasized: true),
+            .normal
+        )
+    }
+
+    func test_selected_on_strong_selection_is_emphasized() {
+        XCTAssertEqual(
+            MercantisTheme.sidebarRowEmphasis(isSelected: true, isEmphasized: true),
+            .emphasizedSelection
+        )
+    }
+
+    func test_selected_on_unfocused_selection_is_muted() {
+        XCTAssertEqual(
+            MercantisTheme.sidebarRowEmphasis(isSelected: true, isEmphasized: false),
+            .mutedSelection
+        )
+    }
+
+    // MARK: - Contrast contract
+
+    func test_emphasized_selection_uses_high_contrast_white_foreground() {
+        let emphasis = MercantisTheme.sidebarRowEmphasis(isSelected: true, isEmphasized: true)
+        XCTAssertTrue(emphasis.usesHighContrastForeground)
+        // High-contrast white, NOT the accent (which is the selection background
+        // colour) — this is the core fix for the blue-on-blue bug.
+        XCTAssertEqual(emphasis.foreground, MercantisTheme.selectionForegroundEmphasized)
+        XCTAssertEqual(emphasis.foreground, Color.white)
+    }
+
+    func test_selected_foreground_is_not_the_selected_background_colour() {
+        // Accessibility requirement: selected text must not share the selected
+        // background's semantic colour. The strong selection background is the
+        // accent, so the emphasized foreground must differ from it.
+        let emphasized = MercantisTheme.sidebarRowEmphasis(isSelected: true, isEmphasized: true)
+        XCTAssertNotEqual(emphasized.foreground, MercantisTheme.accent)
+        XCTAssertNotEqual(emphasized.foreground, MercantisTheme.selectionForeground)
+    }
+
+    func test_muted_selection_keeps_primary_label_colour() {
+        // On the light/grey unfocused selection white would wash out, so the
+        // muted state keeps the primary label colour rather than going white.
+        let muted = MercantisTheme.sidebarRowEmphasis(isSelected: true, isEmphasized: false)
+        XCTAssertFalse(muted.usesHighContrastForeground)
+        XCTAssertEqual(muted.foreground, MercantisTheme.textPrimary)
+        XCTAssertNotEqual(muted.foreground, MercantisTheme.selectionForegroundEmphasized)
+    }
+
+    func test_normal_row_uses_primary_not_accent_foreground() {
+        let normal = MercantisTheme.sidebarRowEmphasis(isSelected: false, isEmphasized: false)
+        XCTAssertFalse(normal.usesHighContrastForeground)
+        XCTAssertEqual(normal.foreground, MercantisTheme.textPrimary)
+    }
+}

--- a/mercantis core/UIShell/Components/MercantisSidebarComponents.swift
+++ b/mercantis core/UIShell/Components/MercantisSidebarComponents.swift
@@ -13,10 +13,22 @@ public struct MercantisSidebarIconChip: View {
     public let tone: MercantisModuleTone?
     public var isSelected: Bool
 
+    /// Mirrors the row: `.increased` when the platform paints the strong accent
+    /// selection behind us, so the chip can switch to a white-on-translucent
+    /// treatment rather than keeping its module colour on a blue background.
+    @Environment(\.backgroundProminence) private var backgroundProminence
+
     public init(systemImage: String, tone: MercantisModuleTone? = nil, isSelected: Bool = false) {
         self.systemImage = systemImage
         self.tone = tone
         self.isSelected = isSelected
+    }
+
+    private var emphasis: MercantisTheme.SidebarRowEmphasis {
+        MercantisTheme.sidebarRowEmphasis(
+            isSelected: isSelected,
+            isEmphasized: backgroundProminence == .increased
+        )
     }
 
     public var body: some View {
@@ -32,17 +44,35 @@ public struct MercantisSidebarIconChip: View {
     }
 
     private var fill: Color {
-        if let tone {
-            return MercantisTheme.moduleFill(tone)
+        // On a selected row the module colour is dropped: a brand/module chip on
+        // top of the accent selection is the blue-on-blue bug. Use a subtle
+        // white translucent fill on the strong selection, an accent-soft fill on
+        // the muted selection, and only show the module tint when unselected.
+        switch emphasis {
+        case .emphasizedSelection:
+            return Color.white.opacity(0.22)
+        case .mutedSelection:
+            return MercantisTheme.accentFillSoft
+        case .normal:
+            if let tone {
+                return MercantisTheme.moduleFill(tone)
+            }
+            return Color.secondary.opacity(0.08)
         }
-        return isSelected ? MercantisTheme.accentFillSoft : Color.secondary.opacity(0.08)
     }
 
     private var tint: Color {
-        if let tone {
-            return MercantisTheme.moduleTint(tone)
+        switch emphasis {
+        case .emphasizedSelection:
+            return MercantisTheme.selectionForegroundEmphasized
+        case .mutedSelection:
+            return MercantisTheme.accent
+        case .normal:
+            if let tone {
+                return MercantisTheme.moduleTint(tone)
+            }
+            return MercantisTheme.textMuted
         }
-        return isSelected ? MercantisTheme.accent : MercantisTheme.textMuted
     }
 }
 
@@ -57,6 +87,11 @@ public struct MercantisSidebarRow: View {
     public var isSelected: Bool
     public var badge: String?
     public var indentation: CGFloat
+
+    /// `.increased` when the parent `List(selection:)` is painting the strong
+    /// (focused) accent selection behind this row; `.standard` for an unfocused
+    /// / muted selection or a normal row. Drives the high-contrast foreground.
+    @Environment(\.backgroundProminence) private var backgroundProminence
 
     public init(
         title: String,
@@ -74,8 +109,20 @@ public struct MercantisSidebarRow: View {
         self.indentation = indentation
     }
 
+    private var emphasis: MercantisTheme.SidebarRowEmphasis {
+        MercantisTheme.sidebarRowEmphasis(
+            isSelected: isSelected,
+            isEmphasized: backgroundProminence == .increased
+        )
+    }
+
     public var body: some View {
-        HStack(spacing: 9) {
+        // On the strong accent selection the leading rule, badge and any fill
+        // switch to the high-contrast (white) treatment so nothing reads as
+        // blue/purple-on-blue; the unfocused selection keeps the accent tones.
+        let highContrast = emphasis.usesHighContrastForeground
+
+        return HStack(spacing: 9) {
             MercantisSidebarIconChip(
                 systemImage: systemImage,
                 tone: tone,
@@ -95,34 +142,52 @@ public struct MercantisSidebarRow: View {
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
                     .background(
-                        isSelected
-                            ? MercantisTheme.accentFillSoft
-                            : Color.secondary.opacity(0.14),
+                        badgeBackground(highContrast: highContrast),
                         in: Capsule()
                     )
-                    .foregroundStyle(isSelected ? MercantisTheme.accent : .secondary)
+                    .foregroundStyle(badgeForeground(highContrast: highContrast))
             }
         }
         .padding(.leading, indentation)
         .padding(.horizontal, 6)
         .padding(.vertical, 4)
         .background(
+            // Only draw our own soft fill for the muted/unfocused selection;
+            // the strong selection background is owned by the native list, so
+            // layering an accent wash there would muddy it.
             RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .fill(isSelected ? MercantisTheme.accentFillSoft : Color.clear)
+                .fill(emphasis == .mutedSelection ? MercantisTheme.accentFillSoft : Color.clear)
         )
         .overlay(alignment: .leading) {
+            // Colour is never the only selection signal: keep a leading rule on
+            // every selected row, tinted white on the strong selection and
+            // accent on the muted one so it stays visible against either fill.
             if isSelected {
                 RoundedRectangle(cornerRadius: 1.5, style: .continuous)
-                    .fill(MercantisTheme.accent)
+                    .fill(highContrast ? MercantisTheme.selectionForegroundEmphasized : MercantisTheme.accent)
                     .frame(width: 2.5)
                     .padding(.vertical, 5)
                     .padding(.leading, indentation)
             }
         }
-        .foregroundStyle(isSelected ? MercantisTheme.selectionForeground : MercantisTheme.textPrimary)
+        .foregroundStyle(emphasis.foreground)
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+
+    private func badgeBackground(highContrast: Bool) -> Color {
+        if highContrast {
+            return Color.white.opacity(0.22)
+        }
+        return isSelected ? MercantisTheme.accentFillSoft : Color.secondary.opacity(0.14)
+    }
+
+    private func badgeForeground(highContrast: Bool) -> Color {
+        if highContrast {
+            return MercantisTheme.selectionForegroundEmphasized
+        }
+        return isSelected ? MercantisTheme.accent : .secondary
     }
 }
 
@@ -316,5 +381,36 @@ public struct MercantisSidebarBrandHeader: View {
     }
     .listStyle(.sidebar)
     .frame(width: 260, height: 360)
+}
+
+/// Verifies the selected-row foreground stays high-contrast on the strong
+/// accent selection (the blue-on-blue regression). The strong selection sets
+/// `\.backgroundProminence` to `.increased`; here we force it so the selected
+/// rows render with white text + a white-translucent chip rather than the
+/// module/accent tint — readable in both light and dark mode.
+#Preview("Selected row contrast") {
+    func rows() -> some View {
+        List {
+            Section {
+                MercantisSidebarRow(title: "Account", systemImage: "list.bullet.rectangle", tone: .accounting, isSelected: true)
+                MercantisSidebarRow(title: "Customers", systemImage: "person.2", tone: .crm, isSelected: true, badge: "124")
+                MercantisSidebarRow(title: "Stock Movements", systemImage: "tray.full", tone: .stock, isSelected: true)
+            } header: {
+                MercantisSidebarModuleHeader(title: "Selected (emphasized)", systemImage: "checkmark", tone: .accounting)
+            }
+        }
+        .listStyle(.sidebar)
+        // Paint the strong accent behind the rows and mark the selection as
+        // emphasized so the preview matches a focused native sidebar selection.
+        .scrollContentBackground(.hidden)
+        .background(MercantisTheme.accent)
+        .environment(\.backgroundProminence, .increased)
+        .frame(width: 260, height: 200)
+    }
+
+    return VStack(spacing: 0) {
+        rows().environment(\.colorScheme, .light)
+        rows().environment(\.colorScheme, .dark)
+    }
 }
 #endif

--- a/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
+++ b/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
@@ -152,6 +152,13 @@ public enum MercantisTheme {
     )
     public static let selectionBackground = accentFillSoft
     public static let selectionForeground = accent
+    /// High-contrast foreground for a row drawn on the *strong* (emphasized,
+    /// key-window) selection fill — the saturated accent that macOS paints
+    /// behind a focused sidebar/list selection. White clears the accent in
+    /// both light and dark appearances, mirroring Finder's selected sidebar
+    /// text, and is deliberately *not* the accent so selected text never
+    /// shares the selected background's semantic colour (the blue-on-blue bug).
+    public static let selectionForegroundEmphasized = Color.white
     public static let mutedBadge = Color.secondary.opacity(0.16)
     public static let inspectorHighlight = brandPrimary.opacity(0.08)
     public static let subtleSeparatorOpacity = 0.15
@@ -313,6 +320,50 @@ public enum MercantisTheme {
 
     public static func moduleBorder(_ tone: MercantisModuleTone) -> Color {
         moduleTint(tone).opacity(0.22)
+    }
+
+    // MARK: - Sidebar selection treatment
+
+    /// How a selectable sidebar/list row should colour its content, derived
+    /// from whether the row is selected and how prominently the platform is
+    /// painting the selection background.
+    ///
+    /// SwiftUI sets `\.backgroundProminence` to `.increased` for a row whose
+    /// selection is drawn with the strong (focused, key-window) accent fill,
+    /// and `.standard` for an unfocused/muted grey selection. Driving the
+    /// foreground off that environment value is the macOS-native way to keep
+    /// selected content readable in every state instead of forcing one colour.
+    public enum SidebarRowEmphasis: Equatable, Sendable {
+        /// Not selected — normal label colour on a clear/hover background.
+        case normal
+        /// Selected on the strong accent fill — needs a high-contrast (white)
+        /// foreground so text and icon stay legible on the saturated accent.
+        case emphasizedSelection
+        /// Selected on a muted/unfocused fill — keeps the primary label colour
+        /// because white would wash out on the light grey background.
+        case mutedSelection
+
+        /// Foreground colour for the row's text and icon in this state.
+        public var foreground: Color {
+            switch self {
+            case .normal:              return MercantisTheme.textPrimary
+            case .emphasizedSelection: return MercantisTheme.selectionForegroundEmphasized
+            case .mutedSelection:      return MercantisTheme.textPrimary
+            }
+        }
+
+        /// Whether this state draws the strong accent selection (and therefore
+        /// uses the white, high-contrast content treatment).
+        public var usesHighContrastForeground: Bool {
+            self == .emphasizedSelection
+        }
+    }
+
+    /// Resolves the selection treatment for a row. `isEmphasized` should come
+    /// from `@Environment(\.backgroundProminence) == .increased`.
+    public static func sidebarRowEmphasis(isSelected: Bool, isEmphasized: Bool) -> SidebarRowEmphasis {
+        guard isSelected else { return .normal }
+        return isEmphasized ? .emphasizedSelection : .mutedSelection
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes a contrast regression where selected sidebar rows kept their module/accent-tinted foreground colours when drawn on top of the strong (focused) accent selection background, resulting in blue-on-blue text that was nearly invisible.

## Changes
- **Added `SidebarRowEmphasis` enum** to `MercantisTheme` that encodes the three selection states: normal (unselected), emphasizedSelection (selected on strong accent), and mutedSelection (selected on unfocused grey)
- **Added `sidebarRowEmphasis(isSelected:isEmphasized:)` resolver** that derives the emphasis state from the row's selection status and the platform's `backgroundProminence` environment value
- **Updated `MercantisSidebarRow`** to read `\.backgroundProminence` and use the emphasis state to conditionally apply high-contrast (white) foreground, fill, and accent colours when drawn on the strong selection
- **Updated `MercantisSidebarIconChip`** to apply the same emphasis-driven colour logic for consistency
- **Added `selectionForegroundEmphasized` token** (white) to distinguish high-contrast selected text from the accent colour used for the selection background
- **Added comprehensive unit tests** (`SidebarSelectionContrastTests`) verifying the emphasis resolution logic and contrast contract
- **Added preview** demonstrating selected rows with both light and dark mode rendering on the strong accent background

## Implementation Details
The fix leverages SwiftUI's native `backgroundProminence` environment value, which the platform sets to `.increased` when painting the strong (key-window) accent selection. By reading this value, the sidebar components can automatically switch to white text and translucent white fills on the strong selection, while keeping accent tints on the muted/unfocused selection where white would wash out. This mirrors Finder's native sidebar behaviour and ensures readability in all states without forcing a single colour scheme.

https://claude.ai/code/session_018fKGccu5ofZmYriFuTHyoj