### PR TITLE
Add generic saved-report infrastructure (ADR-050)

### DIFF
--- a/Docs/ADR/ADR-050-saved-report-infrastructure.md
+++ b/Docs/ADR/ADR-050-saved-report-infrastructure.md
@@ -1,0 +1,144 @@
+# ADR-050 — Generic Saved-Report Infrastructure
+
+**Status:** Accepted
+**Date:** 2026-06-02
+
+---
+
+## Context
+
+Core already had fixed, app-declared reports: a `ReportDefinition`
+(columns + filters + `allowedRoles`) registered in an `AppManifest`,
+executed by `ReportEngine.execute(report:)` into a `ReportResult`, and
+rendered by `GenericReportView` (ADR-049).
+
+What it did **not** have was any notion of a *user-created* or
+*user-customised* report variant. A user could not:
+
+- hide or reorder columns on a report,
+- save their own filter defaults,
+- store a preferred sort order,
+- keep a private/shared variant of a built-in report.
+
+Every report was hardcoded by the app author. Hub wants to let users
+customise report columns, filters, sorting, and saved views — but the
+*mechanism* for that is generic and belongs in Core, not in any one app.
+
+## Decision
+
+Add a generic, app-neutral saved-report layer to Core, in
+`mercantis core/Reporting/`:
+
+### Model — `SavedReportDefinition`
+
+A data-only, `Codable` value type. It carries **no** SQL, no
+expressions, and no script — only structured configuration:
+
+| Field | Purpose |
+|---|---|
+| `id` | stable identifier |
+| `name` | display name |
+| `baseReportId?` | the built-in `ReportDefinition` it was cloned from, if any |
+| `sourceDocType` | the DocType queried |
+| `ownerUserId` | the owning user |
+| `visibility` | `.private` / `.shared` |
+| `columns` | `[SavedReportColumn]` |
+| `filters` | `[SavedReportFilter]` |
+| `sorts` | `[SavedReportSort]` |
+| `createdAt` / `updatedAt` | timestamps |
+
+- **`SavedReportColumn`** — `fieldKey`, `labelOverride?`, `visible`,
+  `order`, `width?`. Visibility toggles a column without losing its
+  config; `order` drives left-to-right placement.
+- **`SavedReportFilter`** — `fieldKey`, `operator`, `value?`,
+  `defaultValue?`, `required`. The operator is a closed enum
+  (`equals`, `notEquals`, the four comparisons, `contains`, `isNull`,
+  `isNotNull`) that maps 1:1 onto the existing typed `ListFilter.Op`.
+- **`SavedReportSort`** — `fieldKey`, `direction`.
+
+`Codable` decode is lenient (missing `visibility`, collections, and
+timestamps fall back to defaults) so stored payloads survive schema
+growth.
+
+### Conversion from a built-in report
+
+`SavedReportDefinition.from(reportDefinition:ownerUserId:…)` (and the
+engine's `convert(_:ownerUserId:…)` convenience) clone a built-in
+`ReportDefinition` into editable saved configuration: every declared
+column becomes a visible column in declaration order, every declared
+filter becomes an optional saved filter seeded with the built-in's
+default, and `baseReportId` records the origin.
+
+### Execution — `SavedReportEngine`
+
+`SavedReportEngine.execute(savedReport:requestingUserId:runtimeFilterValues:userRoles:)`
+returns a normal `ReportResult` and enforces the safety rules:
+
+1. **Ownership/visibility gate.** A `.private` report is reachable only
+   by its owner; `.shared` by anyone.
+2. **Field allow-listing.** Every referenced `fieldKey` (column, filter,
+   sort) must exist in the source DocType metadata or be a known
+   document system column (`id`, `status`, `createdAt`, …). Unknown
+   fields are rejected — a saved report can't reach beyond its declared
+   surface.
+3. **No arbitrary code.** Filters compile to typed `ListFilter`
+   predicates; there is no SQL string and no Swift/script path.
+4. **Permissions preserved.** Queries run through
+   `DocumentEngine.list`, so DocType `rowAccessExpression` and
+   role-based row filtering (ADR-037) still apply — a saved report can
+   never widen access beyond what the requesting user could already
+   see.
+
+Effective filter value resolves as
+`runtime override → stored value → defaultValue`; a `required` filter
+with no effective value is a hard error.
+
+The built-in `ReportEngine` path is untouched. Both engines now format
+cells through a shared `ReportValueFormatter`, so a column value looks
+identical regardless of which engine produced it.
+
+## Consequences
+
+**Positive**
+
+- Apps get user-customisable reports (column show/hide, reordering,
+  saved filter defaults, stored sorts, private/shared variants) without
+  hardcoding report variants.
+- The model is app-neutral; Hub layers its ERP reports on top without
+  Core learning any ERP concepts.
+- Reuses the existing typed `ListFilter`/`ListSort` surface and
+  row-access enforcement, so no new query or permission path is
+  introduced.
+
+**Negative / limits (deliberately out of scope)**
+
+- No pivot tables, charts, grouping, scheduled email, or arbitrary-SQL
+  editor — the `ReportResult` shape leaves room to add those later
+  without changing this model.
+- Sharing is a simple two-state `private`/`shared` flag; there is no
+  per-role grant list and no cross-company security model.
+- Persistence of saved reports is left to the host (the engine keeps an
+  in-memory registry mirroring `ReportEngine`); a DocType-backed store
+  can be a follow-up if needed.
+
+**Neutral**
+
+- `userRoles: Set<String>` matches the engine's existing role-set API,
+  keeping role-set composition uniform.
+
+## Core / Hub boundary
+
+This infrastructure is **reusable plumbing** and lives in
+`mercantis.core.app`. It defines *how* a report can be customised, not
+*which* reports exist.
+
+| Lives in Core (this ADR) | Lives in Hub (follow-up) |
+|---|---|
+| `SavedReportDefinition` + column/filter/sort value types | Concrete saved reports (Sales Register, VAT Summary, Stock Ledger, …) |
+| `SavedReportEngine` (validate, convert, execute) | ERP DocTypes the reports target |
+| Generic visibility / ownership metadata | Hub navigation entries and report screens |
+| Field allow-listing against DocType metadata | Cross-company / org-specific access policy |
+
+Core must not gain ERP-specific report names, ERP DocTypes, VAT/stock/
+sales/POS reports, or Hub navigation. Hub integration is a separate
+follow-up issue built on this foundation.

--- a/Docs/ADR/README.md
+++ b/Docs/ADR/README.md
@@ -57,6 +57,7 @@ ADRs document significant architectural decisions: the context that motivated th
 | [ADR-047](ADR-047-filesystem-cloud-adapter.md) | Filesystem Reference `CloudAdapter` | Accepted |
 | [ADR-048](ADR-048-notification-log-persistence.md) | Persistent Notification Log + In-App Inbox | Accepted |
 | [ADR-049](ADR-049-report-role-filtering-and-view.md) | `ReportEngine` Role Filtering + `GenericReportView` | Accepted |
+| [ADR-050](ADR-050-saved-report-infrastructure.md) | Generic Saved-Report Infrastructure | Accepted |
 
 ## How to Read an ADR
 

--- a/mercantis core/Reporting/ReportEngine.swift
+++ b/mercantis core/Reporting/ReportEngine.swift
@@ -85,38 +85,10 @@ public final class ReportEngine {
         // Build the result rows from the declared columns.
         let rows: [[String?]] = documents.map { doc in
             report.columns.map { columnKey in
-                self.formatValue(doc.fields[columnKey])
+                ReportValueFormatter.string(from: doc.fields[columnKey])
             }
         }
 
         return ReportResult(columns: report.columns, rows: rows)
     }
-
-    // MARK: - Helpers
-
-    private func formatValue(_ value: FieldValue?) -> String? {
-        switch value {
-        case .string(let s): return s
-        case .int(let i):    return "\(i)"
-        case .double(let d): return String(format: "%.2f", d)
-        case .bool(let b):   return b ? "Yes" : "No"
-        case .date(let d):   return Self.dateFormatter.string(from: d)
-        case .dateTime(let d): return Self.dateTimeFormatter.string(from: d)
-        case .data(let d):   return "<\(d.count) bytes>"
-        case .array(let xs): return "[\(xs.count) items]"
-        case .null, nil:     return nil
-        }
-    }
-
-    private static let dateFormatter: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withFullDate]
-        return f
-    }()
-
-    private static let dateTimeFormatter: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime]
-        return f
-    }()
 }

--- a/mercantis core/Reporting/ReportValueFormatter.swift
+++ b/mercantis core/Reporting/ReportValueFormatter.swift
@@ -1,0 +1,49 @@
+//
+//  ReportValueFormatter.swift
+//  mercantis core
+//
+//  Shared, side-effect-free formatting of a `FieldValue` into the
+//  optional string a `ReportResult` cell carries. Both the built-in
+//  `ReportEngine` and the `SavedReportEngine` (ADR-050) render cells
+//  through this single helper so column values look identical no matter
+//  which path produced them.
+//
+
+import Foundation
+
+/// Formats a `FieldValue` into the display string used for a report cell.
+///
+/// The mapping is intentionally lossless-enough for tabular display but not
+/// a round-trippable encoding: doubles are fixed to two decimals, booleans
+/// read as "Yes"/"No", and the opaque `.data` / `.array` cases collapse to a
+/// short summary. `nil` and `.null` both render as a missing cell (`nil`),
+/// which `GenericReportView` shows as an em dash.
+public enum ReportValueFormatter {
+
+    /// Render a single optional `FieldValue` as a report cell string.
+    public static func string(from value: FieldValue?) -> String? {
+        switch value {
+        case .string(let s):   return s
+        case .int(let i):      return "\(i)"
+        case .double(let d):   return String(format: "%.2f", d)
+        case .bool(let b):     return b ? "Yes" : "No"
+        case .date(let d):     return dateFormatter.string(from: d)
+        case .dateTime(let d): return dateTimeFormatter.string(from: d)
+        case .data(let d):     return "<\(d.count) bytes>"
+        case .array(let xs):   return "[\(xs.count) items]"
+        case .null, nil:       return nil
+        }
+    }
+
+    private static let dateFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withFullDate]
+        return f
+    }()
+
+    private static let dateTimeFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+}

--- a/mercantis core/Reporting/SavedReportDefinition.swift
+++ b/mercantis core/Reporting/SavedReportDefinition.swift
@@ -1,0 +1,309 @@
+//
+//  SavedReportDefinition.swift
+//  mercantis core
+//
+//  Generic saved-report infrastructure (ADR-050). A `SavedReportDefinition`
+//  is an app-neutral, user-owned customisation of a report: which columns
+//  show and in what order, which filters apply (with stored defaults), and
+//  how rows are sorted. It is deliberately data-only — it carries no SQL, no
+//  expressions, and no script. The `SavedReportEngine` interprets it against
+//  DocType metadata and the `DocumentEngine` to produce a normal
+//  `ReportResult`.
+//
+//  This type lives in Core because the shape is reusable by any app. ERP
+//  report names, DocTypes, and Hub navigation deliberately do NOT live here;
+//  Hub composes saved reports on top of this foundation.
+//
+
+import Foundation
+
+// MARK: - Visibility
+
+/// Who may see and run a saved report.
+///
+/// Kept intentionally minimal (no per-role grants, no cross-company model —
+/// those are out of scope for the Core foundation). `private` reports are
+/// visible only to their owner; `shared` reports are visible to anyone who
+/// can already reach the underlying documents.
+public enum SavedReportVisibility: String, Codable, Sendable, CaseIterable {
+    case `private`
+    case shared
+}
+
+// MARK: - Sort
+
+/// Direction for a saved-report sort key.
+public enum SavedReportSortDirection: String, Codable, Sendable, CaseIterable {
+    case ascending
+    case descending
+}
+
+/// One ordered sort key in a saved report.
+public struct SavedReportSort: Codable, Sendable, Equatable {
+    public let fieldKey: String
+    public var direction: SavedReportSortDirection
+
+    public init(fieldKey: String, direction: SavedReportSortDirection = .ascending) {
+        self.fieldKey = fieldKey
+        self.direction = direction
+    }
+}
+
+// MARK: - Filter
+
+/// The comparison a saved-report filter applies. Each case maps 1:1 onto a
+/// `ListFilter.Op` the `DocumentEngine` already understands — there is no
+/// free-form SQL or expression surface here.
+public enum SavedReportFilterOperator: String, Codable, Sendable, CaseIterable {
+    case equals
+    case notEquals
+    case greaterThan
+    case greaterThanOrEqual
+    case lessThan
+    case lessThanOrEqual
+    /// Substring match (`LIKE %value%`). Only meaningful for text fields.
+    case contains
+    case isNull
+    case isNotNull
+
+    /// Whether the operator needs a value to compare against. `isNull` /
+    /// `isNotNull` are unary and ignore any stored value.
+    public var requiresValue: Bool {
+        switch self {
+        case .isNull, .isNotNull: return false
+        default: return true
+        }
+    }
+}
+
+/// A stored filter on a saved report.
+///
+/// At execution the effective value resolves as
+/// `runtime override → value → defaultValue`. A `required` filter with no
+/// effective value is a hard error so a report can't silently run unfiltered.
+public struct SavedReportFilter: Codable, Sendable, Equatable {
+    public let fieldKey: String
+    public var op: SavedReportFilterOperator
+    /// The value baked into the saved report (may be overridden at run time).
+    public var value: FieldValue?
+    /// Fallback used when neither a runtime override nor `value` is supplied.
+    public var defaultValue: FieldValue?
+    /// When true, execution fails unless an effective value is available.
+    public var required: Bool
+
+    public init(
+        fieldKey: String,
+        op: SavedReportFilterOperator = .equals,
+        value: FieldValue? = nil,
+        defaultValue: FieldValue? = nil,
+        required: Bool = false
+    ) {
+        self.fieldKey = fieldKey
+        self.op = op
+        self.value = value
+        self.defaultValue = defaultValue
+        self.required = required
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        // `operator` is a Swift keyword; persist under the natural JSON key.
+        case fieldKey
+        case op = "operator"
+        case value
+        case defaultValue
+        case required
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        fieldKey = try c.decode(String.self, forKey: .fieldKey)
+        op = try c.decodeIfPresent(SavedReportFilterOperator.self, forKey: .op) ?? .equals
+        value = try c.decodeIfPresent(FieldValue.self, forKey: .value)
+        defaultValue = try c.decodeIfPresent(FieldValue.self, forKey: .defaultValue)
+        required = try c.decodeIfPresent(Bool.self, forKey: .required) ?? false
+    }
+}
+
+// MARK: - Column
+
+/// A column in a saved report. `order` drives left-to-right placement;
+/// `visible == false` hides the column without losing its configuration.
+public struct SavedReportColumn: Codable, Identifiable, Sendable, Equatable {
+    public var id: String { fieldKey }
+
+    public let fieldKey: String
+    /// Header text to show instead of the raw field key, when set.
+    public var labelOverride: String?
+    public var visible: Bool
+    public var order: Int
+    /// Optional preferred render width (points). Advisory only — the engine
+    /// ignores it; UI hosts may honour it.
+    public var width: Double?
+
+    public init(
+        fieldKey: String,
+        labelOverride: String? = nil,
+        visible: Bool = true,
+        order: Int,
+        width: Double? = nil
+    ) {
+        self.fieldKey = fieldKey
+        self.labelOverride = labelOverride
+        self.visible = visible
+        self.order = order
+        self.width = width
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case fieldKey, labelOverride, visible, order, width
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        fieldKey = try c.decode(String.self, forKey: .fieldKey)
+        labelOverride = try c.decodeIfPresent(String.self, forKey: .labelOverride)
+        visible = try c.decodeIfPresent(Bool.self, forKey: .visible) ?? true
+        order = try c.decode(Int.self, forKey: .order)
+        width = try c.decodeIfPresent(Double.self, forKey: .width)
+    }
+
+    /// The header label this column contributes to a `ReportResult` —
+    /// the override when present, otherwise the raw field key (matching the
+    /// built-in `ReportEngine`, which leaves humanisation to the view).
+    public var resolvedLabel: String {
+        labelOverride ?? fieldKey
+    }
+}
+
+// MARK: - Saved report
+
+/// A generic, app-neutral saved/customised report. (ADR-050)
+public struct SavedReportDefinition: Codable, Identifiable, Sendable, Equatable {
+    public let id: String
+    public var name: String
+    /// The built-in `ReportDefinition.id` this was derived from, if any.
+    public var baseReportId: String?
+    /// The DocType whose documents the report queries.
+    public let sourceDocType: String
+    /// The user who owns (and, when `private`, exclusively sees) this report.
+    public var ownerUserId: String
+    public var visibility: SavedReportVisibility
+    public var columns: [SavedReportColumn]
+    public var filters: [SavedReportFilter]
+    public var sorts: [SavedReportSort]
+    public let createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: String = UUID().uuidString,
+        name: String,
+        baseReportId: String? = nil,
+        sourceDocType: String,
+        ownerUserId: String,
+        visibility: SavedReportVisibility = .private,
+        columns: [SavedReportColumn] = [],
+        filters: [SavedReportFilter] = [],
+        sorts: [SavedReportSort] = [],
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.baseReportId = baseReportId
+        self.sourceDocType = sourceDocType
+        self.ownerUserId = ownerUserId
+        self.visibility = visibility
+        self.columns = columns
+        self.filters = filters
+        self.sorts = sorts
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, baseReportId, sourceDocType, ownerUserId, visibility
+        case columns, filters, sorts, createdAt, updatedAt
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        baseReportId = try c.decodeIfPresent(String.self, forKey: .baseReportId)
+        sourceDocType = try c.decode(String.self, forKey: .sourceDocType)
+        ownerUserId = try c.decode(String.self, forKey: .ownerUserId)
+        visibility = try c.decodeIfPresent(SavedReportVisibility.self, forKey: .visibility) ?? .private
+        columns = try c.decodeIfPresent([SavedReportColumn].self, forKey: .columns) ?? []
+        filters = try c.decodeIfPresent([SavedReportFilter].self, forKey: .filters) ?? []
+        sorts = try c.decodeIfPresent([SavedReportSort].self, forKey: .sorts) ?? []
+        createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+        updatedAt = try c.decodeIfPresent(Date.self, forKey: .updatedAt) ?? Date()
+    }
+
+    // MARK: - Derived views
+
+    /// Visible columns in `order`, ties broken by their original array index so
+    /// ordering is deterministic. These define the `ReportResult` column set.
+    public var visibleColumnsInOrder: [SavedReportColumn] {
+        columns.enumerated()
+            .filter { $0.element.visible }
+            .sorted { lhs, rhs in
+                lhs.element.order != rhs.element.order
+                    ? lhs.element.order < rhs.element.order
+                    : lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+
+    /// Ownership/visibility gate. `private` reports are reachable only by their
+    /// owner; `shared` reports are reachable by anyone (document-level access is
+    /// still enforced separately when the report runs).
+    public func canBeAccessed(byUserId userId: String) -> Bool {
+        switch visibility {
+        case .shared:   return true
+        case .private:  return userId == ownerUserId
+        }
+    }
+
+    // MARK: - Conversion from a built-in report
+
+    /// Clone a built-in `ReportDefinition` into editable saved-report
+    /// configuration. Every declared column becomes a visible column in
+    /// declaration order; every declared filter becomes an (optional) saved
+    /// filter seeded with the built-in's default value. Sorts start empty —
+    /// built-in reports don't declare a sort order.
+    public static func from(
+        reportDefinition report: ReportDefinition,
+        id: String = UUID().uuidString,
+        name: String? = nil,
+        ownerUserId: String,
+        visibility: SavedReportVisibility = .private,
+        now: Date = Date()
+    ) -> SavedReportDefinition {
+        let columns = report.columns.enumerated().map { index, key in
+            SavedReportColumn(fieldKey: key, visible: true, order: index)
+        }
+        let filters = report.filters.map { filter in
+            SavedReportFilter(
+                fieldKey: filter.fieldKey,
+                op: .equals,
+                value: nil,
+                defaultValue: filter.defaultValue,
+                required: false
+            )
+        }
+        return SavedReportDefinition(
+            id: id,
+            name: name ?? report.name,
+            baseReportId: report.id,
+            sourceDocType: report.docType,
+            ownerUserId: ownerUserId,
+            visibility: visibility,
+            columns: columns,
+            filters: filters,
+            sorts: [],
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+}

--- a/mercantis core/Reporting/SavedReportEngine.swift
+++ b/mercantis core/Reporting/SavedReportEngine.swift
@@ -1,0 +1,313 @@
+//
+//  SavedReportEngine.swift
+//  mercantis core
+//
+//  Executes `SavedReportDefinition`s (ADR-050) against the local database and
+//  returns the same `ReportResult` the built-in `ReportEngine` produces.
+//
+//  Safety properties enforced here:
+//  - Only fields that exist in the source DocType metadata (or are well-known
+//    document system columns) may be referenced — unknown fields are rejected.
+//  - Filters map onto the typed `ListFilter` operator surface; there is no
+//    arbitrary SQL and no Swift/script execution path.
+//  - Queries go through `DocumentEngine.list`, so DocType `rowAccessExpression`
+//    and role-based row filtering still apply — saved reports cannot widen
+//    access beyond what the requesting user could already see.
+//
+
+import Foundation
+
+/// Interprets `SavedReportDefinition`s into `ReportResult`s.
+///
+/// The engine also offers a small in-memory registry (mirroring
+/// `ReportEngine`) so hosts can register saved reports, list the ones a user
+/// may access, and clone built-in reports into saved configuration.
+public final class SavedReportEngine {
+
+    /// Document system columns that may be referenced by a saved report even
+    /// though they aren't user-declared `FieldDefinition`s. Mirrors the columns
+    /// `DocumentEngine` exposes for filtering/sorting.
+    public static let systemFieldKeys: Set<String> = [
+        "id", "doctype", "company", "status",
+        "createdAt", "updatedAt", "syncVersion", "syncState",
+        "docStatus", "amendedFrom", "parentID"
+    ]
+
+    private let documentEngine: DocumentEngine
+    private let registry: MetadataRegistry
+
+    /// Saved reports known to this engine, keyed by id.
+    private var savedReports: [String: SavedReportDefinition] = [:]
+
+    public init(documentEngine: DocumentEngine, registry: MetadataRegistry) {
+        self.documentEngine = documentEngine
+        self.registry = registry
+    }
+
+    // MARK: - Registry
+
+    /// Register (or replace) a saved report.
+    public func register(_ savedReport: SavedReportDefinition) {
+        savedReports[savedReport.id] = savedReport
+    }
+
+    /// Remove a saved report by id.
+    public func remove(_ id: String) {
+        savedReports.removeValue(forKey: id)
+    }
+
+    /// Look up a registered saved report.
+    public func get(_ id: String) -> SavedReportDefinition? {
+        savedReports[id]
+    }
+
+    /// All registered saved reports, sorted by name for deterministic ordering.
+    public func all() -> [SavedReportDefinition] {
+        savedReports.values.sorted { $0.name < $1.name }
+    }
+
+    /// Saved reports the given user may access — every `shared` report plus the
+    /// user's own `private` reports — sorted by name.
+    public func accessibleSavedReports(forUserId userId: String) -> [SavedReportDefinition] {
+        savedReports.values
+            .filter { $0.canBeAccessed(byUserId: userId) }
+            .sorted { $0.name < $1.name }
+    }
+
+    // MARK: - Conversion
+
+    /// Clone a built-in `ReportDefinition` into a saved report and register it.
+    @discardableResult
+    public func convert(
+        _ report: ReportDefinition,
+        id: String = UUID().uuidString,
+        name: String? = nil,
+        ownerUserId: String,
+        visibility: SavedReportVisibility = .private,
+        now: Date = Date()
+    ) -> SavedReportDefinition {
+        let saved = SavedReportDefinition.from(
+            reportDefinition: report,
+            id: id,
+            name: name,
+            ownerUserId: ownerUserId,
+            visibility: visibility,
+            now: now
+        )
+        register(saved)
+        return saved
+    }
+
+    // MARK: - Execute
+
+    /// Execute a saved report and return its `ReportResult`.
+    ///
+    /// - Parameters:
+    ///   - savedReport: The configuration to run.
+    ///   - requestingUserId: When supplied, the saved report's ownership/visibility
+    ///     gate is enforced and the id is used as the document-access subject.
+    ///   - runtimeFilterValues: Per-field overrides keyed by `fieldKey`; these
+    ///     take precedence over each filter's stored `value` / `defaultValue`.
+    ///   - userRoles: Roles applied to DocType row-level access filtering.
+    /// - Returns: A `ReportResult` whose columns are the saved report's visible
+    ///   columns (in order) and whose rows are the matching documents.
+    public func execute(
+        savedReport: SavedReportDefinition,
+        requestingUserId: String? = nil,
+        runtimeFilterValues: [String: FieldValue] = [:],
+        userRoles: Set<String> = []
+    ) throws -> ReportResult {
+        // Ownership / sharing gate.
+        if let requestingUserId, !savedReport.canBeAccessed(byUserId: requestingUserId) {
+            throw SavedReportError.notAuthorized(
+                savedReportId: savedReport.id,
+                userId: requestingUserId
+            )
+        }
+
+        // The source DocType must be registered so we can validate fields
+        // against real metadata rather than trusting the stored config.
+        guard let docType = registry.get(savedReport.sourceDocType) else {
+            throw SavedReportError.docTypeNotRegistered(savedReport.sourceDocType)
+        }
+        let allowedFields = Self.allowedFieldKeys(for: docType)
+
+        let visibleColumns = savedReport.visibleColumnsInOrder
+        guard !visibleColumns.isEmpty else {
+            throw SavedReportError.noVisibleColumns(savedReportId: savedReport.id)
+        }
+
+        // Reject any reference to a field that isn't part of the DocType
+        // metadata (or a known system column). This is the guard that keeps a
+        // saved report from reaching beyond its declared surface.
+        try validateFields(
+            in: savedReport,
+            visibleColumns: visibleColumns,
+            allowedFields: allowedFields
+        )
+
+        // Build typed predicates from the stored filters.
+        var predicates: [ListFilter] = []
+        for filter in savedReport.filters {
+            let effective = runtimeFilterValues[filter.fieldKey]
+                ?? filter.value
+                ?? filter.defaultValue
+            if let predicate = try makePredicate(filter, effectiveValue: effective) {
+                predicates.append(predicate)
+            }
+        }
+
+        // Build the sort chain.
+        let sortBy: [ListSort] = savedReport.sorts.map { sort in
+            ListSort(
+                fieldKey: sort.fieldKey,
+                direction: sort.direction == .ascending ? .ascending : .descending
+            )
+        }
+
+        // Query through the DocumentEngine so row-level access still applies.
+        let documents = try documentEngine.list(
+            docType: savedReport.sourceDocType,
+            predicates: predicates.isEmpty ? nil : predicates,
+            sortBy: sortBy.isEmpty ? nil : sortBy,
+            userRoles: userRoles,
+            listUserId: requestingUserId
+        )
+
+        let columns = visibleColumns.map(\.resolvedLabel)
+        let rows: [[String?]] = documents.map { doc in
+            visibleColumns.map { column in
+                ReportValueFormatter.string(from: value(for: column.fieldKey, in: doc))
+            }
+        }
+
+        return ReportResult(columns: columns, rows: rows)
+    }
+
+    // MARK: - Validation
+
+    /// The set of field keys a saved report on `docType` may legally reference.
+    public static func allowedFieldKeys(for docType: DocType) -> Set<String> {
+        systemFieldKeys.union(docType.fields.map(\.key))
+    }
+
+    private func validateFields(
+        in savedReport: SavedReportDefinition,
+        visibleColumns: [SavedReportColumn],
+        allowedFields: Set<String>
+    ) throws {
+        func check(_ key: String) throws {
+            guard allowedFields.contains(key) else {
+                throw SavedReportError.unknownField(
+                    fieldKey: key,
+                    docType: savedReport.sourceDocType
+                )
+            }
+        }
+        for column in visibleColumns { try check(column.fieldKey) }
+        for filter in savedReport.filters { try check(filter.fieldKey) }
+        for sort in savedReport.sorts { try check(sort.fieldKey) }
+    }
+
+    // MARK: - Predicate construction
+
+    /// Turn a saved filter + its resolved value into a `ListFilter`, or `nil`
+    /// when an optional filter has no value to apply.
+    private func makePredicate(
+        _ filter: SavedReportFilter,
+        effectiveValue: FieldValue?
+    ) throws -> ListFilter? {
+        let key = filter.fieldKey
+        switch filter.op {
+        case .isNull:
+            return ListFilter(key, .isNull)
+        case .isNotNull:
+            return ListFilter(key, .isNotNull)
+        case .equals, .notEquals, .greaterThan, .greaterThanOrEqual,
+             .lessThan, .lessThanOrEqual, .contains:
+            guard let value = effectiveValue, value != .null else {
+                if filter.required {
+                    throw SavedReportError.missingRequiredFilter(fieldKey: key)
+                }
+                return nil  // optional, unset → simply skipped
+            }
+            return ListFilter(key, listOp(for: filter.op, value: value))
+        }
+    }
+
+    /// Map a value-bearing saved operator onto a `ListFilter.Op`.
+    private func listOp(for op: SavedReportFilterOperator, value: FieldValue) -> ListFilter.Op {
+        switch op {
+        case .equals:             return .eq(value)
+        case .notEquals:          return .neq(value)
+        case .greaterThan:        return .gt(value)
+        case .greaterThanOrEqual: return .gte(value)
+        case .lessThan:           return .lt(value)
+        case .lessThanOrEqual:    return .lte(value)
+        case .contains:           return .like("%\(likeFragment(from: value))%")
+        // The unary operators never reach here (handled in `makePredicate`),
+        // but the switch stays exhaustive.
+        case .isNull:             return .isNull
+        case .isNotNull:          return .isNotNull
+        }
+    }
+
+    /// String form of a value for a `contains` (`LIKE`) pattern.
+    private func likeFragment(from value: FieldValue) -> String {
+        ReportValueFormatter.string(from: value) ?? ""
+    }
+
+    // MARK: - Value resolution
+
+    /// Read a column value from a document. User-declared fields win; otherwise
+    /// fall back to the document's system columns (matching `DocumentEngine`).
+    private func value(for key: String, in document: Document) -> FieldValue? {
+        if let userValue = document.fields[key] { return userValue }
+        switch key {
+        case "id":          return .string(document.id)
+        case "doctype":     return .string(document.docType)
+        case "company":     return .string(document.company)
+        case "status":      return .string(document.status)
+        case "createdAt":   return .dateTime(document.createdAt)
+        case "updatedAt":   return .dateTime(document.updatedAt)
+        case "syncVersion": return .int(Int(document.syncVersion))
+        case "syncState":   return .string(document.syncState.rawValue)
+        case "docStatus":   return .int(document.docStatus)
+        case "amendedFrom": return document.amendedFrom.map { .string($0) }
+        case "parentID":    return document.parentID.map { .string($0) }
+        default:            return nil
+        }
+    }
+}
+
+// MARK: - Errors
+
+public enum SavedReportError: Error, Sendable, Equatable {
+    /// The saved report's `sourceDocType` isn't registered in metadata.
+    case docTypeNotRegistered(String)
+    /// A referenced field isn't part of the DocType metadata or system columns.
+    case unknownField(fieldKey: String, docType: String)
+    /// The saved report has no visible columns to render.
+    case noVisibleColumns(savedReportId: String)
+    /// A `required` filter resolved to no value.
+    case missingRequiredFilter(fieldKey: String)
+    /// The requesting user may not access this (private) saved report.
+    case notAuthorized(savedReportId: String, userId: String)
+}
+
+extension SavedReportError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .docTypeNotRegistered(let id):
+            return "The report's source type \"\(id)\" isn't registered. Its app manifest may not have finished installing."
+        case .unknownField(let fieldKey, let docType):
+            return "Field \"\(fieldKey)\" doesn't exist on \"\(docType)\", so it can't be used in a saved report."
+        case .noVisibleColumns:
+            return "This saved report has no visible columns. Show at least one column before running it."
+        case .missingRequiredFilter(let fieldKey):
+            return "The required filter \"\(fieldKey)\" needs a value before this report can run."
+        case .notAuthorized(_, let userId):
+            return "User \"\(userId)\" isn't allowed to open this private saved report."
+        }
+    }
+}

--- a/mercantis coreTests/SavedReportEngineTests.swift
+++ b/mercantis coreTests/SavedReportEngineTests.swift
@@ -1,0 +1,489 @@
+//
+//  SavedReportEngineTests.swift
+//  mercantis coreTests
+//
+//  Saved-report infrastructure (ADR-050): configuration, conversion from a
+//  built-in `ReportDefinition`, and execution into a `ReportResult`.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class SavedReportEngineTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+    private var engine: SavedReportEngine!
+
+    private let docTypeId = "Invoice"
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness(userId: "alice")
+        engine = SavedReportEngine(documentEngine: harness.engine, registry: harness.registry)
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        engine = nil
+        harness = nil
+    }
+
+    // MARK: - Fixtures
+
+    /// Register the `Invoice` DocType and seed three documents.
+    private func seed() throws {
+        let docType = TestSupport.makeDocType(
+            id: docTypeId,
+            fields: [
+                TestSupport.textField("title", required: true),
+                TestSupport.numberField("amount"),
+                TestSupport.textField("city")
+            ],
+            titleField: "title"
+        )
+        try harness.registry.register(docType)
+
+        try save(title: "Alpha", amount: 100, city: "Valletta")
+        try save(title: "Beta",  amount: 50,  city: "Sliema")
+        try save(title: "Gamma", amount: 200, city: "Valletta")
+    }
+
+    private func save(title: String, amount: Int, city: String) throws {
+        let doc = TestSupport.makeDocument(
+            docType: docTypeId,
+            fields: [
+                "title": .string(title),
+                "amount": .int(amount),
+                "city": .string(city)
+            ]
+        )
+        try harness.engine.save(doc)
+    }
+
+    private func column(_ key: String, order: Int, visible: Bool = true, label: String? = nil) -> SavedReportColumn {
+        SavedReportColumn(fieldKey: key, labelOverride: label, visible: visible, order: order)
+    }
+
+    private func makeReport(
+        columns: [SavedReportColumn],
+        filters: [SavedReportFilter] = [],
+        sorts: [SavedReportSort] = [],
+        owner: String = "alice",
+        visibility: SavedReportVisibility = .private
+    ) -> SavedReportDefinition {
+        SavedReportDefinition(
+            id: "saved-1",
+            name: "My Invoices",
+            baseReportId: nil,
+            sourceDocType: docTypeId,
+            ownerUserId: owner,
+            visibility: visibility,
+            columns: columns,
+            filters: filters,
+            sorts: sorts
+        )
+    }
+
+    // MARK: - Conversion
+
+    func testConvertBuiltInReportClonesColumnsAndFilters() throws {
+        let builtIn = ReportDefinition(
+            id: "builtin-invoices",
+            name: "Invoices",
+            docType: docTypeId,
+            columns: ["title", "amount", "city"],
+            filters: [
+                ReportFilter(fieldKey: "city", label: "City", defaultValue: .string("Valletta"))
+            ],
+            allowedRoles: ["Accounts Manager"]
+        )
+
+        let saved = engine.convert(builtIn, id: "saved-x", ownerUserId: "alice")
+
+        XCTAssertEqual(saved.baseReportId, "builtin-invoices")
+        XCTAssertEqual(saved.sourceDocType, docTypeId)
+        XCTAssertEqual(saved.name, "Invoices")
+        XCTAssertEqual(saved.ownerUserId, "alice")
+        XCTAssertEqual(saved.visibility, .private)
+
+        // Columns cloned in declaration order, all visible.
+        XCTAssertEqual(saved.columns.map(\.fieldKey), ["title", "amount", "city"])
+        XCTAssertEqual(saved.columns.map(\.order), [0, 1, 2])
+        XCTAssertTrue(saved.columns.allSatisfy(\.visible))
+
+        // Filter cloned with the built-in default seeded.
+        XCTAssertEqual(saved.filters.count, 1)
+        XCTAssertEqual(saved.filters[0].fieldKey, "city")
+        XCTAssertEqual(saved.filters[0].op, .equals)
+        XCTAssertEqual(saved.filters[0].defaultValue, .string("Valletta"))
+
+        // Convert registers it so the engine can find it again.
+        XCTAssertEqual(engine.get("saved-x")?.id, "saved-x")
+    }
+
+    // MARK: - Execution
+
+    func testExecuteReturnsVisibleColumnsAndRows() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0), column("amount", order: 1)],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)]
+        )
+
+        let result = try engine.execute(savedReport: report)
+
+        XCTAssertEqual(result.columns, ["title", "amount"])
+        XCTAssertEqual(result.rowCount, 3)
+        XCTAssertEqual(result.rows, [
+            ["Alpha", "100"],
+            ["Beta", "50"],
+            ["Gamma", "200"]
+        ])
+    }
+
+    func testHiddenColumnsAreExcluded() throws {
+        try seed()
+        let report = makeReport(
+            columns: [
+                column("title", order: 0),
+                column("amount", order: 1, visible: false),
+                column("city", order: 2)
+            ],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)]
+        )
+
+        let result = try engine.execute(savedReport: report)
+
+        XCTAssertEqual(result.columns, ["title", "city"])
+        XCTAssertEqual(result.rows.first, ["Alpha", "Valletta"])
+    }
+
+    func testColumnsAreRenderedInOrder() throws {
+        try seed()
+        // Declared amount-before-title but ordered title-first.
+        let report = makeReport(
+            columns: [column("amount", order: 1), column("title", order: 0)],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)]
+        )
+
+        let result = try engine.execute(savedReport: report)
+
+        XCTAssertEqual(result.columns, ["title", "amount"])
+        XCTAssertEqual(result.rows.first, ["Alpha", "100"])
+    }
+
+    func testLabelOverrideBecomesColumnHeader() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0, label: "Invoice Name")],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)]
+        )
+
+        let result = try engine.execute(savedReport: report)
+
+        XCTAssertEqual(result.columns, ["Invoice Name"])
+    }
+
+    // MARK: - Filters
+
+    func testStoredFilterValueIsApplied() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0)],
+            filters: [SavedReportFilter(fieldKey: "city", op: .equals, value: .string("Valletta"))],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)]
+        )
+
+        let result = try engine.execute(savedReport: report)
+
+        XCTAssertEqual(result.rows, [["Alpha"], ["Gamma"]])
+    }
+
+    func testDefaultFilterValueIsUsedWhenNoValueOrOverride() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0)],
+            filters: [SavedReportFilter(
+                fieldKey: "city", op: .equals, value: nil, defaultValue: .string("Sliema")
+            )],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)]
+        )
+
+        let result = try engine.execute(savedReport: report)
+
+        XCTAssertEqual(result.rows, [["Beta"]])
+    }
+
+    func testRuntimeOverrideBeatsStoredAndDefault() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0)],
+            filters: [SavedReportFilter(
+                fieldKey: "city", op: .equals,
+                value: .string("Sliema"), defaultValue: .string("Sliema")
+            )],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)]
+        )
+
+        let result = try engine.execute(
+            savedReport: report,
+            runtimeFilterValues: ["city": .string("Valletta")]
+        )
+
+        XCTAssertEqual(result.rows, [["Alpha"], ["Gamma"]])
+    }
+
+    func testComparisonOperatorFilter() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0)],
+            filters: [SavedReportFilter(fieldKey: "amount", op: .greaterThanOrEqual, value: .int(100))],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)]
+        )
+
+        let result = try engine.execute(savedReport: report)
+
+        XCTAssertEqual(result.rows, [["Alpha"], ["Gamma"]])
+    }
+
+    func testContainsFilter() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0)],
+            filters: [SavedReportFilter(fieldKey: "city", op: .contains, value: .string("etta"))],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)]
+        )
+
+        let result = try engine.execute(savedReport: report)
+
+        XCTAssertEqual(result.rows, [["Alpha"], ["Gamma"]])
+    }
+
+    func testOptionalFilterWithoutValueIsSkipped() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0)],
+            filters: [SavedReportFilter(fieldKey: "city", op: .equals, required: false)],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)]
+        )
+
+        let result = try engine.execute(savedReport: report)
+
+        // No value anywhere → filter ignored, all rows returned.
+        XCTAssertEqual(result.rowCount, 3)
+    }
+
+    func testRequiredFilterWithoutValueThrows() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0)],
+            filters: [SavedReportFilter(fieldKey: "city", op: .equals, required: true)]
+        )
+
+        XCTAssertThrowsError(try engine.execute(savedReport: report)) { error in
+            XCTAssertEqual(error as? SavedReportError, .missingRequiredFilter(fieldKey: "city"))
+        }
+    }
+
+    // MARK: - Sorting
+
+    func testSortDescendingIsApplied() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0), column("amount", order: 1)],
+            sorts: [SavedReportSort(fieldKey: "amount", direction: .descending)]
+        )
+
+        let result = try engine.execute(savedReport: report)
+
+        XCTAssertEqual(result.rows.map { $0[0] }, ["Gamma", "Alpha", "Beta"])
+    }
+
+    // MARK: - Validation
+
+    func testUnknownColumnFieldThrows() throws {
+        try seed()
+        let report = makeReport(columns: [column("nope", order: 0)])
+
+        XCTAssertThrowsError(try engine.execute(savedReport: report)) { error in
+            XCTAssertEqual(
+                error as? SavedReportError,
+                .unknownField(fieldKey: "nope", docType: docTypeId)
+            )
+        }
+    }
+
+    func testUnknownFilterFieldThrows() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0)],
+            filters: [SavedReportFilter(fieldKey: "ghost", op: .isNotNull)]
+        )
+
+        XCTAssertThrowsError(try engine.execute(savedReport: report)) { error in
+            XCTAssertEqual(
+                error as? SavedReportError,
+                .unknownField(fieldKey: "ghost", docType: docTypeId)
+            )
+        }
+    }
+
+    func testSystemColumnIsAllowed() throws {
+        try seed()
+        // `id` is a system column, not a declared field, but is valid.
+        let report = makeReport(
+            columns: [column("id", order: 0), column("title", order: 1)],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)]
+        )
+
+        let result = try engine.execute(savedReport: report)
+
+        XCTAssertEqual(result.columns, ["id", "title"])
+        XCTAssertEqual(result.rowCount, 3)
+    }
+
+    func testUnregisteredDocTypeThrows() throws {
+        let report = SavedReportDefinition(
+            name: "Ghost report",
+            sourceDocType: "Ghost",
+            ownerUserId: "alice",
+            columns: [column("title", order: 0)]
+        )
+
+        XCTAssertThrowsError(try engine.execute(savedReport: report)) { error in
+            XCTAssertEqual(error as? SavedReportError, .docTypeNotRegistered("Ghost"))
+        }
+    }
+
+    func testNoVisibleColumnsThrows() throws {
+        try seed()
+        let report = makeReport(columns: [column("title", order: 0, visible: false)])
+
+        XCTAssertThrowsError(try engine.execute(savedReport: report)) { error in
+            XCTAssertEqual(error as? SavedReportError, .noVisibleColumns(savedReportId: "saved-1"))
+        }
+    }
+
+    // MARK: - Ownership / sharing
+
+    func testPrivateReportRejectsOtherUser() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0)],
+            owner: "alice",
+            visibility: .private
+        )
+
+        XCTAssertThrowsError(
+            try engine.execute(savedReport: report, requestingUserId: "bob")
+        ) { error in
+            XCTAssertEqual(
+                error as? SavedReportError,
+                .notAuthorized(savedReportId: "saved-1", userId: "bob")
+            )
+        }
+    }
+
+    func testSharedReportAllowsAnyUser() throws {
+        try seed()
+        let report = makeReport(
+            columns: [column("title", order: 0)],
+            sorts: [SavedReportSort(fieldKey: "title", direction: .ascending)],
+            owner: "alice",
+            visibility: .shared
+        )
+
+        let result = try engine.execute(savedReport: report, requestingUserId: "bob")
+        XCTAssertEqual(result.rowCount, 3)
+    }
+
+    func testAccessibleSavedReportsHonourVisibility() {
+        engine.register(makeReport(columns: [column("title", order: 0)], owner: "alice", visibility: .private))
+        engine.register(SavedReportDefinition(
+            id: "shared-1", name: "Shared", sourceDocType: docTypeId,
+            ownerUserId: "carol", visibility: .shared,
+            columns: [column("title", order: 0)]
+        ))
+        engine.register(SavedReportDefinition(
+            id: "bob-private", name: "Bob only", sourceDocType: docTypeId,
+            ownerUserId: "bob", visibility: .private,
+            columns: [column("title", order: 0)]
+        ))
+
+        let forAlice = engine.accessibleSavedReports(forUserId: "alice").map(\.id)
+        XCTAssertEqual(Set(forAlice), Set(["saved-1", "shared-1"]))
+
+        let forBob = engine.accessibleSavedReports(forUserId: "bob").map(\.id)
+        XCTAssertEqual(Set(forBob), Set(["bob-private", "shared-1"]))
+    }
+
+    // MARK: - Codable
+
+    func testSavedReportRoundTrips() throws {
+        let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let original = SavedReportDefinition(
+            id: "rt",
+            name: "Round Trip",
+            baseReportId: "builtin",
+            sourceDocType: docTypeId,
+            ownerUserId: "alice",
+            visibility: .shared,
+            columns: [
+                column("title", order: 0, label: "Name"),
+                column("amount", order: 1, visible: false)
+            ],
+            filters: [SavedReportFilter(
+                fieldKey: "city", op: .contains,
+                value: .string("V"), defaultValue: .string("Valletta"), required: true
+            )],
+            sorts: [SavedReportSort(fieldKey: "amount", direction: .descending)],
+            createdAt: fixedDate,
+            updatedAt: fixedDate
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(SavedReportDefinition.self, from: data)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testLenientDecodeFillsDefaults() throws {
+        // A minimal payload omitting visibility / collections / timestamps.
+        let json = """
+        {
+            "id": "min",
+            "name": "Minimal",
+            "sourceDocType": "Invoice",
+            "ownerUserId": "alice",
+            "columns": [{ "fieldKey": "title", "order": 0 }]
+        }
+        """
+        let decoded = try JSONDecoder().decode(SavedReportDefinition.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.visibility, .private)
+        XCTAssertTrue(decoded.filters.isEmpty)
+        XCTAssertTrue(decoded.sorts.isEmpty)
+        XCTAssertEqual(decoded.columns.count, 1)
+        XCTAssertTrue(decoded.columns[0].visible)   // defaulted true
+    }
+
+    // MARK: - Built-in report path unchanged
+
+    func testBuiltInReportEngineStillWorks() throws {
+        try seed()
+        let reportEngine = ReportEngine(documentEngine: harness.engine)
+        let report = ReportDefinition(
+            id: "r", name: "All Invoices", docType: docTypeId,
+            columns: ["title", "amount"], filters: []
+        )
+        reportEngine.register(report)
+
+        let result = try reportEngine.execute(report: report)
+        XCTAssertEqual(result.columns, ["title", "amount"])
+        XCTAssertEqual(result.rowCount, 3)
+    }
+}


### PR DESCRIPTION
## Summary

Implements a generic, app-neutral saved-report layer in Core that allows users to customize and save report variants with configurable columns, filters, sorting, and visibility settings. This enables Hub and other apps to offer user-created report views without hardcoding report variants.

## Key Changes

- **New `SavedReportDefinition` model** — A data-only, `Codable` value type carrying structured report configuration (columns, filters, sorts, ownership, visibility) with no SQL or expressions. Includes lenient decoding for schema evolution.

- **New `SavedReportEngine`** — Executes saved reports against the document database and returns `ReportResult` objects. Enforces four safety rules:
  - Ownership/visibility gate (private reports only accessible to owner; shared reports to anyone)
  - Field allow-listing (only DocType fields and known system columns permitted)
  - No arbitrary code (filters compile to typed `ListFilter` predicates)
  - Preserved permissions (queries run through `DocumentEngine.list` so row-level access still applies)

- **Conversion from built-in reports** — `SavedReportDefinition.from(reportDefinition:…)` clones a built-in `ReportDefinition` into editable saved configuration, preserving columns and filter defaults while recording the origin via `baseReportId`.

- **Extracted `ReportValueFormatter`** — Refactored cell formatting logic from `ReportEngine` into a shared utility so both built-in and saved reports render values identically.

- **In-memory registry** — `SavedReportEngine` maintains a registry mirroring `ReportEngine`, with methods to register, retrieve, list all, and filter by user access.

- **Comprehensive test suite** — 489-line test file covering conversion, execution, column visibility/ordering, label overrides, filter operators (equals, comparison, contains, null checks), sorting, validation, ownership/sharing, and `Codable` round-tripping.

- **ADR-050 documentation** — Architecture decision record explaining context, design, consequences, and Core/Hub boundary.

## Notable Implementation Details

- Filter value resolution follows a priority chain: runtime override → stored value → default value
- Required filters without an effective value throw `SavedReportError.missingRequiredFilter`
- System columns (`id`, `status`, `createdAt`, etc.) are allowed alongside user-declared fields
- The built-in `ReportEngine` path remains untouched; both engines now share `ReportValueFormatter`
- Sorting and filtering leverage existing typed `ListFilter`/`ListSort` infrastructure, avoiding new query paths

https://claude.ai/code/session_01T1wXzhcNPsQKWQKk9PWDD2