### PR TITLE
Report view polish: top-align, optional title, ReportResult CSV

### DIFF
--- a/Docs/ADR/ADR-049-report-role-filtering-and-view.md
+++ b/Docs/ADR/ADR-049-report-role-filtering-and-view.md
@@ -77,3 +77,21 @@ filter state and re-execution loop.
   across the engine.
 - Sort order is `name`-ascending. Hosts that want different
   orderings can re-sort; the engine's order is documented.
+
+## Update — report-view polish (2026-06-03)
+
+Follow-up refinements after Hub started rendering user-customised and
+from-scratch reports through this view:
+
+- **`GenericReportView` top-aligns its content.** The body now fills the
+  available space and pins the header + table to the top, instead of letting
+  a short table float in the vertical centre.
+- **`showsTitle: Bool = true`.** Hosts that already display the report name
+  (e.g. in a navigation bar) can pass `showsTitle: false` to drop the
+  duplicate in-view title while keeping the row count and Refresh /
+  Export-CSV actions. Default `true` keeps every existing call site
+  unchanged.
+- **`ReportResult.csvString()`** moves CSV serialisation into `MercantisCore`
+  (RFC-4180 escaping). It lives in the engine layer, not the UI layer, so the
+  CLI / headless exporters can produce CSV without importing SwiftUI; the host
+  app still owns how the file is delivered (save panel, share sheet).

--- a/mercantis core/Reporting/ReportResultCSV.swift
+++ b/mercantis core/Reporting/ReportResultCSV.swift
@@ -1,0 +1,40 @@
+//
+//  ReportResultCSV.swift
+//  mercantis core
+//
+//  Reusable CSV serialisation for a `ReportResult`. Lives in `MercantisCore`
+//  (not the UI layer) so headless consumers — the CLI, exporters, tests —
+//  can turn a report into CSV without importing SwiftUI. Presentation of the
+//  result (a save panel, a share sheet) stays with the host app.
+//
+
+import Foundation
+
+public extension ReportResult {
+
+    /// Serialise the result as RFC-4180 CSV: a header row of column names
+    /// followed by one line per row. A field is quoted when it contains a
+    /// comma, double-quote, or newline, and embedded quotes are doubled.
+    /// `nil` cells render as empty fields.
+    ///
+    /// - Parameters:
+    ///   - separator: Field delimiter. Defaults to `","`.
+    ///   - newline: Row delimiter. Defaults to `"\n"`.
+    func csvString(separator: String = ",", newline: String = "\n") -> String {
+        var lines: [String] = []
+        lines.append(columns.map { Self.escapeCSVField($0, separator: separator) }.joined(separator: separator))
+        for row in rows {
+            lines.append(row.map { Self.escapeCSVField($0 ?? "", separator: separator) }.joined(separator: separator))
+        }
+        return lines.joined(separator: newline)
+    }
+
+    private static func escapeCSVField(_ field: String, separator: String) -> String {
+        let needsQuoting = field.contains(separator)
+            || field.contains("\"")
+            || field.contains("\n")
+            || field.contains("\r")
+        guard needsQuoting else { return field }
+        return "\"\(field.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+}

--- a/mercantis core/UIShell/GenericReportView.swift
+++ b/mercantis core/UIShell/GenericReportView.swift
@@ -23,17 +23,23 @@ public struct GenericReportView: View {
 
     public let title: String
     public let result: ReportResult
+    /// When `false`, the header omits the title text but keeps the row count
+    /// and action buttons. Hosts that already show the report name elsewhere
+    /// (e.g. a navigation bar) use this to avoid a duplicate title.
+    public let showsTitle: Bool
     public let onRefresh: (() -> Void)?
     public let onExportCSV: (() -> Void)?
 
     public init(
         title: String,
         result: ReportResult,
+        showsTitle: Bool = true,
         onRefresh: (() -> Void)? = nil,
         onExportCSV: (() -> Void)? = nil
     ) {
         self.title = title
         self.result = result
+        self.showsTitle = showsTitle
         self.onRefresh = onRefresh
         self.onExportCSV = onExportCSV
     }
@@ -47,14 +53,20 @@ public struct GenericReportView: View {
                 resultsTable
             }
         }
+        // Fill the available space and keep content pinned to the top so the
+        // table sits directly under the header rather than floating in the
+        // vertical centre when there are only a few rows.
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
     // MARK: - Sub-views
 
     private var header: some View {
         HStack(spacing: 12) {
-            Text(title)
-                .font(.title3.weight(.semibold))
+            if showsTitle {
+                Text(title)
+                    .font(.title3.weight(.semibold))
+            }
             Spacer()
             Text(rowCountLabel)
                 .font(.subheadline)

--- a/mercantis coreTests/ReportResultCSVTests.swift
+++ b/mercantis coreTests/ReportResultCSVTests.swift
@@ -1,0 +1,45 @@
+//
+//  ReportResultCSVTests.swift
+//  mercantis coreTests
+//
+//  Reusable `ReportResult.csvString()` serialisation (RFC-4180 escaping).
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class ReportResultCSVTests: XCTestCase {
+
+    func testHeaderAndRows() {
+        let result = ReportResult(
+            columns: ["A", "B"],
+            rows: [["1", "2"], ["3", "4"]]
+        )
+        XCTAssertEqual(result.csvString(), "A,B\n1,2\n3,4")
+    }
+
+    func testQuotesFieldsWithCommasAndDoublesEmbeddedQuotes() {
+        let result = ReportResult(
+            columns: ["Name", "Note"],
+            rows: [["Acme, Inc.", "He said \"hi\""]]
+        )
+        let lines = result.csvString().components(separatedBy: "\n")
+        XCTAssertEqual(lines[0], "Name,Note")
+        XCTAssertEqual(lines[1], "\"Acme, Inc.\",\"He said \"\"hi\"\"\"")
+    }
+
+    func testNilCellsBecomeEmptyFields() {
+        let result = ReportResult(columns: ["A", "B"], rows: [["x", nil]])
+        XCTAssertEqual(result.csvString(), "A,B\nx,")
+    }
+
+    func testNewlineInsideFieldIsQuoted() {
+        let result = ReportResult(columns: ["A"], rows: [["line1\nline2"]])
+        XCTAssertEqual(result.csvString(), "A\n\"line1\nline2\"")
+    }
+
+    func testEmptyResultEmitsHeaderOnly() {
+        let result = ReportResult(columns: ["A", "B"], rows: [])
+        XCTAssertEqual(result.csvString(), "A,B")
+    }
+}


### PR DESCRIPTION
## Summary

Small, generic refinements to the reporting layer so the report view looks right and is reusable. These move three things into Core that Hub had been working around app-side (per the Core/Hub boundary — generic table behaviour belongs in Core's `GenericReportView`/`ReportResult`, ERP specifics stay in Hub).

## Changes

- **`GenericReportView` top-aligns its content.** The body now fills the available space and pins header + table to the top, so a short table sits directly under the header instead of floating in the vertical centre.
- **`GenericReportView` gains `showsTitle: Bool = true`.** Hosts that already show the report name elsewhere (e.g. a navigation bar) can pass `showsTitle: false` to drop the duplicate in-view title while keeping the row count and Refresh / Export-CSV actions. Default `true` — **every existing call site is unchanged**.
- **`ReportResult.csvString()`** adds RFC-4180 CSV serialisation in `MercantisCore` (engine layer, not UI), so headless consumers (CLI, exporters, tests) can produce CSV without importing SwiftUI. The host app still owns delivery (save panel / share sheet).

## Tests

`ReportResultCSVTests` covers header+rows, comma/quote/newline escaping, nil cells, and the empty-result case.

## Notes

- Backward compatible; additive API only.
- Documented as an update in ADR-049.
- Follow-up: a Hub change adopts these (drops the `.frame` top-align hack and the `title: ""` hack, calls `ReportResult.csvString()`).

https://claude.ai/code/session_01T1wXzhcNPsQKWQKk9PWDD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1wXzhcNPsQKWQKk9PWDD2)_