### PR TITLE
Port Flutter UI widgets to Swift and expand field type support

### DIFF
--- a/mercantis core/DocumentEngine/ValidationPipeline.swift
+++ b/mercantis core/DocumentEngine/ValidationPipeline.swift
@@ -291,6 +291,39 @@ public struct TypeCoercionStage: ValidationStage {
         case .table:
             // Table fields are stored in children, not in the fields dictionary.
             return true
+        case .password, .code, .color, .signature, .geolocation, .autocomplete, .dynamicLink:
+            // String-backed editors (secure text, code, hex colour, signature JSON,
+            // lat/long string, autocomplete/dynamic-link selections).
+            if case .string = value { return true }
+            return false
+        case .tableMultiSelect:
+            // Stored as a string list today; accept the string or array shapes.
+            switch value {
+            case .string, .array: return true
+            default: return false
+            }
+        case .percent:
+            switch value {
+            case .int, .double: return true
+            case .string(let s): return Double(s) != nil
+            default: return false
+            }
+        case .rating, .duration:
+            // Whole-number editors (star count / total seconds).
+            switch value {
+            case .int, .double: return true
+            case .string(let s): return Int(s) != nil || Double(s) != nil
+            default: return false
+            }
+        case .time:
+            switch value {
+            case .dateTime, .date: return true
+            case .string(let s): return Self.parseDateTime(s) != nil || Self.parseDate(s) != nil
+            default: return false
+            }
+        case .heading, .sectionBreak, .columnBreak:
+            // Layout-only separators carry no persisted value.
+            return true
         }
     }
 

--- a/mercantis core/Metadata/FieldDefinition.swift
+++ b/mercantis core/Metadata/FieldDefinition.swift
@@ -29,6 +29,25 @@ public enum FieldType: String, Codable, Sendable, CaseIterable {
     case barcode
     case status
     case formula
+    // P-parity: field types ported from the Flutter `FieldType` enum so the
+    // Swift `GenericFormView` renders the same set of editors. Names are kept
+    // in the existing Swift camelCase style (e.g. `datetime`, `multiselect`)
+    // rather than the Dart spellings.
+    case percent
+    case time
+    case password
+    case autocomplete
+    case dynamicLink
+    case tableMultiSelect
+    case signature
+    case color
+    case duration
+    case rating
+    case code
+    case geolocation
+    case heading
+    case sectionBreak
+    case columnBreak
 }
 
 /// A value that can be assigned to a field.

--- a/mercantis core/UIShell/AttachmentsPanel.swift
+++ b/mercantis core/UIShell/AttachmentsPanel.swift
@@ -1,0 +1,262 @@
+//
+//  AttachmentsPanel.swift
+//  mercantis core
+//
+//  UI for the file-attachment engine (ADR-043). Lists / uploads / deletes
+//  the attachments bound to a saved document via `AttachmentManager`.
+//
+//  Mirrors the Flutter `attachments_panel.dart`. Drop into a record's
+//  Attachments tab. On macOS uploads use `NSOpenPanel`; iOS shows a stub
+//  note (no document-picker bridge is wired here yet).
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+#if os(macOS)
+import AppKit
+import UniformTypeIdentifiers
+#endif
+
+/// Lists, uploads, and deletes the file attachments bound to a document,
+/// backed by `AttachmentManager`.
+///
+/// The panel only operates on *saved* documents — an empty `documentId`
+/// renders a "save first" placeholder, matching the Flutter widget.
+public struct AttachmentsPanel: View {
+
+    /// The document these attachments belong to. Empty for an unsaved record.
+    private let documentId: String
+    private let docType: String
+    private let manager: AttachmentManager
+    /// Acting user id recorded on the attach / detach audit rows.
+    private let userId: String
+
+    @State private var attachments: [Attachment] = []
+    @State private var isBusy = false
+    @State private var errorMessage: String?
+    @State private var pendingDelete: Attachment?
+
+    public init(
+        documentId: String,
+        docType: String,
+        manager: AttachmentManager,
+        userId: String
+    ) {
+        self.documentId = documentId
+        self.docType = docType
+        self.manager = manager
+        self.userId = userId
+    }
+
+    public var body: some View {
+        Group {
+            if documentId.isEmpty {
+                ContentUnavailableView(
+                    "Save the document to add attachments",
+                    systemImage: "paperclip",
+                    description: Text("Attachments can be added once this record has been saved.")
+                )
+            } else {
+                content
+            }
+        }
+        .onAppear(perform: reload)
+        .confirmationDialog(
+            "Delete this attachment?",
+            isPresented: deleteDialogBinding,
+            titleVisibility: .visible,
+            presenting: pendingDelete
+        ) { attachment in
+            Button("Delete \(attachment.fileName)", role: .destructive) {
+                performDelete(attachment)
+            }
+            Button("Cancel", role: .cancel) { pendingDelete = nil }
+        } message: { _ in
+            Text("This permanently removes the file. This action cannot be undone.")
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(MercantisTheme.danger)
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(MercantisTheme.fillSoft(for: .danger), in: RoundedRectangle(cornerRadius: 8))
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
+            }
+
+            if attachments.isEmpty {
+                ContentUnavailableView(
+                    "No attachments",
+                    systemImage: "paperclip",
+                    description: Text("Use Add Attachment to upload a file to this record.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List {
+                    ForEach(attachments) { attachment in
+                        AttachmentRow(
+                            attachment: attachment,
+                            onDelete: { pendingDelete = attachment }
+                        )
+                        .disabled(isBusy)
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Text("\(attachments.count) attachment\(attachments.count == 1 ? "" : "s")")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Button(action: addAttachment) {
+                if isBusy {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Label("Add Attachment", systemImage: "square.and.arrow.up")
+                }
+            }
+            .buttonStyle(MercantisPrimaryButtonStyle())
+            .disabled(isBusy)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(
+            get: { pendingDelete != nil },
+            set: { if !$0 { pendingDelete = nil } }
+        )
+    }
+
+    // MARK: - Actions
+
+    private func reload() {
+        guard !documentId.isEmpty else { return }
+        do {
+            attachments = try manager.attachments(forDocumentId: documentId)
+            errorMessage = nil
+        } catch {
+            errorMessage = "Failed to load attachments: \((error as NSError).localizedDescription)"
+        }
+    }
+
+    private func addAttachment() {
+        guard !documentId.isEmpty else { return }
+        #if os(macOS)
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        isBusy = true
+        errorMessage = nil
+        do {
+            let data = try Data(contentsOf: url)
+            _ = try manager.attach(
+                documentId: documentId,
+                docType: docType,
+                fileName: url.lastPathComponent,
+                mimeType: Self.mimeType(for: url),
+                data: data,
+                userId: userId
+            )
+            reload()
+        } catch {
+            errorMessage = "Upload failed: \((error as NSError).localizedDescription)"
+        }
+        isBusy = false
+        #else
+        // iOS: a UIDocumentPickerViewController bridge is not wired here yet.
+        // Hosts embedding this panel on iOS should surface their own picker
+        // and call `manager.attach(...)` directly.
+        errorMessage = "File picking is not available on this platform yet."
+        #endif
+    }
+
+    private func performDelete(_ attachment: Attachment) {
+        isBusy = true
+        errorMessage = nil
+        do {
+            try manager.delete(id: attachment.id, userId: userId)
+            reload()
+        } catch {
+            errorMessage = "Delete failed: \((error as NSError).localizedDescription)"
+        }
+        pendingDelete = nil
+        isBusy = false
+    }
+
+    #if os(macOS)
+    private static func mimeType(for url: URL) -> String {
+        if let type = UTType(filenameExtension: url.pathExtension),
+           let mime = type.preferredMIMEType {
+            return mime
+        }
+        return "application/octet-stream"
+    }
+    #endif
+}
+
+/// One attachment row: file glyph, name, size + uploaded date, delete button.
+private struct AttachmentRow: View {
+    let attachment: Attachment
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "doc")
+                .font(.system(size: 18))
+                .foregroundStyle(MercantisTheme.textMuted)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(attachment.fileName)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(MercantisTheme.textPrimary)
+                Text("\(Self.humanSize(attachment.byteSize)) · \(Self.formattedDate(attachment.uploadedAt))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button(role: .destructive, action: onDelete) {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .help("Delete attachment")
+        }
+        .padding(.vertical, 4)
+    }
+
+    private static func humanSize(_ bytes: Int) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        if bytes < 1024 * 1024 { return String(format: "%.1f KB", Double(bytes) / 1024) }
+        return String(format: "%.1f MB", Double(bytes) / (1024 * 1024))
+    }
+
+    private static func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
+    }
+}

--- a/mercantis core/UIShell/DashboardResultGrid.swift
+++ b/mercantis core/UIShell/DashboardResultGrid.swift
@@ -1,0 +1,246 @@
+//
+//  DashboardResultGrid.swift
+//  mercantis core
+//
+//  Feature-parity port of the Flutter `DashboardResultGrid`
+//  (`mercantis_core_ui/lib/src/widgets/dashboard_result_grid.dart`). Renders a
+//  resolved `DashboardResult` (`Reporting/DashboardEngine.swift`) as a
+//  responsive grid of widget cards — count KPIs, lists, shortcuts, and mini
+//  chart tables — with per-widget error isolation.
+//
+//  Unlike the current `NavigationShell.dashboardDetail(dashboardId:)`, which
+//  re-counts documents inline, this grid renders the engine's typed
+//  `DashboardResult`. It can either resolve the dashboard itself (pass a
+//  `DashboardEngine` + id) or render a result the host already resolved.
+//
+//  The Swift `DashboardWidgetResult` enum has no `.sum` case (the Flutter model
+//  does) — the engine emits `.count`, `.list`, `.chart`, `.shortcut`, `.error`,
+//  so only those are rendered here. Per-widget failures arrive as
+//  `.error(title:reason:)` and render as a red-tinted card rather than blanking
+//  the grid. Wiring is described in `CORE_VIEWS_WIRING.md`.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+public struct DashboardResultGrid: View {
+
+    /// Resolved dashboard data. Either supplied directly or produced once on
+    /// appear by resolving `resolver` for `dashboardId`.
+    @State private var result: DashboardResult?
+    @State private var resolveError: String?
+    @State private var hasResolved = false
+
+    private let dashboardId: String
+    private let resolver: DashboardEngine?
+    private let userRoles: Set<String>
+    /// Called when the user taps a shortcut card. The string is the resolved
+    /// target (a docType id, report id, or explicit `target` parameter).
+    private let onShortcut: ((String) -> Void)?
+
+    /// Resolve-on-appear initializer. The grid calls
+    /// `engine.resolve(dashboardId:userRoles:)` which folds per-widget failures
+    /// into `.error` widgets (only an unknown dashboard id throws).
+    public init(
+        engine: DashboardEngine,
+        dashboardId: String,
+        userRoles: Set<String> = [],
+        onShortcut: ((String) -> Void)? = nil
+    ) {
+        self.resolver = engine
+        self.dashboardId = dashboardId
+        self.userRoles = userRoles
+        self.onShortcut = onShortcut
+        _result = State(initialValue: nil)
+    }
+
+    /// Pre-resolved initializer for hosts that already hold a `DashboardResult`.
+    public init(
+        result: DashboardResult,
+        onShortcut: ((String) -> Void)? = nil
+    ) {
+        self.resolver = nil
+        self.dashboardId = result.dashboardId
+        self.userRoles = []
+        self.onShortcut = onShortcut
+        _result = State(initialValue: result)
+        _hasResolved = State(initialValue: true)
+    }
+
+    public var body: some View {
+        Group {
+            if let resolveError {
+                ContentUnavailableView {
+                    Label("Dashboard unavailable", systemImage: "rectangle.3.group")
+                } description: {
+                    Text(resolveError)
+                }
+            } else if let result {
+                grid(for: result)
+                    .navigationTitle(result.dashboardName)
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .background(MercantisTheme.background)
+        .onAppear {
+            guard !hasResolved else { return }
+            hasResolved = true
+            resolve()
+        }
+    }
+
+    private func resolve() {
+        guard let resolver else { return }
+        do {
+            result = try resolver.resolve(dashboardId: dashboardId, userRoles: userRoles)
+            resolveError = nil
+        } catch {
+            resolveError = error.localizedDescription
+        }
+    }
+
+    private func grid(for result: DashboardResult) -> some View {
+        ScrollView {
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 240), spacing: 12)],
+                alignment: .leading,
+                spacing: 12
+            ) {
+                ForEach(Array(result.widgets.enumerated()), id: \.offset) { _, widget in
+                    DashboardWidgetCard(widget: widget, onShortcut: onShortcut)
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+/// Renders a single `DashboardWidgetResult`. Each case maps to a card style; an
+/// `.error` widget renders a red-tinted "could not load" card so one bad tile
+/// never blanks the grid.
+private struct DashboardWidgetCard: View {
+    let widget: DashboardWidgetResult
+    let onShortcut: ((String) -> Void)?
+
+    var body: some View {
+        switch widget {
+        case let .count(title, value, docType):
+            kpiCard(title: title, value: "\(value)", footnote: docType)
+
+        case let .list(title, columns, rows, _):
+            listCard(title: title, columns: columns, rows: rows)
+
+        case let .chart(title, columns, rows, _):
+            chartCard(title: title, columns: columns, rows: rows)
+
+        case let .shortcut(title, target):
+            shortcutCard(title: title, target: target)
+
+        case let .error(title, reason):
+            errorCard(title: title, reason: reason)
+        }
+    }
+
+    // MARK: - Card styles
+
+    private func kpiCard(title: String, value: String, footnote: String?) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 30, weight: .semibold, design: .rounded))
+            if let footnote, !footnote.isEmpty {
+                Text(footnote)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .mercantisCard()
+    }
+
+    private func listCard(title: String, columns: [String], rows: [[String?]]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.headline)
+            if rows.isEmpty {
+                Text("No records")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                    let values = row.compactMap { $0 }.filter { !$0.isEmpty }
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(values.first ?? "—")
+                            .font(.callout)
+                            .lineLimit(1)
+                        if values.count > 1 {
+                            Text(values.dropFirst().joined(separator: " · "))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+            }
+        }
+        .mercantisCard()
+    }
+
+    private func chartCard(title: String, columns: [String], rows: [[String?]]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.headline)
+            if rows.isEmpty {
+                Text("No data")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                // Mini table mirroring the Flutter `_miniTable` (first 5 rows).
+                ForEach(Array(rows.prefix(5).enumerated()), id: \.offset) { _, row in
+                    Text(row.map { $0 ?? "" }.joined(separator: "  ·  "))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                if rows.count > 5 {
+                    Text("+\(rows.count - 5) more")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .mercantisCard()
+    }
+
+    private func shortcutCard(title: String, target: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title).font(.headline)
+            Button("Open") {
+                if !target.isEmpty { onShortcut?(target) }
+            }
+            .buttonStyle(MercantisSecondaryButtonStyle())
+            .disabled(target.isEmpty || onShortcut == nil)
+        }
+        .mercantisCard()
+    }
+
+    private func errorCard(title: String, reason: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(title, systemImage: "exclamationmark.triangle")
+                .font(.headline)
+                .foregroundStyle(MercantisTheme.danger)
+            Text(reason)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+        }
+        .mercantisCard()
+        .overlay(
+            RoundedRectangle(cornerRadius: MercantisSpacing.cardCornerRadius, style: .continuous)
+                .stroke(MercantisTheme.danger.opacity(0.28), lineWidth: 1)
+        )
+    }
+}

--- a/mercantis core/UIShell/DocTypeBuilderView.swift
+++ b/mercantis core/UIShell/DocTypeBuilderView.swift
@@ -33,6 +33,58 @@ final class DocTypeToolingContext: ObservableObject {
     /// list / mutate fields on the active DocType.
     private(set) lazy var customFieldStore = CustomFieldStore(database: database)
 
+    /// Persistent notification inbox + log. Surfaced so the shell's Inbox
+    /// section can render real entries (mirrors the `customFieldStore` pattern).
+    private(set) lazy var notificationInbox = NotificationInbox(database: database)
+
+    /// Build a `DashboardEngine` wired to the current document/report engines and
+    /// pre-registered with every dashboard known to the workspace. The report
+    /// engine is rebuilt on each `reload()`, so this is created on demand rather
+    /// than cached.
+    func makeDashboardEngine() -> DashboardEngine {
+        let engine = DashboardEngine(
+            documentEngine: documentEngine,
+            reportEngine: reportEngine
+        )
+        dashboards.forEach { engine.register($0) }
+        return engine
+    }
+
+    /// The acting user id used for engine writes (attach/detach audit rows, etc).
+    /// Mirrors the id the document engine is constructed with.
+    var currentUserId: String { "local-user" }
+
+    /// Audit/history reader used by the record Timeline tab.
+    func makeAuditLogWriter() -> AuditLogWriter {
+        AuditLogWriter(database: database)
+    }
+
+    /// Attachment manager for the record Attachments tab. Returns `nil` if the
+    /// on-disk attachment store can't be opened beside the database.
+    func makeAttachmentManager() -> AttachmentManager? {
+        guard let store = try? AttachmentStore(beside: database) else { return nil }
+        return AttachmentManager(
+            database: database,
+            store: store,
+            auditWriter: makeAuditLogWriter()
+        )
+    }
+
+    /// CSV/JSON bulk exporter for the list Import/Export menu.
+    func makeDataExporter() -> DataExporter {
+        DataExporter(documentEngine: documentEngine, registry: registry)
+    }
+
+    /// CSV/JSON bulk importer for the list Import/Export menu.
+    func makeDataImporter() -> DataImporter {
+        DataImporter(documentEngine: documentEngine, registry: registry)
+    }
+
+    /// Print/PDF service for the record Print button (default renderers include PDF).
+    func makePrintService() -> PrintService {
+        PrintService()
+    }
+
     init() {
         let dbURL = Self.databaseURL()
         do {
@@ -1030,6 +1082,21 @@ public struct DocTypeBuilderView: View {
         case .image:                    return "photo"
         case .barcode:                  return "barcode"
         case .status:                   return "flag"
+        case .percent:                  return "percent"
+        case .time:                     return "clock"
+        case .password:                 return "lock"
+        case .autocomplete:             return "text.magnifyingglass"
+        case .dynamicLink:              return "link.badge.plus"
+        case .tableMultiSelect:         return "tablecells.badge.ellipsis"
+        case .signature:                return "signature"
+        case .color:                    return "paintpalette"
+        case .duration:                 return "timer"
+        case .rating:                   return "star"
+        case .code:                     return "chevron.left.forwardslash.chevron.right"
+        case .geolocation:              return "mappin.and.ellipse"
+        case .heading:                  return "textformat.size"
+        case .sectionBreak:             return "rectangle.split.1x2"
+        case .columnBreak:              return "rectangle.split.2x1"
         }
     }
 

--- a/mercantis core/UIShell/DocumentTimelineView.swift
+++ b/mercantis core/UIShell/DocumentTimelineView.swift
@@ -1,0 +1,282 @@
+//
+//  DocumentTimelineView.swift
+//  mercantis core
+//
+//  UI over the immutable audit log (AuditLog.swift §3.2). Renders a
+//  document's history (save / submit / cancel / amend / attach / detach …)
+//  as a vertical timeline with per-event field diffs decoded from each
+//  audit row's `{ "before": {...}, "after": {...} }` payload.
+//
+//  Mirrors the Flutter `document_timeline_view.dart` +
+//  `document_timeline_panel.dart`. Drop into the record chrome's Timeline
+//  tab. The data source is `AuditLogWriter`, whose reader API
+//  (`entries(forDocumentId:)`) returns rows oldest-first.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+/// Renders a document's audit-log history as a timeline. Newest event is
+/// shown first.
+public struct DocumentTimelineView: View {
+
+    /// The saved document's id. Empty for an unsaved document.
+    private let documentId: String
+    /// The audit-log reader. `AuditLogWriter` exposes
+    /// `entries(forDocumentId:)`, the structured audit source used here.
+    private let auditLog: AuditLogWriter
+
+    @State private var entries: [TimelineItem] = []
+    @State private var errorMessage: String?
+
+    public init(documentId: String, auditLog: AuditLogWriter) {
+        self.documentId = documentId
+        self.auditLog = auditLog
+    }
+
+    public var body: some View {
+        Group {
+            if documentId.isEmpty {
+                ContentUnavailableView(
+                    "Save the document to see activity",
+                    systemImage: "clock.arrow.circlepath",
+                    description: Text("A timeline of changes appears once this record has been saved.")
+                )
+            } else if let errorMessage {
+                ContentUnavailableView(
+                    "Couldn't load activity",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(errorMessage)
+                )
+            } else if entries.isEmpty {
+                ContentUnavailableView(
+                    "No activity yet",
+                    systemImage: "clock",
+                    description: Text("Changes to this record will be recorded here.")
+                )
+            } else {
+                timeline
+            }
+        }
+        .onAppear(perform: reload)
+    }
+
+    private var timeline: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Timeline")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(MercantisTheme.textPrimary)
+                    .padding(.bottom, 14)
+
+                ForEach(Array(entries.enumerated()), id: \.element.id) { index, item in
+                    TimelineRow(item: item, isLast: index == entries.count - 1)
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func reload() {
+        guard !documentId.isEmpty else { return }
+        do {
+            // Reader returns oldest-first; reverse for newest-first display.
+            let raw = try auditLog.entries(forDocumentId: documentId)
+            entries = raw.reversed().map(TimelineItem.init(entry:))
+            errorMessage = nil
+        } catch {
+            errorMessage = (error as NSError).localizedDescription
+        }
+    }
+}
+
+// MARK: - Timeline row
+
+private struct TimelineRow: View {
+    let item: TimelineItem
+    let isLast: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(spacing: 0) {
+                ZStack {
+                    Circle()
+                        .fill(MercantisTheme.fillSoft(for: item.tone))
+                        .frame(width: 28, height: 28)
+                    Image(systemName: item.symbol)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(MercantisTheme.tint(for: item.tone))
+                }
+                if !isLast {
+                    Rectangle()
+                        .fill(MercantisTheme.border)
+                        .frame(width: 2)
+                        .frame(maxHeight: .infinity)
+                }
+            }
+            .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(MercantisTheme.textPrimary)
+
+                if !item.diffs.isEmpty {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(item.diffs) { diff in
+                            FieldDiffRow(diff: diff)
+                        }
+                    }
+                    .padding(.top, 2)
+                }
+
+                Text(item.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.bottom, isLast ? 0 : 18)
+
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+private struct FieldDiffRow: View {
+    let diff: FieldDiff
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(diff.label)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(MercantisTheme.textMuted)
+            if let before = diff.before {
+                Text(before)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(MercantisTheme.danger)
+                    .strikethrough()
+            }
+            Image(systemName: "arrow.right")
+                .font(.system(size: 8, weight: .bold))
+                .foregroundStyle(MercantisTheme.textTertiary)
+            Text(diff.after ?? "—")
+                .font(.caption.monospaced())
+                .foregroundStyle(MercantisTheme.success)
+        }
+    }
+}
+
+// MARK: - View models
+
+private struct FieldDiff: Identifiable {
+    let id = UUID()
+    let label: String
+    let before: String?
+    let after: String?
+}
+
+private struct TimelineItem: Identifiable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let symbol: String
+    let tone: MercantisSemanticTone
+    let diffs: [FieldDiff]
+
+    init(entry: AuditLogEntry) {
+        self.id = entry.id
+        let style = Self.style(forAction: entry.action)
+        self.symbol = style.symbol
+        self.tone = style.tone
+        self.title = style.title
+
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        let when = formatter.string(from: entry.timestamp)
+        let who = entry.userId.isEmpty ? "system" : entry.userId
+        self.subtitle = "\(who) · \(when)"
+
+        self.diffs = Self.decodeDiffs(from: entry.payloadJSON)
+    }
+
+    private static func style(forAction action: String) -> (title: String, symbol: String, tone: MercantisSemanticTone) {
+        switch action.lowercased() {
+        case "save":       return ("Saved", "square.and.pencil", .info)
+        case "submit":     return ("Submitted", "paperplane.fill", .success)
+        case "cancel":     return ("Cancelled", "xmark.circle", .danger)
+        case "amend":      return ("Amended", "arrow.triangle.branch", .warning)
+        case "delete":     return ("Deleted", "trash", .danger)
+        case "applyremote": return ("Synced from server", "arrow.triangle.2.circlepath", .muted)
+        case "attach":     return ("Attached a file", "paperclip", .info)
+        case "detach":     return ("Removed a file", "paperclip.badge.ellipsis", .muted)
+        case "detachall":  return ("Removed all files", "paperclip.badge.ellipsis", .muted)
+        default:           return (action.prefix(1).uppercased() + action.dropFirst(), "circle.fill", .muted)
+        }
+    }
+
+    /// Decode the `{ "before": {fieldMap}, "after": {fieldMap} }` payload
+    /// written by `AuditLogWriter.append(... before:after:)` into a list of
+    /// human-readable field diffs. Non-diff payloads (e.g. attachment
+    /// summaries) decode to an empty list and just show the title.
+    private static func decodeDiffs(from json: String) -> [FieldDiff] {
+        guard let data = json.data(using: .utf8) else { return [] }
+        struct Wrapper: Decodable {
+            let before: [String: FieldValue]?
+            let after: [String: FieldValue]?
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let wrapper = try? decoder.decode(Wrapper.self, from: data) else { return [] }
+
+        let before = wrapper.before ?? [:]
+        let after = wrapper.after ?? [:]
+        let keys = Set(before.keys).union(after.keys).sorted()
+
+        return keys.compactMap { key in
+            let b = before[key]
+            let a = after[key]
+            let bStr = b.map(Self.display)
+            let aStr = a.map(Self.display)
+            // Skip keys that didn't actually change.
+            if bStr == aStr { return nil }
+            return FieldDiff(label: Self.humanLabel(key), before: bStr, after: aStr)
+        }
+    }
+
+    private static func display(_ value: FieldValue) -> String {
+        switch value {
+        case .string(let s): return s.isEmpty ? "—" : s
+        case .int(let i):    return String(i)
+        case .double(let d): return String(d)
+        case .bool(let b):   return b ? "true" : "false"
+        case .null:          return "—"
+        case .date(let d), .dateTime(let d):
+            let f = DateFormatter()
+            f.dateStyle = .short
+            f.timeStyle = .short
+            return f.string(from: d)
+        case .data(let d):   return "<\(d.count) bytes>"
+        case .array(let xs): return xs.map(display).joined(separator: ", ")
+        }
+    }
+
+    /// Humanise a snake_case / camelCase key into a label.
+    private static func humanLabel(_ key: String) -> String {
+        guard !key.isEmpty else { return key }
+        var spaced = ""
+        for (i, ch) in key.enumerated() {
+            if ch == "_" {
+                spaced += " "
+            } else if ch.isUppercase, i > 0 {
+                spaced += " "
+                spaced.append(ch)
+            } else {
+                spaced.append(ch)
+            }
+        }
+        return spaced.prefix(1).uppercased() + spaced.dropFirst()
+    }
+}

--- a/mercantis core/UIShell/Fields/CodeField.swift
+++ b/mercantis core/UIShell/Fields/CodeField.swift
@@ -1,0 +1,41 @@
+//
+//  CodeField.swift
+//  mercantis core
+//
+//  Feature-parity with the Flutter `CodeField` (scalar_field_widgets.dart).
+//  A monospace, multi-line text area for snippets / scripts. Stores a `String`.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+public struct CodeField: View {
+    @Binding var value: String
+    let isReadOnly: Bool
+
+    public init(value: Binding<String>, isReadOnly: Bool) {
+        self._value = value
+        self.isReadOnly = isReadOnly
+    }
+
+    public var body: some View {
+        Group {
+            if isReadOnly {
+                Text(value.isEmpty ? "—" : value)
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                TextEditor(text: $value)
+                    .font(.system(.body, design: .monospaced))
+                    .frame(minHeight: 110)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(.separator, lineWidth: 1)
+                    )
+            }
+        }
+    }
+}

--- a/mercantis core/UIShell/Fields/ColorField.swift
+++ b/mercantis core/UIShell/Fields/ColorField.swift
@@ -1,0 +1,79 @@
+//
+//  ColorField.swift
+//  mercantis core
+//
+//  Feature-parity with the Flutter `ColorField` (color_field.dart). Stores a
+//  `#RRGGBB` hex string. Shows the current swatch + hex; the native macOS/iOS
+//  `ColorPicker` drives selection, and the chosen colour is written back as an
+//  uppercase `#RRGGBB` string.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+public struct ColorField: View {
+    /// Backing `#RRGGBB` hex string ("" when unset).
+    @Binding var value: String
+    let isReadOnly: Bool
+
+    public init(value: Binding<String>, isReadOnly: Bool) {
+        self._value = value
+        self.isReadOnly = isReadOnly
+    }
+
+    private var colorBinding: Binding<Color> {
+        Binding<Color>(
+            get: { Self.parseHex(value) ?? .clear },
+            set: { value = Self.toHex($0) }
+        )
+    }
+
+    public var body: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Self.parseHex(value) ?? Color.secondary.opacity(0.2))
+                .frame(width: 24, height: 24)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(MercantisTheme.border, lineWidth: 1)
+                )
+            Text(value.isEmpty ? "No colour" : value.uppercased())
+                .foregroundStyle(value.isEmpty ? .secondary : MercantisTheme.textPrimary)
+            Spacer(minLength: 0)
+            if !isReadOnly {
+                ColorPicker("", selection: colorBinding, supportsOpacity: false)
+                    .labelsHidden()
+            }
+        }
+    }
+
+    /// Parses `#RRGGBB` (or `RRGGBB`) into a `Color`; returns nil when invalid.
+    public static func parseHex(_ hex: String?) -> Color? {
+        guard var h = hex?.trimmingCharacters(in: .whitespaces), !h.isEmpty else { return nil }
+        if h.hasPrefix("#") { h.removeFirst() }
+        guard h.count == 6, let v = UInt32(h, radix: 16) else { return nil }
+        let r = Double((v >> 16) & 0xFF) / 255.0
+        let g = Double((v >> 8) & 0xFF) / 255.0
+        let b = Double(v & 0xFF) / 255.0
+        return Color(.sRGB, red: r, green: g, blue: b, opacity: 1)
+    }
+
+    /// Encodes a `Color` to an uppercase `#RRGGBB` string.
+    public static func toHex(_ color: Color) -> String {
+#if os(macOS)
+        let resolved = NSColor(color).usingColorSpace(.sRGB) ?? NSColor(color)
+        let r = Int((resolved.redComponent * 255).rounded())
+        let g = Int((resolved.greenComponent * 255).rounded())
+        let b = Int((resolved.blueComponent * 255).rounded())
+#else
+        var rf: CGFloat = 0, gf: CGFloat = 0, bf: CGFloat = 0, af: CGFloat = 0
+        UIColor(color).getRed(&rf, green: &gf, blue: &bf, alpha: &af)
+        let r = Int((rf * 255).rounded())
+        let g = Int((gf * 255).rounded())
+        let b = Int((bf * 255).rounded())
+#endif
+        return String(format: "#%02X%02X%02X", r, g, b)
+    }
+}

--- a/mercantis core/UIShell/Fields/DurationField.swift
+++ b/mercantis core/UIShell/Fields/DurationField.swift
@@ -1,0 +1,71 @@
+//
+//  DurationField.swift
+//  mercantis core
+//
+//  Feature-parity with the Flutter `DurationField` (scalar_field_widgets.dart).
+//  Hours + minutes entry. Stores total seconds as an `Int` (matching the
+//  Flutter storage), surfaced here through an `Int` binding.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+public struct DurationField: View {
+    /// Total duration in seconds. 0 means "unset".
+    @Binding var seconds: Int
+    let isReadOnly: Bool
+
+    public init(seconds: Binding<Int>, isReadOnly: Bool) {
+        self._seconds = seconds
+        self.isReadOnly = isReadOnly
+    }
+
+    private var hoursBinding: Binding<String> {
+        Binding<String>(
+            get: { seconds / 3600 == 0 ? "" : "\(seconds / 3600)" },
+            set: { recompute(hours: Int($0), minutes: nil) }
+        )
+    }
+
+    private var minutesBinding: Binding<String> {
+        Binding<String>(
+            get: { (seconds % 3600) / 60 == 0 ? "" : "\((seconds % 3600) / 60)" },
+            set: { recompute(hours: nil, minutes: Int($0)) }
+        )
+    }
+
+    private func recompute(hours: Int?, minutes: Int?) {
+        let h = hours ?? (seconds / 3600)
+        let m = minutes ?? ((seconds % 3600) / 60)
+        seconds = (h * 3600) + (m * 60)
+    }
+
+    public var body: some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 4) {
+                TextField("0", text: hoursBinding)
+                    .mercantisInput()
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: 56)
+                    .disabled(isReadOnly)
+#if os(iOS)
+                    .keyboardType(.numberPad)
+#endif
+                Text("h").foregroundStyle(MercantisTheme.textMuted)
+            }
+            HStack(spacing: 4) {
+                TextField("0", text: minutesBinding)
+                    .mercantisInput()
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: 56)
+                    .disabled(isReadOnly)
+#if os(iOS)
+                    .keyboardType(.numberPad)
+#endif
+                Text("m").foregroundStyle(MercantisTheme.textMuted)
+            }
+        }
+    }
+}

--- a/mercantis core/UIShell/Fields/RatingField.swift
+++ b/mercantis core/UIShell/Fields/RatingField.swift
@@ -1,0 +1,43 @@
+//
+//  RatingField.swift
+//  mercantis core
+//
+//  Feature-parity with the Flutter `RatingField` (scalar_field_widgets.dart).
+//  A 1–5 tappable star picker. Stores an `Int` (0 = no rating). Tapping the
+//  current rating again clears it.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+public struct RatingField: View {
+    @Binding var value: Int
+    let isReadOnly: Bool
+    let max: Int
+
+    public init(value: Binding<Int>, isReadOnly: Bool, max: Int = 5) {
+        self._value = value
+        self.isReadOnly = isReadOnly
+        self.max = max
+    }
+
+    public var body: some View {
+        HStack(spacing: 4) {
+            ForEach(1...max, id: \.self) { i in
+                Button {
+                    guard !isReadOnly else { return }
+                    // Tapping the current rating again clears it.
+                    value = (i == value) ? 0 : i
+                } label: {
+                    Image(systemName: i <= value ? "star.fill" : "star")
+                        .foregroundStyle(i <= value ? Color.yellow : MercantisTheme.textMuted)
+                        .font(.system(size: 18))
+                }
+                .buttonStyle(.plain)
+                .disabled(isReadOnly)
+            }
+        }
+    }
+}

--- a/mercantis core/UIShell/Fields/SignatureField.swift
+++ b/mercantis core/UIShell/Fields/SignatureField.swift
@@ -1,0 +1,137 @@
+//
+//  SignatureField.swift
+//  mercantis core
+//
+//  Feature-parity with the Flutter `SignatureField` (signature_field.dart).
+//  Captures freehand strokes via a drag gesture on a `Canvas` and stores them
+//  as JSON with normalised (0..1) coordinates, so a signature re-renders at any
+//  size. The stored shape matches Flutter exactly:
+//
+//      {"strokes": [[[x, y], [x, y], ...], ...]}
+//
+//  so signatures round-trip between the Swift and Flutter apps.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+public struct SignatureField: View {
+    /// Backing JSON string ("" when unset).
+    @Binding var value: String
+    let isReadOnly: Bool
+
+    /// Live strokes in normalised (0..1) coordinates.
+    @State private var strokes: [[CGPoint]]
+    @State private var canvasSize: CGSize = .zero
+
+    public init(value: Binding<String>, isReadOnly: Bool) {
+        self._value = value
+        self.isReadOnly = isReadOnly
+        _strokes = State(initialValue: Self.decodeStrokes(value.wrappedValue))
+    }
+
+    private var hasSignature: Bool { strokes.contains { !$0.isEmpty } }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            GeometryReader { geo in
+                Canvas { context, size in
+                    var path = Path()
+                    for stroke in strokes where !stroke.isEmpty {
+                        let scaled = stroke.map { CGPoint(x: $0.x * size.width, y: $0.y * size.height) }
+                        if scaled.count == 1 {
+                            // A single tap — draw a dot.
+                            let p = scaled[0]
+                            path.addEllipse(in: CGRect(x: p.x - 1.25, y: p.y - 1.25, width: 2.5, height: 2.5))
+                        } else {
+                            path.move(to: scaled[0])
+                            for p in scaled.dropFirst() { path.addLine(to: p) }
+                        }
+                    }
+                    context.stroke(
+                        path,
+                        with: .color(MercantisTheme.textPrimary),
+                        style: StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round)
+                    )
+                }
+                .background(
+                    Group {
+                        if !hasSignature {
+                            Text(isReadOnly ? "No signature" : "Drag to sign")
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                )
+                .contentShape(Rectangle())
+                .gesture(
+                    isReadOnly ? nil : DragGesture(minimumDistance: 0)
+                        .onChanged { v in
+                            let size = geo.size
+                            canvasSize = size
+                            guard size.width > 0, size.height > 0 else { return }
+                            let norm = CGPoint(
+                                x: min(max(v.location.x / size.width, 0), 1),
+                                y: min(max(v.location.y / size.height, 0), 1)
+                            )
+                            if v.translation == .zero {
+                                // Gesture just began — start a new stroke.
+                                strokes.append([norm])
+                            } else if !strokes.isEmpty {
+                                strokes[strokes.count - 1].append(norm)
+                            }
+                        }
+                        .onEnded { _ in commit() }
+                )
+            }
+            .frame(height: 140)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(MercantisTheme.border, lineWidth: 1)
+            )
+
+            if !isReadOnly && hasSignature {
+                Button {
+                    strokes = []
+                    value = ""
+                } label: {
+                    Label("Clear", systemImage: "xmark.circle")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+            }
+        }
+    }
+
+    private func commit() {
+        value = hasSignature ? Self.encodeStrokes(strokes) : ""
+    }
+
+    // MARK: - Encoding (matches Flutter signature_field.dart)
+
+    private struct Envelope: Codable {
+        let strokes: [[[Double]]]
+    }
+
+    /// Decodes the stored JSON into normalised strokes. Tolerates nil / malformed
+    /// input by returning an empty list.
+    public static func decodeStrokes(_ raw: String?) -> [[CGPoint]] {
+        guard let raw, !raw.isEmpty, let data = raw.data(using: .utf8) else { return [] }
+        guard let env = try? JSONDecoder().decode(Envelope.self, from: data) else { return [] }
+        return env.strokes.map { stroke in
+            stroke.compactMap { p in
+                p.count >= 2 ? CGPoint(x: p[0], y: p[1]) : nil
+            }
+        }
+    }
+
+    /// Encodes normalised strokes to the stored JSON shape.
+    public static func encodeStrokes(_ strokes: [[CGPoint]]) -> String {
+        let env = Envelope(strokes: strokes.map { $0.map { [Double($0.x), Double($0.y)] } })
+        guard let data = try? JSONEncoder().encode(env),
+              let s = String(data: data, encoding: .utf8) else { return "" }
+        return s
+    }
+}

--- a/mercantis core/UIShell/GenericFormView.swift
+++ b/mercantis core/UIShell/GenericFormView.swift
@@ -203,7 +203,12 @@ public struct GenericFormView: View {
     private func fieldRow(for field: FieldDefinition, stacked: Bool) -> some View {
         let isReadOnly = isReadOnly(field: field)
 
-        if stacked || usesStackedLayout(field) {
+        if isLayoutSeparator(field) {
+            // Headings / section / column breaks are pure layout — they carry
+            // their own label and span the full width with no leading label cell.
+            layoutSeparator(field: field)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else if stacked || usesStackedLayout(field) {
             VStack(alignment: .leading, spacing: 5) {
                 fieldLabel(for: field)
                     .font(.system(size: 11, weight: .medium))
@@ -243,7 +248,9 @@ public struct GenericFormView: View {
 
     private func usesStackedLayout(_ field: FieldDefinition) -> Bool {
         switch field.type {
-        case .longText, .richText, .table, .multiselect, .image:
+        case .longText, .richText, .table, .multiselect, .image,
+             .code, .signature, .tableMultiSelect,
+             .heading, .sectionBreak, .columnBreak:
             return true
         default:
             return false
@@ -255,22 +262,55 @@ public struct GenericFormView: View {
         switch field.type {
         case .text, .email, .phone:
             textField(field: field, isReadOnly: isReadOnly)
-        case .longText:
-            longTextField(field: field, isReadOnly: isReadOnly)
+        case .longText, .code:
+            // `.code` renders a monospaced multi-line editor; `.longText` keeps
+            // the plain TextEditor below.
+            if field.type == .code {
+                codeField(field: field, isReadOnly: isReadOnly)
+            } else {
+                longTextField(field: field, isReadOnly: isReadOnly)
+            }
         case .richText:
             richTextField(field: field, isReadOnly: isReadOnly)
         case .number, .decimal, .currency:
             numberField(field: field, isReadOnly: isReadOnly)
+        case .percent:
+            percentField(field: field, isReadOnly: isReadOnly)
         case .boolean:
             toggleField(field: field, isReadOnly: isReadOnly)
         case .date, .datetime:
             dateField(field: field, isReadOnly: isReadOnly)
+        case .time:
+            timeField(field: field, isReadOnly: isReadOnly)
         case .select, .status:
             selectField(field: field, isReadOnly: isReadOnly)
-        case .multiselect:
+        case .multiselect, .tableMultiSelect:
+            // `.tableMultiSelect` has no dedicated Swift editor yet; it falls
+            // back to the chip-style multiselect (closest existing editor),
+            // matching the Flutter app's graceful degradation.
             multiselectField(field: field, isReadOnly: isReadOnly)
-        case .link:
+        case .link, .dynamicLink:
+            // `.dynamicLink` falls back to the standard link picker.
             linkField(field: field, isReadOnly: isReadOnly)
+        case .autocomplete:
+            // No bespoke autocomplete editor; degrade to plain text entry.
+            textField(field: field, isReadOnly: isReadOnly)
+        case .password:
+            passwordField(field: field, isReadOnly: isReadOnly)
+        case .rating:
+            ratingField(field: field, isReadOnly: isReadOnly)
+        case .duration:
+            durationField(field: field, isReadOnly: isReadOnly)
+        case .color:
+            colorField(field: field, isReadOnly: isReadOnly)
+        case .signature:
+            signatureField(field: field, isReadOnly: isReadOnly)
+        case .geolocation:
+            // No map picker yet; degrade to plain text entry (lat,lng string),
+            // matching the Flutter app's text-based geolocation fallback.
+            textField(field: field, isReadOnly: isReadOnly)
+        case .heading, .sectionBreak, .columnBreak:
+            layoutSeparator(field: field)
         case .formula:
             formulaField(field: field)
         case .table:
@@ -536,6 +576,108 @@ public struct GenericFormView: View {
         BarcodeField(value: stringBinding(for: field), isReadOnly: isReadOnly)
     }
 
+    // MARK: - Parity field controls
+
+    /// `.percent` — numeric entry with a trailing `%` suffix. Stores a Double.
+    private func percentField(field: FieldDefinition, isReadOnly: Bool) -> some View {
+        let strBinding = numberBinding(for: field)
+        return Group {
+            if isReadOnly {
+                Text(strBinding.wrappedValue.isEmpty ? "—" : "\(strBinding.wrappedValue)%")
+                    .foregroundStyle(.secondary)
+            } else {
+                HStack(spacing: 4) {
+                    TextField(field.label, text: strBinding)
+                        .textFieldStyle(.roundedBorder)
+                        .labelsHidden()
+                        .multilineTextAlignment(.trailing)
+#if os(iOS)
+                        .keyboardType(.decimalPad)
+#endif
+                    Text("%").foregroundStyle(MercantisTheme.textMuted)
+                }
+            }
+        }
+    }
+
+    /// `.password` — masked entry backed by `SecureField`. Stores a String.
+    private func passwordField(field: FieldDefinition, isReadOnly: Bool) -> some View {
+        let binding = stringBinding(for: field)
+        return Group {
+            if isReadOnly {
+                Text(binding.wrappedValue.isEmpty ? "—" : "••••••••")
+                    .foregroundStyle(.secondary)
+            } else {
+                SecureField(field.label, text: binding)
+                    .textFieldStyle(.roundedBorder)
+                    .labelsHidden()
+            }
+        }
+    }
+
+    /// `.time` — time-only picker. Persists the selection as the typed
+    /// `.dateTime` FieldValue (only the hour/minute components are displayed).
+    private func timeField(field: FieldDefinition, isReadOnly: Bool) -> some View {
+        DatePicker(
+            "",
+            selection: timeBinding(for: field),
+            displayedComponents: [.hourAndMinute]
+        )
+        .labelsHidden()
+        .disabled(isReadOnly)
+    }
+
+    private func ratingField(field: FieldDefinition, isReadOnly: Bool) -> some View {
+        RatingField(value: intBinding(for: field), isReadOnly: isReadOnly)
+    }
+
+    private func durationField(field: FieldDefinition, isReadOnly: Bool) -> some View {
+        DurationField(seconds: intBinding(for: field), isReadOnly: isReadOnly)
+    }
+
+    private func codeField(field: FieldDefinition, isReadOnly: Bool) -> some View {
+        CodeField(value: stringBinding(for: field), isReadOnly: isReadOnly)
+    }
+
+    private func colorField(field: FieldDefinition, isReadOnly: Bool) -> some View {
+        ColorField(value: stringBinding(for: field), isReadOnly: isReadOnly)
+    }
+
+    private func signatureField(field: FieldDefinition, isReadOnly: Bool) -> some View {
+        SignatureField(value: stringBinding(for: field), isReadOnly: isReadOnly)
+    }
+
+    private func isLayoutSeparator(_ field: FieldDefinition) -> Bool {
+        switch field.type {
+        case .heading, .sectionBreak, .columnBreak: return true
+        default: return false
+        }
+    }
+
+    /// `.heading` / `.sectionBreak` / `.columnBreak` — non-editable layout
+    /// separators. A heading renders its label as a bold title; the breaks
+    /// render a divider (with the label as a caption when present).
+    @ViewBuilder
+    private func layoutSeparator(field: FieldDefinition) -> some View {
+        switch field.type {
+        case .heading:
+            Text(field.label)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(MercantisTheme.textPrimary)
+                .padding(.top, 4)
+        default:
+            VStack(alignment: .leading, spacing: 4) {
+                if !field.label.isEmpty {
+                    Text(field.label.uppercased())
+                        .font(.system(size: 11, weight: .semibold))
+                        .tracking(0.5)
+                        .foregroundStyle(MercantisTheme.textMuted)
+                }
+                Divider()
+            }
+        }
+    }
+
     private func formulaField(field: FieldDefinition) -> some View {
         let computed = field.formulaExpression.flatMap { expr in
             try? expressionEvaluator.evaluateFormula(expression: expr, context: document.fields)
@@ -610,6 +752,41 @@ public struct GenericFormView: View {
                 default:
                     document.fields[field.key] = .string(ISO8601DateFormatter().string(from: newValue))
                 }
+            }
+        )
+    }
+
+    /// Integer-backed binding used by rating (stars) and duration (seconds).
+    /// Tolerates a stored Double or numeric String and always writes `.int`.
+    private func intBinding(for field: FieldDefinition) -> Binding<Int> {
+        Binding<Int>(
+            get: {
+                switch document.fields[field.key] {
+                case .int(let i): return i
+                case .double(let d): return Int(d.rounded())
+                case .string(let s): return Int(s) ?? 0
+                default: return 0
+                }
+            },
+            set: { newValue in
+                document.fields[field.key] = .int(newValue)
+            }
+        )
+    }
+
+    /// Time-only binding. Reads/writes the typed `.dateTime` FieldValue; only
+    /// the hour/minute components are surfaced through the picker.
+    private func timeBinding(for field: FieldDefinition) -> Binding<Date> {
+        Binding<Date>(
+            get: {
+                switch document.fields[field.key] {
+                case .dateTime(let d), .date(let d): return d
+                case .string(let s): return ISO8601DateFormatter().date(from: s) ?? Date()
+                default: return Date()
+                }
+            },
+            set: { newValue in
+                document.fields[field.key] = .dateTime(newValue)
             }
         )
     }

--- a/mercantis core/UIShell/ImportExportMenu.swift
+++ b/mercantis core/UIShell/ImportExportMenu.swift
@@ -1,0 +1,152 @@
+//
+//  ImportExportMenu.swift
+//  mercantis core
+//
+//  UI for the bulk import / export engine (ADR-046). A SwiftUI `Menu`
+//  offering Export CSV, Export JSON, and Import-from-file for one DocType's
+//  list. On macOS, Export uses `NSSavePanel` and Import uses `NSOpenPanel`.
+//
+//  Mirrors the Flutter `import_export_menu.dart`. Drop into a list
+//  workspace's overflow / toolbar. `onChanged` fires after a successful
+//  import so the host can refresh the list it renders.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+#if os(macOS)
+import AppKit
+import UniformTypeIdentifiers
+#endif
+
+/// Import / Export menu for a single DocType, backed by `DataExporter` and
+/// `DataImporter`.
+public struct ImportExportMenu: View {
+
+    private let docType: String
+    private let exporter: DataExporter
+    private let importer: DataImporter
+    /// Called after a successful import so the host can reload its list.
+    private let onChanged: (() -> Void)?
+
+    @State private var resultMessage: String?
+    @State private var resultIsError = false
+    @State private var showResult = false
+
+    public init(
+        docType: String,
+        exporter: DataExporter,
+        importer: DataImporter,
+        onChanged: (() -> Void)? = nil
+    ) {
+        self.docType = docType
+        self.exporter = exporter
+        self.importer = importer
+        self.onChanged = onChanged
+    }
+
+    public var body: some View {
+        Menu {
+            Button {
+                export(format: .csv)
+            } label: {
+                Label("Export CSV", systemImage: "tablecells")
+            }
+            Button {
+                export(format: .json)
+            } label: {
+                Label("Export JSON", systemImage: "curlybraces")
+            }
+            Divider()
+            Button {
+                runImport()
+            } label: {
+                Label("Import…", systemImage: "square.and.arrow.down")
+            }
+        } label: {
+            Label("Import / Export", systemImage: "arrow.up.arrow.down.circle")
+        }
+        .accessibilityLabel("Import or export records")
+        .alert(resultIsError ? "Operation failed" : "Done", isPresented: $showResult) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(resultMessage ?? "")
+        }
+    }
+
+    // MARK: - Export
+
+    private func export(format: ImportExportFormat) {
+        #if os(macOS)
+        do {
+            let data = try exporter.export(docType: docType, format: format)
+            let panel = NSSavePanel()
+            panel.nameFieldStringValue = "\(docType).\(format.rawValue)"
+            if let type = Self.contentType(for: format) {
+                panel.allowedContentTypes = [type]
+            }
+            guard panel.runModal() == .OK, let url = panel.url else { return }
+            try data.write(to: url, options: .atomic)
+            present("Exported \(docType) to \(url.lastPathComponent).", isError: false)
+        } catch {
+            present("Export failed: \((error as NSError).localizedDescription)", isError: true)
+        }
+        #else
+        present("Export is not available on this platform yet.", isError: true)
+        #endif
+    }
+
+    // MARK: - Import
+
+    private func runImport() {
+        #if os(macOS)
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [.commaSeparatedText, .json].compactMap { $0 }
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let format: ImportExportFormat =
+                url.pathExtension.lowercased() == "json" ? .json : .csv
+            let report = try importer.import(docType: docType, data: data, format: format)
+            onChanged?()
+            present(Self.summary(report), isError: report.failedCount > 0)
+        } catch {
+            present("Import failed: \((error as NSError).localizedDescription)", isError: true)
+        }
+        #else
+        present("Import is not available on this platform yet.", isError: true)
+        #endif
+    }
+
+    // MARK: - Helpers
+
+    private func present(_ message: String, isError: Bool) {
+        resultMessage = message
+        resultIsError = isError
+        showResult = true
+    }
+
+    private static func summary(_ report: ImportReport) -> String {
+        """
+        \(report.rowsRead) rows read
+        Inserted: \(report.insertedCount)
+        Updated: \(report.updatedCount)
+        Skipped: \(report.skippedCount)
+        Failed: \(report.failedCount)
+        """
+    }
+
+    #if os(macOS)
+    private static func contentType(for format: ImportExportFormat) -> UTType? {
+        switch format {
+        case .csv:  return .commaSeparatedText
+        case .json: return .json
+        }
+    }
+    #endif
+}

--- a/mercantis core/UIShell/NavigationShell.swift
+++ b/mercantis core/UIShell/NavigationShell.swift
@@ -317,21 +317,11 @@ public struct NavigationShell: View {
     }
 
     private var settingsContext: some View {
-        List {
-            Label("Metadata-Driven UI", systemImage: "checkmark.seal")
-            Label("Sync Engine", systemImage: "arrow.triangle.2.circlepath")
-            Label("Workspace Settings", systemImage: "gear")
-        }
-        .navigationTitle("Settings")
+        SettingsView()
     }
 
     private var inboxContext: some View {
-        List {
-            Label("Workflow Approvals", systemImage: "tray")
-            Label("Mentions", systemImage: "at")
-            Label("System Alerts", systemImage: "bell")
-        }
-        .navigationTitle("Inbox")
+        NotificationInboxView(inbox: tooling.notificationInbox)
     }
 
     private var homeDetail: some View {
@@ -443,27 +433,12 @@ public struct NavigationShell: View {
     private func reportDetail(reportId: String) -> some View {
         if let report = tooling.report(withId: reportId),
            let result = tooling.executeReport(report) {
-            List {
-                Section {
-                    Text("\(result.rowCount) rows")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                ForEach(Array(result.rows.enumerated()), id: \.offset) { _, row in
-                    VStack(alignment: .leading, spacing: 4) {
-                        ForEach(Array(result.columns.enumerated()), id: \.offset) { index, column in
-                            HStack {
-                                Text(column)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                Spacer()
-                                Text(row[index] ?? "—")
-                            }
-                        }
-                    }
-                    .padding(.vertical, 4)
-                }
-            }
+            ReportResultView(
+                title: report.name,
+                result: result,
+                showsTitle: false,
+                onRefresh: nil
+            )
             .navigationTitle(report.name)
         } else {
             ContentUnavailableView("Report unavailable", systemImage: "chart.bar")
@@ -472,35 +447,19 @@ public struct NavigationShell: View {
 
     @ViewBuilder
     private func dashboardDetail(dashboardId: String) -> some View {
-        if let dashboard = tooling.dashboard(withId: dashboardId) {
-            ScrollView {
-                LazyVGrid(columns: [GridItem(.adaptive(minimum: 220), spacing: 12)], spacing: 12) {
-                    ForEach(Array(dashboard.widgets.enumerated()), id: \.offset) { _, widget in
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text(widget.title)
-                                .font(.headline)
-                            if let docType = widget.docType {
-                                Text("\(tooling.listDocuments(docTypeId: docType).count) records")
-                                    .foregroundStyle(.secondary)
-                                Button("Open \(docType)") {
-                                    router.openDocType(docType, module: tooling.docType(withId: docType)?.module)
-                                }
-                                .buttonStyle(MercantisSecondaryButtonStyle())
-                            } else if let reportId = widget.reportId {
-                                Button("Open Report") {
-                                    router.openReport(reportId, module: tooling.report(withId: reportId).flatMap(moduleForReport))
-                                }
-                                .buttonStyle(MercantisSecondaryButtonStyle())
-                            } else {
-                                Text(widget.type.capitalized)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .mercantisCard()
+        if tooling.dashboard(withId: dashboardId) != nil {
+            DashboardResultGrid(
+                engine: tooling.makeDashboardEngine(),
+                dashboardId: dashboardId,
+                userRoles: [],
+                onShortcut: { target in
+                    if let dt = tooling.docType(withId: target) {
+                        router.openDocType(target, module: dt.module)
+                    } else if let report = tooling.report(withId: target) {
+                        router.openReport(target, module: moduleForReport(report))
                     }
                 }
-                .padding()
-            }
+            )
             .navigationTitle(dashboard.name)
         } else {
             ContentUnavailableView("Dashboard unavailable", systemImage: "rectangle.3.group")
@@ -993,6 +952,91 @@ struct WorkspaceDefinition: Identifiable, Hashable {
     ]
 }
 
+/// Detail-pane tab container that surfaces the record's Form, audit Timeline,
+/// and Attachments alongside each other. Introduced at the shell call site
+/// (rather than baked into `RecordCollectionHostView`) so the host's
+/// `RecordViewMode` stays list/browse/detail.
+private struct RecordDetailTabs: View {
+    let docType: DocType
+    @Binding var document: Document
+    let attachmentManager: AttachmentManager?
+    let auditLog: AuditLogWriter
+    let userId: String
+
+    private enum Tab: String, CaseIterable, Identifiable {
+        case form, timeline, files
+        var id: String { rawValue }
+        var title: String {
+            switch self {
+            case .form: return "Form"
+            case .timeline: return "Timeline"
+            case .files: return "Attachments"
+            }
+        }
+    }
+
+    @State private var tab: Tab = .form
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("", selection: $tab) {
+                ForEach(Tab.allCases) { t in
+                    Text(t.title).tag(t)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(.horizontal)
+            .padding(.vertical, 6)
+
+            switch tab {
+            case .form:
+                GenericFormView(docType: docType, document: $document)
+            case .timeline:
+                DocumentTimelineView(documentId: document.id, auditLog: auditLog)
+            case .files:
+                if let attachmentManager {
+                    AttachmentsPanel(
+                        documentId: document.id,
+                        docType: document.docType,
+                        manager: attachmentManager,
+                        userId: userId
+                    )
+                } else {
+                    ContentUnavailableView(
+                        "Attachments unavailable",
+                        systemImage: "paperclip",
+                        description: Text("The attachment store could not be opened.")
+                    )
+                }
+            }
+        }
+    }
+}
+
+/// Builds a sensible default `PrintFormat` for a record: a heading, a grid over
+/// the scalar fields, and a section per child table. Mirrors the Flutter
+/// auto-format used by the print button.
+private func autoPrintFormat(for document: Document, docType: DocType) -> PrintFormat {
+    let scalarKeys = docType.fields
+        .filter { $0.type != .table && $0.type != .formula }
+        .map(\.key)
+    let tableKeys = docType.fields
+        .filter { $0.type == .table }
+        .map(\.key)
+    var sections: [PrintSection] = [
+        .heading(text: docType.name),
+        .fields(keys: scalarKeys)
+    ]
+    sections.append(contentsOf: tableKeys.map { PrintSection.table(tableKey: $0, columns: []) })
+    return PrintFormat(
+        id: "auto-\(docType.id)",
+        name: docType.name,
+        docType: docType.id,
+        sections: sections
+    )
+}
+
 /// Small wrapper that owns the per-DocType custom-field state and bridges
 /// the tooling context to `RecordCollectionHostView`. Extracted from
 /// `NavigationShell.docTypeDetail` because the host's customize hooks
@@ -1011,6 +1055,14 @@ private struct DocTypeWorkspaceContainer: View {
 
     var body: some View {
         let documents = tooling.listDocuments(docTypeId: docType.id)
+        // Engines backing the record workspace capstones (attachments, timeline,
+        // print, import/export). Lightweight wrappers built from the tooling context.
+        let attachmentManager = tooling.makeAttachmentManager()
+        let auditLog = tooling.makeAuditLogWriter()
+        let printService = tooling.makePrintService()
+        let exporter = tooling.makeDataExporter()
+        let importer = tooling.makeDataImporter()
+        let actingUserId = tooling.currentUserId
         return VStack(spacing: 0) {
             if let errorMessage {
                 Text(errorMessage)
@@ -1033,6 +1085,16 @@ private struct DocTypeWorkspaceContainer: View {
                     let draft = tooling.createDraftDocument(for: docType)
                     onRecordTouched(docType.id)
                     return draft
+                },
+                workspaceOverflowMenu: {
+                    AnyView(
+                        ImportExportMenu(
+                            docType: docType.id,
+                            exporter: exporter,
+                            importer: importer,
+                            onChanged: { tooling.objectWillChange.send() }
+                        )
+                    )
                 },
                 onSaveDocument: { document in
                     let saved = try tooling.saveDocument(document)
@@ -1066,8 +1128,40 @@ private struct DocTypeWorkspaceContainer: View {
                         onRecordTouched(selected.id)
                     }
                 },
-                detailHeader: detailHeaderForModule,
-                externalCreateTrigger: externalCreateTrigger
+                detailHeader: { document in
+                    // Module workspace keeps its bespoke header; every other DocType
+                    // gets a record header carrying the Print/PDF action.
+                    if let detailHeaderForModule {
+                        return detailHeaderForModule(document)
+                    }
+                    return AnyView(
+                        SelectedRecordHeader(
+                            title: document.id.isEmpty ? "New \(docType.name)" : document.id,
+                            subtitle: document.status,
+                            actions: {
+                                AnyView(
+                                    PrintRecordButton(
+                                        document: document,
+                                        printService: printService,
+                                        formatResolver: { doc in autoPrintFormat(for: doc, docType: docType) }
+                                    )
+                                )
+                            }
+                        )
+                    )
+                },
+                externalCreateTrigger: externalCreateTrigger,
+                detailEditor: { dt, documentBinding in
+                    AnyView(
+                        RecordDetailTabs(
+                            docType: dt,
+                            document: documentBinding,
+                            attachmentManager: attachmentManager,
+                            auditLog: auditLog,
+                            userId: actingUserId
+                        )
+                    )
+                }
             )
         }
         .onAppear { reloadCustomFields() }

--- a/mercantis core/UIShell/NotificationInboxView.swift
+++ b/mercantis core/UIShell/NotificationInboxView.swift
@@ -1,0 +1,215 @@
+//
+//  NotificationInboxView.swift
+//  mercantis core
+//
+//  Feature-parity port of the Flutter `NotificationInboxView`
+//  (`mercantis_core_ui/lib/src/widgets/notification_inbox_view.dart`). Reader
+//  UI over the in-app notification inbox (ADR-048): lists a recipient's
+//  notifications with unread styling, tap-to-mark-read, "Mark all read", and
+//  swipe-to-delete.
+//
+//  Backed by `NotificationInbox` (`Notifications/NotificationInbox.swift`).
+//  That reader API is synchronous + throwing (GRDB), so this view loads entries
+//  into `@State` and reloads after every mutation rather than observing a
+//  publisher. The host supplies the inbox via `init`; wiring is described in
+//  `CORE_VIEWS_WIRING.md`.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+public struct NotificationInboxView: View {
+
+    /// The inbox reader. Held as a plain reference (the type is a `final class`,
+    /// not an `ObservableObject`); this view drives its own reload state.
+    private let inbox: NotificationInbox
+    /// Whose feed to show. `nil` = the global (unaddressed) feed, matching the
+    /// inbox's `recipient: nil` semantics.
+    private let recipient: String?
+
+    @State private var items: [NotificationInboxItem] = []
+    @State private var loadError: String?
+    @State private var hasLoaded = false
+
+    public init(inbox: NotificationInbox, recipient: String? = nil) {
+        self.inbox = inbox
+        self.recipient = recipient
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+        .background(MercantisTheme.background)
+        .navigationTitle("Inbox")
+        .onAppear {
+            if !hasLoaded {
+                hasLoaded = true
+                reload()
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Text("Notifications")
+                .font(.title3.weight(.semibold))
+            if unreadCount > 0 {
+                Text("\(unreadCount)")
+                    .mercantisSemanticBadge(tone: .brand)
+            }
+            Spacer()
+            Button("Mark all read", systemImage: "checkmark.circle") {
+                markAllRead()
+            }
+            .buttonStyle(MercantisSecondaryButtonStyle())
+            .disabled(unreadCount == 0)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if let loadError {
+            ContentUnavailableView {
+                Label("Couldn't load notifications", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(loadError)
+            } actions: {
+                Button("Retry") { reload() }
+                    .buttonStyle(MercantisSecondaryButtonStyle())
+            }
+        } else if items.isEmpty {
+            ContentUnavailableView(
+                "No notifications",
+                systemImage: "bell.slash",
+                description: Text("You're all caught up.")
+            )
+        } else {
+            List {
+                ForEach(items) { item in
+                    NotificationInboxRow(item: item) {
+                        markRead(item)
+                    }
+                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                        Button(role: .destructive) {
+                            delete(item)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+        }
+    }
+
+    // MARK: - State
+
+    private var unreadCount: Int {
+        items.lazy.filter { !$0.isRead }.count
+    }
+
+    // MARK: - Actions
+
+    private func reload() {
+        do {
+            items = try inbox.entries(forRecipient: recipient)
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    private func markRead(_ item: NotificationInboxItem) {
+        guard !item.isRead else { return }
+        do {
+            try inbox.markRead(id: item.id)
+            reload()
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    private func markAllRead() {
+        do {
+            try inbox.markAllRead(forRecipient: recipient)
+            reload()
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    private func delete(_ item: NotificationInboxItem) {
+        do {
+            try inbox.delete(id: item.id)
+            reload()
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+}
+
+/// One inbox row. Unread rows show a filled dot + bold subject (mirroring the
+/// Flutter `ListTile` styling) and a tap target that marks the row read.
+private struct NotificationInboxRow: View {
+    let item: NotificationInboxItem
+    let onMarkRead: () -> Void
+
+    var body: some View {
+        Button(action: { if !item.isRead { onMarkRead() } }) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: item.isRead ? "bell" : "circle.fill")
+                    .font(item.isRead ? .body : .system(size: 10))
+                    .foregroundStyle(item.isRead ? Color.secondary : MercantisTheme.accent)
+                    .frame(width: 18, alignment: .center)
+                    .padding(.top, item.isRead ? 0 : 4)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(subjectText)
+                        .font(.body)
+                        .fontWeight(item.isRead ? .regular : .semibold)
+                    if !item.body.isEmpty {
+                        Text(item.body)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(3)
+                    }
+                    Text(Self.formatted(item.emittedAt))
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                Spacer(minLength: 0)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(item.isRead)
+    }
+
+    private var subjectText: String {
+        item.subject.isEmpty ? "(no subject)" : item.subject
+    }
+
+    private static let formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        return f
+    }()
+
+    private static func formatted(_ date: Date) -> String {
+        formatter.string(from: date)
+    }
+}

--- a/mercantis core/UIShell/PrintRecordButton.swift
+++ b/mercantis core/UIShell/PrintRecordButton.swift
@@ -1,0 +1,153 @@
+//
+//  PrintRecordButton.swift
+//  mercantis core
+//
+//  UI for the print engine (ADR-044). Renders a record to a real PDF via
+//  `PrintService` and either prints it (`NSPrintOperation`) or shares it
+//  (`NSSharingServicePicker`).
+//
+//  Mirrors the Flutter `print_record_button.dart`. The caller supplies a
+//  `formatResolver` that returns the `PrintFormat` to use for a given
+//  document (e.g. an auto-format built from the DocType's fields, or a
+//  manifest-declared format). The button registers that format with the
+//  service before rendering, matching the Flutter `registerFormat` step.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+#if os(macOS)
+import AppKit
+import PDFKit
+#endif
+
+/// A menu button that renders the given record to PDF and prints or shares
+/// it through the platform's native facilities.
+public struct PrintRecordButton: View {
+
+    /// The record to print. An empty `id` disables the control.
+    private let document: Document
+    private let printService: PrintService
+    /// Resolves the `PrintFormat` to render `document` with. The button
+    /// registers the returned format with the service before rendering.
+    private let formatResolver: (Document) -> PrintFormat
+
+    @State private var errorMessage: String?
+    @State private var showError = false
+
+    public init(
+        document: Document,
+        printService: PrintService,
+        formatResolver: @escaping (Document) -> PrintFormat
+    ) {
+        self.document = document
+        self.printService = printService
+        self.formatResolver = formatResolver
+    }
+
+    public var body: some View {
+        Menu {
+            Button {
+                run(.print)
+            } label: {
+                Label("Print…", systemImage: "printer")
+            }
+            Button {
+                run(.share)
+            } label: {
+                Label("Share PDF", systemImage: "square.and.arrow.up")
+            }
+        } label: {
+            Label("Print", systemImage: "printer")
+        }
+        .disabled(document.id.isEmpty)
+        .accessibilityLabel("Print or share this record")
+        .alert("Print failed", isPresented: $showError) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private enum Action { case print, share }
+
+    private func run(_ action: Action) {
+        #if os(macOS)
+        do {
+            let format = formatResolver(document)
+            // Ensure the resolved format is known to the service before render.
+            printService.register(format: format)
+            let result = try printService.render(
+                formatId: format.id,
+                document: document,
+                as: .pdf
+            )
+            switch action {
+            case .print:
+                try printPDF(result)
+            case .share:
+                try sharePDF(result)
+            }
+        } catch {
+            present((error as NSError).localizedDescription)
+        }
+        #else
+        present("Printing is not available on this platform yet.")
+        #endif
+    }
+
+    #if os(macOS)
+    /// Write the PDF to a temp file and present `NSPrintOperation` over a
+    /// `PDFView` so the user gets the native print dialog.
+    private func printPDF(_ result: PrintRenderResult) throws {
+        guard let pdfDoc = PDFDocument(data: result.data) else {
+            throw PrintUIError.invalidPDF
+        }
+        let pdfView = PDFView(frame: NSRect(x: 0, y: 0, width: 612, height: 792))
+        pdfView.document = pdfDoc
+
+        let info = NSPrintInfo.shared
+        let operation = pdfView.printOperation(
+            for: info,
+            scalingMode: .pageScaleDownToFit,
+            autoRotate: true
+        )
+        operation?.showsPrintPanel = true
+        operation?.run()
+    }
+
+    /// Write the PDF to a temp file and offer the native share picker.
+    private func sharePDF(_ result: PrintRenderResult) throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(result.suggestedFileName)
+        try result.data.write(to: url, options: .atomic)
+
+        let picker = NSSharingServicePicker(items: [url])
+        if let window = NSApp.keyWindow, let contentView = window.contentView {
+            picker.show(
+                relativeTo: .zero,
+                of: contentView,
+                preferredEdge: .minY
+            )
+        } else {
+            // Fall back to opening in the default viewer (Preview).
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private enum PrintUIError: LocalizedError {
+        case invalidPDF
+        var errorDescription: String? {
+            switch self {
+            case .invalidPDF: return "The renderer produced data that isn't a valid PDF."
+            }
+        }
+    }
+    #endif
+
+    private func present(_ message: String) {
+        errorMessage = message
+        showError = true
+    }
+}

--- a/mercantis core/UIShell/ReportResultView.swift
+++ b/mercantis core/UIShell/ReportResultView.swift
@@ -1,0 +1,233 @@
+//
+//  ReportResultView.swift
+//  mercantis core
+//
+//  Feature-parity port of the Flutter `ReportResultView`
+//  (`mercantis_core_ui/lib/src/widgets/report_result_view.dart`). Renders a
+//  `ReportResult` (`Reporting/ReportEngine.swift`) as a scrollable table with a
+//  Copy-CSV / export action.
+//
+//  Consolidates and supersedes the orphaned `UIShell/GenericReportView.swift`:
+//  the table layout (shared-width `Grid`, alternating row fill, column
+//  humanisation) is carried over, and the Copy-CSV behaviour the Flutter widget
+//  ships is added here. `ReportResult` (Swift) exposes only `columns: [String]`
+//  and `rows: [[String?]]` — it has no `name` or `toCsv()` — so the report name
+//  is passed in by the host and CSV is generated locally.
+//
+//  Wiring (replace `NavigationShell.reportDetail(reportId:)`) is described in
+//  `CORE_VIEWS_WIRING.md`.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+#if os(macOS)
+import AppKit
+#elseif os(iOS)
+import UIKit
+#endif
+
+/// SwiftUI table over a `ReportResult` with a Copy-CSV action and optional
+/// refresh. Read-only: hosts that want filter chips wrap this view and
+/// re-execute the report themselves.
+public struct ReportResultView: View {
+
+    /// The report's display name, shown in the header (and used as the CSV
+    /// filename hint on export).
+    public let title: String
+    public let result: ReportResult
+    /// When `false` the header omits the title (host shows it in the nav bar)
+    /// but keeps the row count and actions.
+    public let showsTitle: Bool
+    public let onRefresh: (() -> Void)?
+
+    @State private var copiedConfirmation = false
+
+    public init(
+        title: String,
+        result: ReportResult,
+        showsTitle: Bool = true,
+        onRefresh: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.result = result
+        self.showsTitle = showsTitle
+        self.onRefresh = onRefresh
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if result.rowCount == 0 {
+                emptyState
+            } else {
+                resultsTable
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(MercantisTheme.background)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            if showsTitle {
+                Text(title)
+                    .font(.title3.weight(.semibold))
+            }
+            Spacer()
+            Text(rowCountLabel)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            if let onRefresh {
+                Button("Refresh", systemImage: "arrow.clockwise", action: onRefresh)
+                    .buttonStyle(MercantisSecondaryButtonStyle())
+                    .labelStyle(.titleAndIcon)
+            }
+            Button(copiedConfirmation ? "Copied" : "Copy CSV",
+                   systemImage: copiedConfirmation ? "checkmark" : "square.and.arrow.up") {
+                copyCSV()
+            }
+            .buttonStyle(MercantisSecondaryButtonStyle())
+            .disabled(result.rowCount == 0)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "No data for this report yet",
+            systemImage: "tray",
+            description: Text("No rows matched the report's filters.")
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Table
+
+    private var resultsTable: some View {
+        // Single-axis nested scroll views pin content to the top-leading edge so
+        // a short report sits directly under the header rather than centring.
+        ScrollView(.vertical) {
+            ScrollView(.horizontal) {
+                // A shared-width `Grid` keeps every column in register across the
+                // header and all rows (independent HStacks would size per-row).
+                Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 0) {
+                    headerRow
+                    Divider()
+                    ForEach(Array(result.rows.enumerated()), id: \.offset) { index, row in
+                        bodyRow(cells: row, isAlternate: index.isMultiple(of: 2))
+                        if index < result.rows.count - 1 {
+                            Divider().opacity(0.4)
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 20)
+            }
+        }
+    }
+
+    private var headerRow: some View {
+        GridRow {
+            ForEach(Array(result.columns.enumerated()), id: \.offset) { _, column in
+                Text(Self.humanise(column))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(minWidth: 100, alignment: .leading)
+                    .padding(.vertical, 8)
+            }
+        }
+    }
+
+    private func bodyRow(cells: [String?], isAlternate: Bool) -> some View {
+        GridRow {
+            ForEach(Array(cells.enumerated()), id: \.offset) { _, cell in
+                Text(cell ?? "—")
+                    .font(.callout)
+                    .foregroundStyle(cell == nil ? .secondary : .primary)
+                    .frame(minWidth: 100, alignment: .leading)
+                    .padding(.vertical, 6)
+            }
+        }
+        .background(isAlternate ? Color.secondary.opacity(0.05) : Color.clear)
+    }
+
+    // MARK: - CSV
+
+    private func copyCSV() {
+        let csv = Self.csv(from: result)
+        #if os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(csv, forType: .string)
+        #elseif os(iOS)
+        UIPasteboard.general.string = csv
+        #endif
+        copiedConfirmation = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
+            copiedConfirmation = false
+        }
+    }
+
+    /// RFC-4180-style CSV: header row of humanised column labels followed by one
+    /// line per result row. Fields containing a comma, quote, or newline are
+    /// wrapped in quotes with embedded quotes doubled. Nil cells become empty.
+    static func csv(from result: ReportResult) -> String {
+        func escape(_ field: String) -> String {
+            if field.contains(",") || field.contains("\"") || field.contains("\n") {
+                return "\"" + field.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+            }
+            return field
+        }
+        var lines: [String] = []
+        lines.append(result.columns.map { escape(humanise($0)) }.joined(separator: ","))
+        for row in result.rows {
+            lines.append(row.map { escape($0 ?? "") }.joined(separator: ","))
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Helpers
+
+    private var rowCountLabel: String {
+        result.rowCount == 1 ? "1 row" : "\(result.rowCount) rows"
+    }
+
+    /// Default column humanisation: `total_amount` → "Total Amount".
+    static func humanise(_ key: String) -> String {
+        guard !key.isEmpty else { return key }
+        var spaced = ""
+        for (i, ch) in key.enumerated() {
+            if ch == "_" {
+                spaced += " "
+            } else if ch.isUppercase, i > 0 {
+                spaced += " "
+                spaced.append(ch)
+            } else {
+                spaced.append(ch)
+            }
+        }
+        return spaced.prefix(1).uppercased() + spaced.dropFirst()
+    }
+}
+
+#if DEBUG
+#Preview("Report result") {
+    ReportResultView(
+        title: "Open Invoices",
+        result: ReportResult(
+            columns: ["invoice_no", "customer", "total_amount"],
+            rows: [
+                ["INV-001", "Acme Co", "1,200.00"],
+                ["INV-002", "Globex", nil],
+            ]
+        )
+    )
+    .frame(width: 600, height: 360)
+}
+#endif

--- a/mercantis core/UIShell/SettingsView.swift
+++ b/mercantis core/UIShell/SettingsView.swift
@@ -1,0 +1,180 @@
+//
+//  SettingsView.swift
+//  mercantis core
+//
+//  Feature-parity port of the Flutter `SettingsView`
+//  (`mercantis_core_ui/lib/src/views/settings_view.dart`). Real settings
+//  surface for the Core shell: an appearance (color-scheme) picker backed by
+//  `@AppStorage`, plus an About section showing app name / version.
+//
+//  Replaces the three-static-label placeholder that `NavigationShell` renders
+//  for `NavigationSection.settings`. Wiring is described in
+//  `CORE_VIEWS_WIRING.md` — this file does not edit `NavigationShell`.
+//
+
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+/// User-facing appearance preference. Mirrors Flutter's `ThemeMode`
+/// (`system` / `light` / `dark`). Persisted as a raw string under
+/// `MercantisAppearancePreference.storageKey` so `@AppStorage` can drive the
+/// picker and any host that wants to apply `.preferredColorScheme`.
+public enum MercantisColorSchemePreference: String, CaseIterable, Identifiable, Sendable {
+    case system
+    case light
+    case dark
+
+    public var id: String { rawValue }
+
+    /// Stable key shared between the picker and any host applying the scheme.
+    public static let storageKey = "mercantis.appearance.colorScheme"
+
+    public var label: String {
+        switch self {
+        case .system: return "System default"
+        case .light:  return "Light"
+        case .dark:   return "Dark"
+        }
+    }
+
+    public var symbol: String {
+        switch self {
+        case .system: return "circle.lefthalf.filled"
+        case .light:  return "sun.max"
+        case .dark:   return "moon"
+        }
+    }
+
+    /// The SwiftUI `ColorScheme` to apply, or `nil` to follow the system.
+    public var colorScheme: ColorScheme? {
+        switch self {
+        case .system: return nil
+        case .light:  return .light
+        case .dark:   return .dark
+        }
+    }
+}
+
+/// Real settings screen for Mercantis Core. Theme-mode picker + About section,
+/// mirroring the Flutter port. Read-only apart from the appearance preference,
+/// which is persisted via `@AppStorage`.
+public struct SettingsView: View {
+
+    /// App name shown in the About row. Defaults to the bundle display name.
+    private let appName: String
+    /// Version string shown in the About row. Defaults to the bundle version.
+    private let appVersion: String?
+
+    @AppStorage(MercantisColorSchemePreference.storageKey)
+    private var rawScheme: String = MercantisColorSchemePreference.system.rawValue
+
+    public init(appName: String? = nil, appVersion: String? = nil) {
+        self.appName = appName ?? Self.bundleAppName
+        self.appVersion = appVersion ?? Self.bundleAppVersion
+    }
+
+    private var selection: Binding<MercantisColorSchemePreference> {
+        Binding(
+            get: { MercantisColorSchemePreference(rawValue: rawScheme) ?? .system },
+            set: { rawScheme = $0.rawValue }
+        )
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                appearanceCard
+                aboutCard
+            }
+            .padding()
+        }
+        .background(MercantisTheme.background)
+        .navigationTitle("Settings")
+    }
+
+    // MARK: - Appearance
+
+    private var appearanceCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Appearance").font(.headline)
+            // A radio-style picker mirrors the Flutter `RadioListTile` group.
+            ForEach(MercantisColorSchemePreference.allCases) { mode in
+                Button {
+                    selection.wrappedValue = mode
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: mode.symbol)
+                            .frame(width: 22)
+                            .foregroundStyle(.secondary)
+                        Text(mode.label)
+                        Spacer()
+                        Image(systemName: selection.wrappedValue == mode
+                              ? "largecircle.fill.circle"
+                              : "circle")
+                            .foregroundStyle(selection.wrappedValue == mode
+                                             ? MercantisTheme.accent
+                                             : Color.secondary)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(selection.wrappedValue == mode ? [.isSelected] : [])
+            }
+        }
+        .mercantisCard()
+    }
+
+    // MARK: - About
+
+    private var aboutCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("About").font(.headline)
+            HStack(spacing: 12) {
+                Image(systemName: "info.circle")
+                    .font(.title3)
+                    .foregroundStyle(MercantisTheme.accent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(appName)
+                        .font(.body.weight(.semibold))
+                    if let appVersion {
+                        Text("Version \(appVersion)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+            }
+        }
+        .mercantisCard()
+    }
+
+    // MARK: - Bundle metadata
+
+    private static var bundleAppName: String {
+        let info = Bundle.main.infoDictionary
+        return (info?["CFBundleDisplayName"] as? String)
+            ?? (info?["CFBundleName"] as? String)
+            ?? "Mercantis"
+    }
+
+    private static var bundleAppVersion: String? {
+        let info = Bundle.main.infoDictionary
+        let short = info?["CFBundleShortVersionString"] as? String
+        let build = info?["CFBundleVersion"] as? String
+        switch (short, build) {
+        case let (short?, build?): return "\(short) (\(build))"
+        case let (short?, nil):    return short
+        case let (nil, build?):    return build
+        default:                   return nil
+        }
+    }
+}
+
+#if DEBUG
+#Preview("Settings") {
+    SettingsView(appName: "Mercantis Core", appVersion: "1.0.0 (42)")
+        .frame(width: 480, height: 420)
+}
+#endif


### PR DESCRIPTION
## Summary
This PR ports several Flutter UI widgets to Swift and significantly expands field type support in `GenericFormView`. The changes bring feature parity with the Flutter `mercantis_core_ui` library by adding new views for documents, reports, dashboards, notifications, and settings, along with specialized field editors.

## Key Changes

### New UI Views (Flutter Ports)
- **DocumentTimelineView**: Renders a document's audit-log history as a vertical timeline with per-event field diffs, mirroring `document_timeline_view.dart`
- **AttachmentsPanel**: Lists, uploads, and deletes file attachments bound to a document via `AttachmentManager`, mirroring `attachments_panel.dart`
- **DashboardResultGrid**: Renders resolved `DashboardResult` as a responsive grid of widget cards (counts, lists, shortcuts, charts) with per-widget error isolation
- **ReportResultView**: Renders `ReportResult` as a scrollable table with Copy-CSV export, replacing the inline report rendering in `NavigationShell`
- **NotificationInboxView**: Reader UI over the in-app notification inbox with unread styling, mark-read, and swipe-to-delete
- **SettingsView**: Real settings screen with appearance (color-scheme) picker backed by `@AppStorage` and About section
- **PrintRecordButton**: Menu button that renders records to PDF and prints or shares via native facilities
- **ImportExportMenu**: Import/Export menu for bulk operations (CSV/JSON export, file import)

### New Field Editors
- **SignatureField**: Freehand signature capture via canvas drag gestures, storing normalized (0..1) coordinates as JSON
- **ColorField**: `#RRGGBB` hex color picker using native `ColorPicker`
- **DurationField**: Hours + minutes entry storing total seconds
- **RatingField**: 1–5 tappable star picker
- **CodeField**: Monospace multi-line text area for code snippets
- **PasswordField**: Secure text entry (added to field routing)
- **TimeField**: Time-only picker (added to field routing)
- **PercentField**: Percentage input (added to field routing)

### Field Type Expansion
- Added 11 new `FieldType` enum cases: `password`, `code`, `color`, `signature`, `geolocation`, `autocomplete`, `dynamicLink`, `tableMultiSelect`, `time`, `percent`, `rating`, `duration`
- Updated `GenericFormView.fieldRow()` to detect layout separators (headings, section breaks, column breaks) and render them full-width
- Expanded `usesStackedLayout()` to include new field types requiring vertical layout
- Updated `fieldEditor()` switch to route all new types to appropriate editors, with graceful degradation where bespoke editors don't exist (e.g., `tableMultiSelect` → `multiselectField`)
- Updated `TypeCoercionStage` in `ValidationPipeline` to validate string-backed editors

### Navigation Shell Updates
- Replaced placeholder `settingsContext` with `SettingsView()`
- Replaced placeholder `inboxContext` with `NotificationInboxView(inbox: tooling.notificationInbox)`
- Replaced inline report rendering in `reportDetail()` with `ReportResultView`
- Replaced inline dashboard rendering in `dashboardDetail()` with `DashboardResultGrid`

### Tooling Context Enhancements
- Added `notificationInbox` lazy property to `DocTypeToolingContext`
- Added `makeDashboardEngine()` factory method to wire dashboard engine with document/report engines
- Added `currentUserId` property for audit logging

## Implementation Details
- All new views follow the existing Mercantis theme and component patterns
- Timeline and notification views load data into `@State` and reload after mutations (synchronous GRDB API)
- Field editors use `@Binding` for two-way value synchronization
- Signature and color fields store normalized/hex formats for cross-platform compatibility
- Print and import/export operations use platform-specific APIs (`NSPrintOperation`, `NSSavePanel`, `NSOpenPanel` on macOS)
- Error handling is consistent with existing patterns (Content

https://claude.ai/code/session_01MZC4D6PmvcB1m6PiyPXAfa