### PR TITLE
Fix macOS PDF print API and timeline actor isolation

### DIFF
--- a/mercantis core/UIShell/DocumentTimelineView.swift
+++ b/mercantis core/UIShell/DocumentTimelineView.swift
@@ -202,7 +202,7 @@ private struct TimelineItem: Identifiable {
         self.diffs = Self.decodeDiffs(from: entry.payloadJSON)
     }
 
-    private static func style(forAction action: String) -> (title: String, symbol: String, tone: MercantisSemanticTone) {
+    nonisolated private static func style(forAction action: String) -> (title: String, symbol: String, tone: MercantisSemanticTone) {
         switch action.lowercased() {
         case "save":       return ("Saved", "square.and.pencil", .info)
         case "submit":     return ("Submitted", "paperplane.fill", .success)
@@ -221,7 +221,7 @@ private struct TimelineItem: Identifiable {
     /// written by `AuditLogWriter.append(... before:after:)` into a list of
     /// human-readable field diffs. Non-diff payloads (e.g. attachment
     /// summaries) decode to an empty list and just show the title.
-    private static func decodeDiffs(from json: String) -> [TimelineFieldDiff] {
+    nonisolated private static func decodeDiffs(from json: String) -> [TimelineFieldDiff] {
         guard let data = json.data(using: .utf8) else { return [] }
         struct Wrapper: Decodable {
             let before: [String: FieldValue]?
@@ -246,7 +246,7 @@ private struct TimelineItem: Identifiable {
         }
     }
 
-    private static func display(_ value: FieldValue) -> String {
+    nonisolated private static func display(_ value: FieldValue) -> String {
         switch value {
         case .string(let s): return s.isEmpty ? "—" : s
         case .int(let i):    return String(i)

--- a/mercantis core/UIShell/PrintRecordButton.swift
+++ b/mercantis core/UIShell/PrintRecordButton.swift
@@ -98,23 +98,21 @@ public struct PrintRecordButton: View {
     }
 
     #if os(macOS)
-    /// Write the PDF to a temp file and present `NSPrintOperation` over a
-    /// `PDFView` so the user gets the native print dialog.
+    /// Render the PDF into a `PDFView` and run a native `NSPrintOperation`
+    /// over it so the user gets the standard print dialog.
     private func printPDF(_ result: PrintRenderResult) throws {
         guard let pdfDoc = PDFDocument(data: result.data) else {
             throw PrintUIError.invalidPDF
         }
-        let pdfView = PDFView(frame: NSRect(x: 0, y: 0, width: 612, height: 792))
+        let pageSize = pdfDoc.page(at: 0)?.bounds(for: .mediaBox).size
+            ?? NSSize(width: 612, height: 792)
+        let pdfView = PDFView(frame: NSRect(origin: .zero, size: pageSize))
         pdfView.document = pdfDoc
+        pdfView.autoScales = true
 
-        let info = NSPrintInfo.shared
-        let operation = pdfView.printOperation(
-            for: info,
-            scalingMode: .pageScaleDownToFit,
-            autoRotate: true
-        )
-        operation?.showsPrintPanel = true
-        operation?.run()
+        let operation = NSPrintOperation(view: pdfView, printInfo: NSPrintInfo.shared)
+        operation.showsPrintPanel = true
+        operation.run()
     }
 
     /// Write the PDF to a temp file and offer the native share picker.


### PR DESCRIPTION
- PrintRecordButton: PDFView has no `printOperation(for:scalingMode:autoRotate:)`; print via `NSPrintOperation(view:printInfo:)` over the PDFView instead, sized to the first page.
- DocumentTimelineView: mark the pure static payload helpers (`display`, `decodeDiffs`, `style`) `nonisolated` so decoding audit diffs off the main actor no longer trips main-actor isolation.


Claude-Session: https://claude.ai/code/session_01MZC4D6PmvcB1m6PiyPXAfa