### PR TITLE
Fix dashboard binding and complete timeline nonisolated chain

### DIFF
--- a/mercantis core/UIShell/DocumentTimelineView.swift
+++ b/mercantis core/UIShell/DocumentTimelineView.swift
@@ -264,7 +264,7 @@ private struct TimelineItem: Identifiable {
     }
 
     /// Humanise a snake_case / camelCase key into a label.
-    private static func humanLabel(_ key: String) -> String {
+    nonisolated private static func humanLabel(_ key: String) -> String {
         guard !key.isEmpty else { return key }
         var spaced = ""
         for (i, ch) in key.enumerated() {

--- a/mercantis core/UIShell/NavigationShell.swift
+++ b/mercantis core/UIShell/NavigationShell.swift
@@ -447,7 +447,7 @@ public struct NavigationShell: View {
 
     @ViewBuilder
     private func dashboardDetail(dashboardId: String) -> some View {
-        if tooling.dashboard(withId: dashboardId) != nil {
+        if let dashboard = tooling.dashboard(withId: dashboardId) {
             DashboardResultGrid(
                 engine: tooling.makeDashboardEngine(),
                 dashboardId: dashboardId,


### PR DESCRIPTION
- NavigationShell.dashboardDetail: restore the `if let dashboard` binding — it's used by `.navigationTitle(dashboard.name)`.
- DocumentTimelineView: mark `humanLabel` nonisolated too so the now-nonisolated `decodeDiffs` can call it.


Claude-Session: https://claude.ai/code/session_01MZC4D6PmvcB1m6PiyPXAfa