### PR TITLE
Make TimelineItem.init(entry:) nonisolated

### DIFF
--- a/mercantis core/UIShell/DocumentTimelineView.swift
+++ b/mercantis core/UIShell/DocumentTimelineView.swift
@@ -185,7 +185,7 @@ private struct TimelineItem: Identifiable {
     let tone: MercantisSemanticTone
     let diffs: [TimelineFieldDiff]
 
-    init(entry: AuditLogEntry) {
+    nonisolated init(entry: AuditLogEntry) {
         self.id = entry.id
         let style = Self.style(forAction: entry.action)
         self.symbol = style.symbol


### PR DESCRIPTION
The view-model init was main-actor-isolated (default isolation), so passing `TimelineItem.init(entry:)` as a function value to `map` clashed with map's nonisolated closure parameter. The init only sets value-type fields and calls the already-nonisolated helpers, so mark it nonisolated.


Claude-Session: https://claude.ai/code/session_01MZC4D6PmvcB1m6PiyPXAfa