### PR TITLE
Allow creating a new linked record from the link picker

### DIFF
--- a/mercantis core/UIShell/CreateRecordSheet.swift
+++ b/mercantis core/UIShell/CreateRecordSheet.swift
@@ -18,6 +18,8 @@ struct CreateRecordSheet: View {
     let linkSearchProvider: ((String, String) -> [Document])?
     let linkResolveProvider: ((String, String) -> Document?)?
     let childDocTypeProvider: ((String) -> DocType?)?
+    let linkCreateProvider: ((String) -> Document?)?
+    let linkCommitProvider: ((Document) throws -> Document)?
 
     @State private var errorMessage: String?
 
@@ -27,7 +29,9 @@ struct CreateRecordSheet: View {
         onCreate: @escaping (Document) throws -> Void,
         linkSearchProvider: ((String, String) -> [Document])? = nil,
         linkResolveProvider: ((String, String) -> Document?)? = nil,
-        childDocTypeProvider: ((String) -> DocType?)? = nil
+        childDocTypeProvider: ((String) -> DocType?)? = nil,
+        linkCreateProvider: ((String) -> Document?)? = nil,
+        linkCommitProvider: ((Document) throws -> Document)? = nil
     ) {
         self.docType = docType
         self._draft = draft
@@ -35,6 +39,8 @@ struct CreateRecordSheet: View {
         self.linkSearchProvider = linkSearchProvider
         self.linkResolveProvider = linkResolveProvider
         self.childDocTypeProvider = childDocTypeProvider
+        self.linkCreateProvider = linkCreateProvider
+        self.linkCommitProvider = linkCommitProvider
     }
 
     var body: some View {
@@ -56,7 +62,9 @@ struct CreateRecordSheet: View {
                 document: $draft,
                 linkSearchProvider: linkSearchProvider,
                 linkResolveProvider: linkResolveProvider,
-                childDocTypeProvider: childDocTypeProvider
+                childDocTypeProvider: childDocTypeProvider,
+                linkCreateProvider: linkCreateProvider,
+                linkCommitProvider: linkCommitProvider
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 

--- a/mercantis core/UIShell/GenericFormView.swift
+++ b/mercantis core/UIShell/GenericFormView.swift
@@ -42,6 +42,11 @@ public struct GenericFormView: View {
     /// can render a human label for the current selection instead of its id.
     let linkResolveProvider: ((String, String) -> Document?)?
     let childDocTypeProvider: ((String) -> DocType?)?
+    /// Builds a blank draft of a target DocType so link fields can offer inline
+    /// "create new" record creation in their picker.
+    let linkCreateProvider: ((String) -> Document?)?
+    /// Persists an inline-created draft and returns the saved document.
+    let linkCommitProvider: ((Document) throws -> Document)?
 
     public init(
         docType: DocType,
@@ -50,7 +55,9 @@ public struct GenericFormView: View {
         expressionEvaluator: ExpressionEvaluator = ExpressionEvaluator(),
         linkSearchProvider: ((String, String) -> [Document])? = nil,
         linkResolveProvider: ((String, String) -> Document?)? = nil,
-        childDocTypeProvider: ((String) -> DocType?)? = nil
+        childDocTypeProvider: ((String) -> DocType?)? = nil,
+        linkCreateProvider: ((String) -> Document?)? = nil,
+        linkCommitProvider: ((Document) throws -> Document)? = nil
     ) {
         self.docType = docType
         self._document = document
@@ -59,6 +66,8 @@ public struct GenericFormView: View {
         self.linkSearchProvider = linkSearchProvider
         self.linkResolveProvider = linkResolveProvider
         self.childDocTypeProvider = childDocTypeProvider
+        self.linkCreateProvider = linkCreateProvider
+        self.linkCommitProvider = linkCommitProvider
     }
 
     public var body: some View {
@@ -516,13 +525,18 @@ public struct GenericFormView: View {
         let resolve: ((String) -> Document?)? = linkResolveProvider.map { base in
             { id in base(target, id) }
         }
+        let make: (() -> Document?)? = linkCreateProvider.map { base in
+            { base(target) }
+        }
         return LinkPickerField(
             targetDocType: target.isEmpty ? "Link" : target,
             value: stringBinding(for: field),
             isReadOnly: isReadOnly,
             targetMeta: childDocTypeProvider?(target),
             searchProvider: provider,
-            resolveDocument: resolve
+            resolveDocument: resolve,
+            makeDraft: make,
+            commitDraft: linkCommitProvider
         )
     }
 

--- a/mercantis core/UIShell/LinkPickerField.swift
+++ b/mercantis core/UIShell/LinkPickerField.swift
@@ -37,11 +37,20 @@ public struct LinkPickerField: View {
     /// field can show a human label instead of the raw id. `nil` falls back to
     /// displaying the stored id verbatim.
     let resolveDocument: ((String) -> Document?)?
+    /// Builds a blank draft of the target DocType for inline "create new"
+    /// from within the picker. `nil` (or a `nil` return) hides the create action.
+    let makeDraft: (() -> Document?)?
+    /// Persists a draft created inline and returns the saved document (whose id
+    /// becomes the link value). `nil` hides the create action.
+    let commitDraft: ((Document) throws -> Document)?
 
     @State private var isPickerPresented = false
     @State private var searchQuery = ""
     @State private var searchResults: [Document] = []
     @State private var lastSearchError: String?
+    @State private var isCreating = false
+    @State private var draftDocument: Document?
+    @State private var createError: String?
 
     public init(
         targetDocType: String,
@@ -49,7 +58,9 @@ public struct LinkPickerField: View {
         isReadOnly: Bool,
         targetMeta: DocType? = nil,
         searchProvider: ((String, String) -> [Document])?,
-        resolveDocument: ((String) -> Document?)? = nil
+        resolveDocument: ((String) -> Document?)? = nil,
+        makeDraft: (() -> Document?)? = nil,
+        commitDraft: ((Document) throws -> Document)? = nil
     ) {
         self.targetDocType = targetDocType
         self._value = value
@@ -57,6 +68,13 @@ public struct LinkPickerField: View {
         self.targetMeta = targetMeta
         self.searchProvider = searchProvider
         self.resolveDocument = resolveDocument
+        self.makeDraft = makeDraft
+        self.commitDraft = commitDraft
+    }
+
+    /// Whether the picker can offer inline creation of a new target record.
+    private var canCreate: Bool {
+        makeDraft != nil && commitDraft != nil && targetMeta != nil
     }
 
     /// Human-facing label for the current selection. Resolves the stored id to
@@ -87,6 +105,9 @@ public struct LinkPickerField: View {
                 .sheet(isPresented: $isPickerPresented, onDismiss: {
                     searchQuery = ""
                     lastSearchError = nil
+                    isCreating = false
+                    draftDocument = nil
+                    createError = nil
                 }) {
                     pickerSheet
                 }
@@ -124,7 +145,22 @@ public struct LinkPickerField: View {
     /// create-record sheet on a Sales Order), making the result list
     /// effectively invisible — which is what the "the picker shows
     /// nothing" report was about.
+    @ViewBuilder
     private var pickerSheet: some View {
+        Group {
+            if isCreating, let meta = targetMeta {
+                createSheet(meta: meta)
+            } else {
+                searchSheet
+            }
+        }
+        .frame(minWidth: 460, idealWidth: 540, minHeight: 380, idealHeight: 460)
+        #if os(macOS)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        #endif
+    }
+
+    private var searchSheet: some View {
         VStack(spacing: 0) {
             pickerHeader
             Divider()
@@ -141,10 +177,100 @@ public struct LinkPickerField: View {
             Divider()
             pickerFooter
         }
-        .frame(minWidth: 460, idealWidth: 540, minHeight: 380, idealHeight: 460)
-        #if os(macOS)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        #endif
+    }
+
+    // MARK: - Inline create
+
+    /// Drive into the inline create form: build a fresh draft and switch the
+    /// sheet over to it.
+    private func startCreate() {
+        guard let draft = makeDraft?() else { return }
+        draftDocument = draft
+        createError = nil
+        isCreating = true
+    }
+
+    /// Persist the inline draft, select it, and dismiss. Errors stay in the
+    /// create form so the user can fix and retry.
+    private func commitNewRecord() {
+        guard let commitDraft, let draft = draftDocument else { return }
+        do {
+            let saved = try commitDraft(draft)
+            value = saved.id
+            isCreating = false
+            draftDocument = nil
+            isPickerPresented = false
+        } catch {
+            createError = (error as NSError).localizedDescription
+        }
+    }
+
+    private var draftBinding: Binding<Document> {
+        Binding(
+            get: { draftDocument ?? Self.emptyDraft(for: targetDocType) },
+            set: { draftDocument = $0 }
+        )
+    }
+
+    nonisolated private static func emptyDraft(for docType: String) -> Document {
+        let now = Date()
+        return Document(
+            id: "",
+            docType: docType,
+            company: "",
+            status: "",
+            createdAt: now,
+            updatedAt: now,
+            syncVersion: 0,
+            syncState: .local,
+            fields: [:],
+            children: [:]
+        )
+    }
+
+    private func createSheet(meta: DocType) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("New \(targetDocType)")
+                    .font(.headline)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(MercantisTheme.surface)
+            Divider()
+            if let createError {
+                Text(createError)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(MercantisTheme.fillSoft(for: .danger))
+            }
+            ScrollView {
+                GenericFormView(docType: meta, document: draftBinding)
+                    .padding(16)
+            }
+            Divider()
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    isCreating = false
+                    draftDocument = nil
+                    createError = nil
+                }
+                .buttonStyle(MercantisSecondaryButtonStyle())
+                .keyboardShortcut(.cancelAction)
+                Button("Create \(targetDocType)") {
+                    commitNewRecord()
+                }
+                .buttonStyle(MercantisPrimaryButtonStyle())
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(MercantisTheme.surface)
+        }
     }
 
     private var pickerHeader: some View {
@@ -194,11 +320,22 @@ public struct LinkPickerField: View {
                      : "No results for \"\(searchQuery)\"")
                     .font(.headline)
                 Text(searchQuery.isEmpty
-                     ? "Create a \(targetDocType) first, then link to it from here."
+                     ? (canCreate
+                        ? "Create one now and link it without leaving this form."
+                        : "Create a \(targetDocType) first, then link to it from here.")
                      : "Try a different search.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
+                if canCreate {
+                    Button {
+                        startCreate()
+                    } label: {
+                        Label("Create new \(targetDocType)", systemImage: "plus")
+                    }
+                    .buttonStyle(MercantisPrimaryButtonStyle())
+                    .padding(.top, 4)
+                }
             }
             .padding(24)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -260,6 +397,14 @@ public struct LinkPickerField: View {
                 }
                 .foregroundStyle(.red)
                 .buttonStyle(.plain)
+            }
+            if canCreate {
+                Button {
+                    startCreate()
+                } label: {
+                    Label("New \(targetDocType)", systemImage: "plus")
+                }
+                .buttonStyle(MercantisSecondaryButtonStyle())
             }
             Button("Cancel") { isPickerPresented = false }
                 .buttonStyle(MercantisSecondaryButtonStyle())

--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -43,6 +43,8 @@ public struct RecordCollectionHostView: View {
     let linkSearchProvider: ((String, String) -> [Document])?
     let linkResolveProvider: ((String, String) -> Document?)?
     let childDocTypeProvider: ((String) -> DocType?)?
+    let linkCreateProvider: ((String) -> Document?)?
+    let linkCommitProvider: ((Document) throws -> Document)?
     let detailEditor: ((DocType, Binding<Document>) -> AnyView)?
     /// Optional built-in / saved list views (e.g. Hub's "Unpaid", "Overdue").
     /// When empty the list synthesises status chips from the loaded data.
@@ -88,6 +90,8 @@ public struct RecordCollectionHostView: View {
         linkSearchProvider: ((String, String) -> [Document])? = nil,
         linkResolveProvider: ((String, String) -> Document?)? = nil,
         childDocTypeProvider: ((String) -> DocType?)? = nil,
+        linkCreateProvider: ((String) -> Document?)? = nil,
+        linkCommitProvider: ((Document) throws -> Document)? = nil,
         detailEditor: ((DocType, Binding<Document>) -> AnyView)? = nil,
         listViews: [RecordListViewDefinition] = [],
         displayPolicy: DocumentDisplayPolicy = .passthrough
@@ -117,6 +121,8 @@ public struct RecordCollectionHostView: View {
         self.linkSearchProvider = linkSearchProvider
         self.linkResolveProvider = linkResolveProvider
         self.childDocTypeProvider = childDocTypeProvider
+        self.linkCreateProvider = linkCreateProvider
+        self.linkCommitProvider = linkCommitProvider
         self.detailEditor = detailEditor
         self.listViews = listViews
         self.displayPolicy = displayPolicy
@@ -140,7 +146,9 @@ public struct RecordCollectionHostView: View {
                 onCreate: performCreate(_:),
                 linkSearchProvider: linkSearchProvider,
                 linkResolveProvider: linkResolveProvider,
-                childDocTypeProvider: childDocTypeProvider
+                childDocTypeProvider: childDocTypeProvider,
+                linkCreateProvider: linkCreateProvider,
+                linkCommitProvider: linkCommitProvider
             )
         }
         .onAppear {
@@ -332,7 +340,9 @@ public struct RecordCollectionHostView: View {
                         document: selectedDocumentBinding,
                         linkSearchProvider: linkSearchProvider,
                         linkResolveProvider: linkResolveProvider,
-                        childDocTypeProvider: childDocTypeProvider
+                        childDocTypeProvider: childDocTypeProvider,
+                        linkCreateProvider: linkCreateProvider,
+                        linkCommitProvider: linkCommitProvider
                     )
                     .disabled(!allowsDetailEditing)
                 }


### PR DESCRIPTION
Adds inline "Create new <DocType>" to the generic link-field picker so users can create and link a record without leaving the form (e.g. add a UOM while creating an Item). Shown only when the host wires the create/commit providers.

- LinkPickerField: optional makeDraft/commitDraft closures; a "Create new" action in the empty state and footer that switches the sheet to an inline GenericFormView for a draft of the target DocType, then saves and selects it.
- GenericFormView, RecordCollectionHostView, CreateRecordSheet: thread linkCreateProvider/linkCommitProvider through to the picker (additive, default nil — no behaviour change when unwired).

Applies to every link dropdown, not just one field.


Claude-Session: https://claude.ai/code/session_01MZC4D6PmvcB1m6PiyPXAfa