### PR TITLE
Drop nonisolated on LinkPickerField.emptyDraft

### DIFF
--- a/mercantis core/UIShell/LinkPickerField.swift
+++ b/mercantis core/UIShell/LinkPickerField.swift
@@ -212,7 +212,7 @@ public struct LinkPickerField: View {
         )
     }
 
-    nonisolated private static func emptyDraft(for docType: String) -> Document {
+    private static func emptyDraft(for docType: String) -> Document {
         let now = Date()
         return Document(
             id: "",


### PR DESCRIPTION
It blocked the call to the main-actor-isolated Document.init. The helper is only used from draftBinding, a member of the @MainActor view, so default main-actor isolation is correct.


Claude-Session: https://claude.ai/code/session_01MZC4D6PmvcB1m6PiyPXAfa