### PR TITLE
Validate required .table fields against children, not fields

### DIFF
--- a/mercantis core/DocumentEngine/ValidationPipeline.swift
+++ b/mercantis core/DocumentEngine/ValidationPipeline.swift
@@ -359,9 +359,16 @@ public struct RequiredFieldStage: ValidationStage {
         var errors: [DocumentValidationError] = []
 
         for field in context.docType.fields where field.required {
-            let value = document.fields[field.key]
+            // Child-table rows live in `document.children`, not in `fields`, so a
+            // required `.table` is satisfied by having at least one child row.
+            let isEmpty: Bool
+            if field.type == .table {
+                isEmpty = (document.children[field.key] ?? []).isEmpty
+            } else {
+                isEmpty = isValueEmpty(document.fields[field.key])
+            }
 
-            if isValueEmpty(value) {
+            if isEmpty {
                 errors.append(DocumentValidationError(
                     stage: stageName,
                     field: field.key,


### PR DESCRIPTION
Child-table rows are stored in document.children[key]; the form binds the table field there and the engine persists from there. RequiredFieldStage checked document.fields[key], which is always empty for a .table field, so any required child table (e.g. POS Invoice "Items", Sales Invoice/Order lines) failed validation with "'Items' is required" even when rows were present. Check the children collection for .table fields instead.


Claude-Session: https://claude.ai/code/session_01MZC4D6PmvcB1m6PiyPXAfa