### PR TITLE
Phase 0 (Core): execution context, child validation, unit-of-work, fail-closed permissions

### DIFF
--- a/mercantis core/DocumentEngine/Document.swift
+++ b/mercantis core/DocumentEngine/Document.swift
@@ -76,7 +76,7 @@ public enum SyncState: String, Codable, Sendable {
 }
 
 /// A single child row belonging to a parent document.
-public struct ChildRow: Identifiable, Codable, Sendable {
+public struct ChildRow: Identifiable, Codable, Sendable, Equatable {
     public let id: String
     public var rowIndex: Int
     public var fields: [String: FieldValue]

--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -163,7 +163,9 @@ public final class DocumentEngine {
     public func save(
         _ document: Document,
         userSuppliedName: String? = nil,
-        context: ExecutionContext? = nil
+        context: ExecutionContext? = nil,
+        lifecycleAudit: LifecycleAudit? = nil,
+        inTransaction: ((UnitOfWork) throws -> Void)? = nil
     ) throws -> Document {
         let ctx = resolved(context)
         var document = try assigningNameIfNeeded(document, userSuppliedName: userSuppliedName)
@@ -235,6 +237,25 @@ public final class DocumentEngine {
                 after: document.fields,
                 in: db
             )
+            // P0.8: the lifecycle audit row (submit/cancel/amend) commits in the
+            // SAME transaction as the docStatus change — no second transaction.
+            if let lifecycleAudit {
+                try auditLogWriter.append(
+                    AuditLogEntry(
+                        documentId: document.id,
+                        docType: document.docType,
+                        userId: ctx.operatorId,
+                        action: lifecycleAudit.action,
+                        payloadJSON: lifecycleAudit.extraJSON
+                    ),
+                    in: db
+                )
+            }
+            // P0.8: the unit-of-work seam. Anything the caller does here (Phase 1
+            // posting batches) commits atomically with the document.
+            if let inTransaction {
+                try inTransaction(UnitOfWork(db: db, context: ctx, auditLogWriter: auditLogWriter))
+            }
         }
 
         eventEmitter.publish(DocumentSavedEvent(
@@ -435,7 +456,11 @@ public final class DocumentEngine {
     // MARK: - Submit (ADR-013)
 
     /// Submit a document, transitioning it from Draft (docStatus 0) to Submitted (docStatus 1).
-    public func submit(_ document: inout Document, context: ExecutionContext? = nil) throws {
+    public func submit(
+        _ document: inout Document,
+        context: ExecutionContext? = nil,
+        inTransaction: ((UnitOfWork) throws -> Void)? = nil
+    ) throws {
         let ctx = resolved(context)
         guard let docType = registry.get(document.docType) else {
             throw DocumentEngineError.docTypeNotFound(document.docType)
@@ -456,13 +481,11 @@ public final class DocumentEngine {
         // made a freshly-fetched document look stale and threw
         // `concurrencyConflict` whenever a second had elapsed since the last
         // save (ISO8601 second-truncation only hid it within the same second).
-        try save(document, context: ctx)
-
-        try writeLifecycleAuditEntry(
-            documentId: document.id,
-            docType: document.docType,
-            action: "submit",
-            operatorId: ctx.operatorId
+        try save(
+            document,
+            context: ctx,
+            lifecycleAudit: LifecycleAudit(action: "submit"),
+            inTransaction: inTransaction
         )
 
         eventEmitter.publish(DocumentSubmittedEvent(
@@ -475,7 +498,11 @@ public final class DocumentEngine {
 
     /// Cancel a submitted document, transitioning it from Submitted (1) to Cancelled (2).
     /// Rejects if any downstream submitted document holds a Link field pointing here. (ADR-013)
-    public func cancel(_ document: inout Document, context: ExecutionContext? = nil) throws {
+    public func cancel(
+        _ document: inout Document,
+        context: ExecutionContext? = nil,
+        inTransaction: ((UnitOfWork) throws -> Void)? = nil
+    ) throws {
         let ctx = resolved(context)
         guard let docType = registry.get(document.docType) else {
             throw DocumentEngineError.docTypeNotFound(document.docType)
@@ -501,13 +528,11 @@ public final class DocumentEngine {
         // See `submit(...)`: leave `updatedAt` untouched so the optimistic
         // concurrency check in `save(...)` compares like-for-like against the
         // stored row and stamps its own fresh timestamp.
-        try save(document, context: ctx)
-
-        try writeLifecycleAuditEntry(
-            documentId: document.id,
-            docType: document.docType,
-            action: "cancel",
-            operatorId: ctx.operatorId
+        try save(
+            document,
+            context: ctx,
+            lifecycleAudit: LifecycleAudit(action: "cancel"),
+            inTransaction: inTransaction
         )
 
         eventEmitter.publish(DocumentCancelledEvent(
@@ -562,14 +587,13 @@ public final class DocumentEngine {
         }
         amended.children = newChildren
 
-        try save(amended, context: ctx)
-
-        try writeLifecycleAuditEntry(
-            documentId: amended.id,
-            docType: amended.docType,
-            action: "amend",
-            operatorId: ctx.operatorId,
-            extraJSON: "{\"amendedFrom\":\"\(document.id)\"}"
+        try save(
+            amended,
+            context: ctx,
+            lifecycleAudit: LifecycleAudit(
+                action: "amend",
+                extraJSON: "{\"amendedFrom\":\"\(document.id)\"}"
+            )
         )
 
         eventEmitter.publish(DocumentAmendedEvent(
@@ -579,30 +603,6 @@ public final class DocumentEngine {
         ))
 
         return amended
-    }
-
-    /// Append a single audit row for a lifecycle action (submit/cancel/amend).
-    /// Lives outside the save's atomic block — the save itself is durable, and
-    /// adding a follow-on audit row keeps the writer composable.
-    private func writeLifecycleAuditEntry(
-        documentId: String,
-        docType: String,
-        action: String,
-        operatorId: String,
-        extraJSON: String = "{}"
-    ) throws {
-        try database.write { db in
-            try auditLogWriter.append(
-                AuditLogEntry(
-                    documentId: documentId,
-                    docType: docType,
-                    userId: operatorId,
-                    action: action,
-                    payloadJSON: extraJSON
-                ),
-                in: db
-            )
-        }
     }
 
     // MARK: - Audit log readers (Phase A §3.2)

--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -129,6 +129,15 @@ public final class DocumentEngine {
         self.userId = userId
     }
 
+    // MARK: - Execution context (P0.1)
+
+    /// Resolve the per-operation `ExecutionContext`. When a caller does not
+    /// supply one, fall back to a `.legacy(...)` context built from the
+    /// engine's constructor identity so pre-P0.1 call sites are unchanged.
+    private func resolved(_ context: ExecutionContext?) -> ExecutionContext {
+        context ?? ExecutionContext.legacy(userId: userId, deviceId: deviceId)
+    }
+
     // MARK: - Cross-document lookup (ADR-029, P2.2)
 
     /// Read-through cache around the engine's own `lookup(docType:name:field:)`.
@@ -151,14 +160,19 @@ public final class DocumentEngine {
     /// If `document.id` is empty, `NamingService` resolves it from the DocType's
     /// `autoname` (defaulting to UUIDv7). (P1.1 / ADR-014)
     @discardableResult
-    public func save(_ document: Document, userSuppliedName: String? = nil) throws -> Document {
+    public func save(
+        _ document: Document,
+        userSuppliedName: String? = nil,
+        context: ExecutionContext? = nil
+    ) throws -> Document {
+        let ctx = resolved(context)
         var document = try assigningNameIfNeeded(document, userSuppliedName: userSuppliedName)
 
         let existing = try loadExistingState(docType: document.docType, id: document.id)
 
         if let docType = registry.get(document.docType) {
             try validator.validate(docType)
-            document = try runValidationPipeline(on: document, docType: docType, isNew: existing == nil)
+            document = try runValidationPipeline(on: document, docType: docType, isNew: existing == nil, context: ctx)
 
             if document.docStatus == 1 && docType.isSubmittable {
                 try enforceSubmitImmutability(document: document, docType: docType)
@@ -183,8 +197,8 @@ public final class DocumentEngine {
             id: UUID(),
             type: .upsertDocument,
             payload: try encoder.encode(document),
-            deviceId: deviceId,
-            userId: userId,
+            deviceId: ctx.deviceId,
+            userId: ctx.operatorId,
             localTimestamp: Date(),
             syncVersion: document.syncVersion,
             status: .pending
@@ -208,13 +222,13 @@ public final class DocumentEngine {
             try recordDocumentVersion(
                 db, document: document,
                 savedAt: saveTimestamp,
-                savedBy: userId,
+                savedBy: ctx.operatorId,
                 oldFields: oldFields
             )
             try auditLogWriter.append(
                 documentId: document.id,
                 docType: document.docType,
-                userId: userId,
+                userId: ctx.operatorId,
                 action: auditAction,
                 before: existing == nil ? nil : oldFields,
                 after: document.fields,
@@ -349,7 +363,8 @@ public final class DocumentEngine {
     // MARK: - Delete
 
     /// Delete a document. Appends a `deleteDocument` mutation atomically.
-    public func delete(docType: String, id: String) throws {
+    public func delete(docType: String, id: String, context: ExecutionContext? = nil) throws {
+        let ctx = resolved(context)
         // ADR-013: Submitted documents cannot be deleted directly.
         let existing = try fetch(docType: docType, id: id)
         if let existing = existing, existing.docStatus == 1 {
@@ -361,8 +376,8 @@ public final class DocumentEngine {
             id: UUID(),
             type: .deleteDocument,
             payload: deletePayload,
-            deviceId: deviceId,
-            userId: userId,
+            deviceId: ctx.deviceId,
+            userId: ctx.operatorId,
             localTimestamp: Date(),
             syncVersion: 0,
             status: .pending
@@ -394,7 +409,7 @@ public final class DocumentEngine {
             try auditLogWriter.append(
                 documentId: id,
                 docType: docType,
-                userId: userId,
+                userId: ctx.operatorId,
                 action: "delete",
                 before: existing?.fields,
                 after: nil,
@@ -406,7 +421,7 @@ public final class DocumentEngine {
         // transaction because attachment metadata + bytes have their own
         // atomic boundary inside `AttachmentManager.deleteAll(...)`.
         if let attachmentManager {
-            try? attachmentManager.deleteAll(forDocumentId: id, userId: userId)
+            try? attachmentManager.deleteAll(forDocumentId: id, userId: ctx.operatorId)
         }
 
         eventEmitter.publish(DocumentDeletedEvent(
@@ -418,7 +433,8 @@ public final class DocumentEngine {
     // MARK: - Submit (ADR-013)
 
     /// Submit a document, transitioning it from Draft (docStatus 0) to Submitted (docStatus 1).
-    public func submit(_ document: inout Document) throws {
+    public func submit(_ document: inout Document, context: ExecutionContext? = nil) throws {
+        let ctx = resolved(context)
         guard let docType = registry.get(document.docType) else {
             throw DocumentEngineError.docTypeNotFound(document.docType)
         }
@@ -438,12 +454,13 @@ public final class DocumentEngine {
         // made a freshly-fetched document look stale and threw
         // `concurrencyConflict` whenever a second had elapsed since the last
         // save (ISO8601 second-truncation only hid it within the same second).
-        try save(document)
+        try save(document, context: ctx)
 
         try writeLifecycleAuditEntry(
             documentId: document.id,
             docType: document.docType,
-            action: "submit"
+            action: "submit",
+            operatorId: ctx.operatorId
         )
 
         eventEmitter.publish(DocumentSubmittedEvent(
@@ -456,7 +473,8 @@ public final class DocumentEngine {
 
     /// Cancel a submitted document, transitioning it from Submitted (1) to Cancelled (2).
     /// Rejects if any downstream submitted document holds a Link field pointing here. (ADR-013)
-    public func cancel(_ document: inout Document) throws {
+    public func cancel(_ document: inout Document, context: ExecutionContext? = nil) throws {
+        let ctx = resolved(context)
         guard let docType = registry.get(document.docType) else {
             throw DocumentEngineError.docTypeNotFound(document.docType)
         }
@@ -481,12 +499,13 @@ public final class DocumentEngine {
         // See `submit(...)`: leave `updatedAt` untouched so the optimistic
         // concurrency check in `save(...)` compares like-for-like against the
         // stored row and stamps its own fresh timestamp.
-        try save(document)
+        try save(document, context: ctx)
 
         try writeLifecycleAuditEntry(
             documentId: document.id,
             docType: document.docType,
-            action: "cancel"
+            action: "cancel",
+            operatorId: ctx.operatorId
         )
 
         eventEmitter.publish(DocumentCancelledEvent(
@@ -499,7 +518,8 @@ public final class DocumentEngine {
 
     /// Amend a cancelled document by creating a new Draft copy. `parentID` is not
     /// inherited — the amended copy is placed at the tree root. (ADR-013)
-    public func amend(_ document: Document) throws -> Document {
+    public func amend(_ document: Document, context: ExecutionContext? = nil) throws -> Document {
+        let ctx = resolved(context)
         guard let docType = registry.get(document.docType) else {
             throw DocumentEngineError.docTypeNotFound(document.docType)
         }
@@ -540,12 +560,13 @@ public final class DocumentEngine {
         }
         amended.children = newChildren
 
-        try save(amended)
+        try save(amended, context: ctx)
 
         try writeLifecycleAuditEntry(
             documentId: amended.id,
             docType: amended.docType,
             action: "amend",
+            operatorId: ctx.operatorId,
             extraJSON: "{\"amendedFrom\":\"\(document.id)\"}"
         )
 
@@ -565,6 +586,7 @@ public final class DocumentEngine {
         documentId: String,
         docType: String,
         action: String,
+        operatorId: String,
         extraJSON: String = "{}"
     ) throws {
         try database.write { db in
@@ -572,7 +594,7 @@ public final class DocumentEngine {
                 AuditLogEntry(
                     documentId: documentId,
                     docType: docType,
-                    userId: userId,
+                    userId: operatorId,
                     action: action,
                     payloadJSON: extraJSON
                 ),
@@ -1203,12 +1225,15 @@ public final class DocumentEngine {
     private func runValidationPipeline(
         on document: Document,
         docType: DocType,
-        isNew: Bool
+        isNew: Bool,
+        context: ExecutionContext? = nil
     ) throws -> Document {
+        let exec = resolved(context)
         var document = document
         let ctx = ValidationContext(
             docType: docType,
-            userId: userId,
+            userId: exec.operatorId,
+            userRoles: exec.roles,
             operation: isNew ? .create : .write,
             expressionEvaluator: ExpressionEvaluator(),
             documentExists: { [weak self] linkedDocType, linkedId in

--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -107,6 +107,13 @@ public final class DocumentEngine {
     /// (P0.4). Off by default so enabling it is a deliberate deployment choice.
     private let failClosedForSubmittable: Bool
 
+    /// Ambient execution-context provider (P0.2). When a call supplies no
+    /// explicit `context:`, the engine consults this before falling back to the
+    /// instance identity. Hub points it at the signed-in operator so audit and
+    /// permission checks reflect the live operator without threading a context
+    /// through every call site.
+    private var contextProvider: (() -> ExecutionContext?)?
+
     public init(
         database: MercantisDatabase,
         registry: MetadataRegistry,
@@ -117,7 +124,8 @@ public final class DocumentEngine {
         namingService: NamingService = NamingService(),
         permissionEngine: PermissionEngine = PermissionEngine(),
         attachmentManager: AttachmentManager? = nil,
-        failClosedForSubmittable: Bool = false
+        failClosedForSubmittable: Bool = false,
+        contextProvider: (() -> ExecutionContext?)? = nil
     ) {
         self.database = database
         self.registry = registry
@@ -132,15 +140,25 @@ public final class DocumentEngine {
         self.deviceId = deviceId
         self.userId = userId
         self.failClosedForSubmittable = failClosedForSubmittable
+        self.contextProvider = contextProvider
     }
 
-    // MARK: - Execution context (P0.1)
+    // MARK: - Execution context (P0.1 / P0.2)
 
-    /// Resolve the per-operation `ExecutionContext`. When a caller does not
-    /// supply one, fall back to a `.legacy(...)` context built from the
-    /// engine's constructor identity so pre-P0.1 call sites are unchanged.
+    /// Set (or replace) the ambient execution-context provider (P0.2). Hub uses
+    /// this to resolve the currently signed-in operator at call time.
+    public func setExecutionContextProvider(_ provider: (() -> ExecutionContext?)?) {
+        self.contextProvider = provider
+    }
+
+    /// Resolve the per-operation `ExecutionContext`. Precedence: an explicit
+    /// `context:` argument, then the ambient `contextProvider` (the live
+    /// operator), then a `.legacy(...)` context built from the engine's
+    /// constructor identity so pre-P0.1 call sites are unchanged.
     private func resolved(_ context: ExecutionContext?) -> ExecutionContext {
-        context ?? ExecutionContext.legacy(userId: userId, deviceId: deviceId)
+        if let context { return context }
+        if let provided = contextProvider?() { return provided }
+        return ExecutionContext.legacy(userId: userId, deviceId: deviceId)
     }
 
     // MARK: - Cross-document lookup (ADR-029, P2.2)

--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -355,7 +355,17 @@ public final class DocumentEngine {
 
         if let docType = registry.get(doc.docType) {
             try validator.validate(docType)
-            doc = try runValidationPipeline(on: doc, docType: docType, isNew: existing == nil)
+            // Remote applies are already validated on the origin device; run
+            // validation under an explicit system context so they are neither
+            // re-gated by, nor consult, the local operator's ambient context
+            // (which may not even be resolvable off the main thread). (P0.2/P0.4)
+            let remoteContext = ExecutionContext.system(
+                operatorId: mutation.userId.isEmpty ? userId : mutation.userId,
+                deviceId: mutation.deviceId
+            )
+            doc = try runValidationPipeline(
+                on: doc, docType: docType, isNew: existing == nil, context: remoteContext
+            )
             if doc.docStatus == 1 && docType.isSubmittable {
                 try enforceSubmitImmutability(document: doc, docType: docType)
             }

--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -103,6 +103,9 @@ public final class DocumentEngine {
     private let attachmentManager: AttachmentManager?
     private let deviceId: String
     private let userId: String
+    /// When true, submittable DocTypes are fail-closed in the permission stage
+    /// (P0.4). Off by default so enabling it is a deliberate deployment choice.
+    private let failClosedForSubmittable: Bool
 
     public init(
         database: MercantisDatabase,
@@ -113,7 +116,8 @@ public final class DocumentEngine {
         validationPipeline: ValidationPipeline = ValidationPipeline(),
         namingService: NamingService = NamingService(),
         permissionEngine: PermissionEngine = PermissionEngine(),
-        attachmentManager: AttachmentManager? = nil
+        attachmentManager: AttachmentManager? = nil,
+        failClosedForSubmittable: Bool = false
     ) {
         self.database = database
         self.registry = registry
@@ -127,6 +131,7 @@ public final class DocumentEngine {
         self.attachmentManager = attachmentManager
         self.deviceId = deviceId
         self.userId = userId
+        self.failClosedForSubmittable = failClosedForSubmittable
     }
 
     // MARK: - Execution context (P0.1)
@@ -1259,7 +1264,9 @@ public final class DocumentEngine {
             },
             childDocTypeProvider: { [weak self] childTypeName in
                 self?.registry.get(childTypeName)
-            }
+            },
+            isSystemOperation: exec.isSystemOperation,
+            failClosedForSubmittable: failClosedForSubmittable
         )
         let errors = validationPipeline.validate(document: &document, context: ctx)
         if !errors.isEmpty {

--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -223,7 +223,8 @@ public final class DocumentEngine {
                 db, document: document,
                 savedAt: saveTimestamp,
                 savedBy: ctx.operatorId,
-                oldFields: oldFields
+                oldFields: oldFields,
+                oldChildren: existing?.children ?? [:]
             )
             try auditLogWriter.append(
                 documentId: document.id,
@@ -341,7 +342,8 @@ public final class DocumentEngine {
                 db, document: doc,
                 savedAt: savedAt,
                 savedBy: savedBy,
-                oldFields: oldFields
+                oldFields: oldFields,
+                oldChildren: existing?.children ?? [:]
             )
             try auditLogWriter.append(
                 documentId: doc.id,
@@ -1254,6 +1256,9 @@ public final class DocumentEngine {
             previousStatus: { [weak self] docTypeName, docId in
                 guard let self else { return nil }
                 return try? self.loadStatus(docType: docTypeName, id: docId)
+            },
+            childDocTypeProvider: { [weak self] childTypeName in
+                self?.registry.get(childTypeName)
             }
         )
         let errors = validationPipeline.validate(document: &document, context: ctx)
@@ -1294,24 +1299,51 @@ public final class DocumentEngine {
     private func loadExistingState(
         docType: String,
         id: String
-    ) throws -> (updatedAt: String?, fields: [String: FieldValue])? {
-        let row = try database.read { db in
-            try Row.fetchOne(
+    ) throws -> (updatedAt: String?, fields: [String: FieldValue], children: [String: [ChildRow]])? {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let (row, childRows) = try database.read { db -> (Row?, [Row]) in
+            let row = try Row.fetchOne(
                 db,
                 sql: "SELECT updatedAt, payload FROM documents WHERE id = ? AND doctype = ? LIMIT 1",
                 arguments: [id, docType]
             )
+            guard row != nil else { return (nil, []) }
+            let childRows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT id, tableName, rowIndex, payload FROM document_children
+                    WHERE parentId = ?
+                    ORDER BY tableName ASC, rowIndex ASC
+                    """,
+                arguments: [id]
+            )
+            return (row, childRows)
         }
         guard let row = row else { return nil }
+
         let updatedAt: String? = row["updatedAt"]
         var fields: [String: FieldValue] = [:]
         let payloadString: String = row["payload"] ?? "{}"
         if let data = payloadString.data(using: .utf8) {
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
             fields = (try? decoder.decode([String: FieldValue].self, from: data)) ?? [:]
         }
-        return (updatedAt, fields)
+
+        var children: [String: [ChildRow]] = [:]
+        for childRow in childRows {
+            let childId: String = childRow["id"] ?? ""
+            let tableName: String = childRow["tableName"] ?? ""
+            let rowIndex: Int = childRow["rowIndex"] ?? 0
+            let childPayload: String = childRow["payload"] ?? "{}"
+            let rowFields = (childPayload.data(using: .utf8)
+                .flatMap { try? decoder.decode([String: FieldValue].self, from: $0) }) ?? [:]
+            children[tableName, default: []].append(
+                ChildRow(id: childId, rowIndex: rowIndex, fields: rowFields)
+            )
+        }
+
+        return (updatedAt, fields, children)
     }
 
     private func upsertDocumentRow(
@@ -1428,9 +1460,13 @@ public final class DocumentEngine {
         document: Document,
         savedAt: Date,
         savedBy: String,
-        oldFields: [String: FieldValue]
+        oldFields: [String: FieldValue],
+        oldChildren: [String: [ChildRow]] = [:]
     ) throws {
-        let diffs = computeFieldDiffs(oldFields: oldFields, newFields: document.fields)
+        // Parent-field diffs plus child-row diffs (P0.6), so a submitted
+        // document's line-item edits are captured in version history too.
+        var diffs = computeFieldDiffs(oldFields: oldFields, newFields: document.fields)
+        diffs.append(contentsOf: computeChildDiffs(oldChildren: oldChildren, newChildren: document.children))
         guard !diffs.isEmpty else { return }
 
         let version = DocumentVersion(
@@ -1499,6 +1535,21 @@ public final class DocumentEngine {
             if oldValue != newValue && !allowedKeys.contains(key) {
                 throw DocumentEngineError.fieldImmutableAfterSubmit(
                     fieldKey: key, documentId: document.id
+                )
+            }
+        }
+
+        // Child rows are frozen after submit too (P0.6), unless the table field
+        // is explicitly `allowOnSubmit`. Rows are compared in (rowIndex, id)
+        // order so a stable reorder is not mistaken for an edit.
+        for field in docType.fields where field.type == .table && !field.allowOnSubmit {
+            let oldRows = (existing.children[field.key] ?? [])
+                .sorted { ($0.rowIndex, $0.id) < ($1.rowIndex, $1.id) }
+            let newRows = (document.children[field.key] ?? [])
+                .sorted { ($0.rowIndex, $0.id) < ($1.rowIndex, $1.id) }
+            if oldRows != newRows {
+                throw DocumentEngineError.fieldImmutableAfterSubmit(
+                    fieldKey: field.key, documentId: document.id
                 )
             }
         }

--- a/mercantis core/DocumentEngine/DocumentVersion.swift
+++ b/mercantis core/DocumentEngine/DocumentVersion.swift
@@ -98,3 +98,58 @@ public func computeFieldDiffs(
 
     return diffs
 }
+
+/// Computes child-table diffs as flattened `FieldDiff` entries. (P0.6)
+///
+/// Before this, document versions captured only parent-field changes, so a
+/// submitted invoice's line-item edits (add/remove a row, change a qty or rate)
+/// left no version history. Each changed child cell is recorded with a
+/// `tableName[rowIndex].fieldKey` key; whole-row additions and removals are
+/// recorded as a `tableName[rowIndex]` entry whose value carries the row id.
+///
+/// Rows are matched by their stable `id` (not position) so reordering a table
+/// does not masquerade as a full rewrite.
+public func computeChildDiffs(
+    oldChildren: [String: [ChildRow]],
+    newChildren: [String: [ChildRow]]
+) -> [FieldDiff] {
+    var diffs: [FieldDiff] = []
+    let tables = Set(oldChildren.keys).union(newChildren.keys)
+
+    for table in tables.sorted() {
+        let oldRows = oldChildren[table] ?? []
+        let newRows = newChildren[table] ?? []
+        let oldById = Dictionary(oldRows.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        let newById = Dictionary(newRows.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        let ids = Set(oldById.keys).union(newById.keys)
+
+        for id in ids.sorted() {
+            switch (oldById[id], newById[id]) {
+            case let (.some(oldRow), .some(newRow)):
+                for fd in computeFieldDiffs(oldFields: oldRow.fields, newFields: newRow.fields) {
+                    diffs.append(FieldDiff(
+                        fieldKey: "\(table)[\(newRow.rowIndex)].\(fd.fieldKey)",
+                        oldValue: fd.oldValue,
+                        newValue: fd.newValue
+                    ))
+                }
+            case let (.some(oldRow), .none):
+                diffs.append(FieldDiff(
+                    fieldKey: "\(table)[\(oldRow.rowIndex)]",
+                    oldValue: .string("row:\(id)"),
+                    newValue: nil
+                ))
+            case let (.none, .some(newRow)):
+                diffs.append(FieldDiff(
+                    fieldKey: "\(table)[\(newRow.rowIndex)]",
+                    oldValue: nil,
+                    newValue: .string("row:\(id)")
+                ))
+            case (.none, .none):
+                break
+            }
+        }
+    }
+
+    return diffs
+}

--- a/mercantis core/DocumentEngine/UnitOfWork.swift
+++ b/mercantis core/DocumentEngine/UnitOfWork.swift
@@ -1,0 +1,85 @@
+//
+//  UnitOfWork.swift
+//  mercantis core
+//
+//  Phase 0 / P0.8 — a transaction-scoped seam that lets work *beyond* the core
+//  document write (lifecycle audit today; posting batches in Phase 1) commit in
+//  the SAME GRDB transaction as the document mutation.
+//
+//  Today `DocumentEngine.submit(...)` flips `docStatus`, calls `save(...)` (one
+//  transaction), then appends the lifecycle audit row in a *second* transaction,
+//  and Hub posting runs in a post-commit event handler in yet more transactions.
+//  That is the root cause of "submitted but unposted / partially posted"
+//  documents. `UnitOfWork` is the boundary that closes that gap: a closure given
+//  a `UnitOfWork` runs inside the document write block, so anything it does is
+//  atomic with the lifecycle change — it commits together or rolls back together.
+//
+
+import Foundation
+import GRDB
+
+/// An extra audit row to append inside a lifecycle operation's transaction
+/// (e.g. the `submit` / `cancel` / `amend` row), so the audit trail can never
+/// be lost to a crash between the state change and the audit write.
+public struct LifecycleAudit: Sendable {
+    public let action: String
+    public let extraJSON: String
+
+    public init(action: String, extraJSON: String = "{}") {
+        self.action = action
+        self.extraJSON = extraJSON
+    }
+}
+
+/// A handle to the in-flight write transaction, plus the `ExecutionContext`
+/// driving it. Passed to `DocumentEngine.save(..., inTransaction:)` so callers
+/// (and, in Phase 1, posting handlers) can write additional rows that must
+/// commit atomically with the document.
+///
+/// The underlying GRDB `Database` is exposed so Phase 1 can append ledger rows
+/// without opening a nested transaction (which GRDB forbids). It is only ever
+/// constructed by `DocumentEngine` from inside an active `database.write` block.
+public struct UnitOfWork {
+
+    /// The active write transaction. Valid only for the duration of the
+    /// enclosing `save(...)` call — do not capture it beyond that.
+    public let db: Database
+
+    /// Who/what is performing the operation. Posting and audit rows written
+    /// through this unit of work should attribute to `context.operatorId`.
+    public let context: ExecutionContext
+
+    private let auditLogWriter: AuditLogWriter
+
+    init(db: Database, context: ExecutionContext, auditLogWriter: AuditLogWriter) {
+        self.db = db
+        self.context = context
+        self.auditLogWriter = auditLogWriter
+    }
+
+    /// Append an audit row in this transaction, attributed to the operator.
+    @discardableResult
+    public func audit(
+        action: String,
+        documentId: String,
+        docType: String,
+        payloadJSON: String = "{}"
+    ) throws -> AuditLogEntry {
+        let entry = AuditLogEntry(
+            documentId: documentId,
+            docType: docType,
+            userId: context.operatorId,
+            action: action,
+            payloadJSON: payloadJSON
+        )
+        try auditLogWriter.append(entry, in: db)
+        return entry
+    }
+
+    /// Execute arbitrary SQL in this transaction. Phase 1 posting uses this (and
+    /// later a typed ledger-append helper) to write GL / stock / subledger rows
+    /// atomically with the source document's submit.
+    public func execute(sql: String, arguments: StatementArguments = StatementArguments()) throws {
+        try db.execute(sql: sql, arguments: arguments)
+    }
+}

--- a/mercantis core/DocumentEngine/ValidationPipeline.swift
+++ b/mercantis core/DocumentEngine/ValidationPipeline.swift
@@ -72,6 +72,17 @@ public struct ValidationContext: Sendable {
     /// declared child DocType. Default: always nil (no child validation).
     public let childDocTypeProvider: @Sendable (String) -> DocType?
 
+    /// Whether this operation is an explicit system / import / migration action.
+    /// When true, `PermissionStage` does not gate it. (P0.4)
+    public let isSystemOperation: Bool
+
+    /// When true, submittable (financial / transactional) DocTypes are
+    /// fail-CLOSED in `PermissionStage`: an empty role set or a DocType with no
+    /// declared permission rules is denied rather than allowed. Defaults to
+    /// false so the legacy permissive behaviour is unchanged until a deployment
+    /// opts in (Hub does so once roles + operator propagation are wired). (P0.4)
+    public let failClosedForSubmittable: Bool
+
     public init(
         docType: DocType,
         userId: String = "",
@@ -83,7 +94,9 @@ public struct ValidationContext: Sendable {
         uniqueConflictExists: @escaping @Sendable (String, String, FieldValue, String) -> Bool = { _, _, _, _ in false },
         workflowProvider: @escaping @Sendable (String) -> WorkflowDefinition? = { _ in nil },
         previousStatus: @escaping @Sendable (String, String) -> String? = { _, _ in nil },
-        childDocTypeProvider: @escaping @Sendable (String) -> DocType? = { _ in nil }
+        childDocTypeProvider: @escaping @Sendable (String) -> DocType? = { _ in nil },
+        isSystemOperation: Bool = false,
+        failClosedForSubmittable: Bool = false
     ) {
         self.docType = docType
         self.userId = userId
@@ -96,6 +109,8 @@ public struct ValidationContext: Sendable {
         self.workflowProvider = workflowProvider
         self.previousStatus = previousStatus
         self.childDocTypeProvider = childDocTypeProvider
+        self.isSystemOperation = isSystemOperation
+        self.failClosedForSubmittable = failClosedForSubmittable
     }
 }
 
@@ -741,8 +756,34 @@ public struct PermissionStage: ValidationStage {
     public init() {}
 
     public func validate(document: Document, context: ValidationContext) -> [DocumentValidationError] {
-        guard !context.userRoles.isEmpty else { return [] }
-        guard !context.docType.permissions.isEmpty else { return [] }
+        // Explicit system / import / migration operations are never gated. (P0.4)
+        if context.isSystemOperation { return [] }
+
+        // Submittable (financial / transactional) DocTypes are fail-CLOSED when a
+        // deployment opts in: they must not silently allow an unauthenticated or
+        // unconstrained write. Non-submittable masters keep the legacy permissive
+        // behaviour, and the whole tightening is off by default. (P0.4)
+        let requiresExplicitGrant = context.failClosedForSubmittable && context.docType.isSubmittable
+
+        guard !context.userRoles.isEmpty else {
+            if requiresExplicitGrant {
+                return [deniedError(
+                    context,
+                    reason: "requires an authenticated operator with a granting role"
+                )]
+            }
+            return []
+        }
+
+        guard !context.docType.permissions.isEmpty else {
+            if requiresExplicitGrant {
+                return [deniedError(
+                    context,
+                    reason: "declares no permission rules, so no role may \(describe(context.operation)) it"
+                )]
+            }
+            return []
+        }
 
         let allowed = context.permissionEngine.canPerform(
             operation: context.operation,
@@ -750,13 +791,18 @@ public struct PermissionStage: ValidationStage {
             userRoles: context.userRoles
         )
         if !allowed {
-            return [DocumentValidationError(
-                stage: stageName,
-                field: nil,
-                message: "User does not have permission to \(describe(context.operation)) '\(context.docType.name)' documents."
-            )]
+            return [deniedError(context, reason: nil)]
         }
         return []
+    }
+
+    private func deniedError(_ context: ValidationContext, reason: String?) -> DocumentValidationError {
+        let base = "User does not have permission to \(describe(context.operation)) '\(context.docType.name)' documents."
+        return DocumentValidationError(
+            stage: stageName,
+            field: nil,
+            message: reason.map { "\(base) (\($0))" } ?? base
+        )
     }
 
     private func describe(_ operation: DocumentOperation) -> String {

--- a/mercantis core/DocumentEngine/ValidationPipeline.swift
+++ b/mercantis core/DocumentEngine/ValidationPipeline.swift
@@ -67,6 +67,11 @@ public struct ValidationContext: Sendable {
     /// `WorkflowGuardStage` to detect state transitions. Default: always nil.
     public let previousStatus: @Sendable (String, String) -> String?
 
+    /// Resolve a child DocType definition by name. Used by
+    /// `ChildTableValidationStage` (P0.5) to validate table rows against their
+    /// declared child DocType. Default: always nil (no child validation).
+    public let childDocTypeProvider: @Sendable (String) -> DocType?
+
     public init(
         docType: DocType,
         userId: String = "",
@@ -77,7 +82,8 @@ public struct ValidationContext: Sendable {
         documentExists: @escaping @Sendable (String, String) -> Bool = { _, _ in true },
         uniqueConflictExists: @escaping @Sendable (String, String, FieldValue, String) -> Bool = { _, _, _, _ in false },
         workflowProvider: @escaping @Sendable (String) -> WorkflowDefinition? = { _ in nil },
-        previousStatus: @escaping @Sendable (String, String) -> String? = { _, _ in nil }
+        previousStatus: @escaping @Sendable (String, String) -> String? = { _, _ in nil },
+        childDocTypeProvider: @escaping @Sendable (String) -> DocType? = { _ in nil }
     ) {
         self.docType = docType
         self.userId = userId
@@ -89,6 +95,7 @@ public struct ValidationContext: Sendable {
         self.uniqueConflictExists = uniqueConflictExists
         self.workflowProvider = workflowProvider
         self.previousStatus = previousStatus
+        self.childDocTypeProvider = childDocTypeProvider
     }
 }
 
@@ -134,6 +141,7 @@ public final class ValidationPipeline {
             RequiredFieldStage(),
             LinkValidationStage(),
             UniqueConstraintStage(),
+            ChildTableValidationStage(),
             ValidationRuleStage(),
             WorkflowGuardStage(),
             PermissionStage()
@@ -447,6 +455,140 @@ public struct UniqueConstraintStage: ValidationStage {
             }
         }
 
+        return errors
+    }
+
+    private func isNull(_ value: FieldValue) -> Bool {
+        if case .null = value { return true }
+        return false
+    }
+}
+
+// MARK: - Stage 4b: Child Table Validation (P0.5)
+
+/// Recursively validates child-table rows against their declared child DocType.
+///
+/// Before this stage, a `.table` field was only checked for emptiness
+/// (`RequiredFieldStage`); the *contents* of each row received no type, option,
+/// link, or rule validation, so financial line items (qty, rate, item link,
+/// tax code) could be persisted with invalid or dangling values. This stage
+/// runs the field-level stages (`TypeCoercion`, `RequiredField`,
+/// `LinkValidation`, `ValidationRule`) against every row of every table field
+/// whose child DocType resolves via `context.childDocTypeProvider`, and also
+/// enforces the child DocType's unique indexes *within the table scope*
+/// (e.g. no duplicate item line if the child DocType marks `item` unique).
+///
+/// Errors are re-attributed with a `tableKey[rowIndex].field` path and a
+/// human-readable "Row N:" prefix so the UI can point at the offending cell.
+///
+/// When a table field has no resolvable child DocType (legacy / untyped
+/// tables), its rows are skipped — behaviour is unchanged for those.
+public struct ChildTableValidationStage: ValidationStage {
+    public let stageName = "ChildTableValidation"
+
+    /// Field-level stages re-used per child row. Unique/Workflow/Permission are
+    /// parent-scoped and intentionally excluded; child uniqueness is handled
+    /// table-locally below.
+    private let rowStages: [ValidationStage] = [
+        TypeCoercionStage(),
+        RequiredFieldStage(),
+        LinkValidationStage(),
+        ValidationRuleStage()
+    ]
+
+    public init() {}
+
+    public func validate(document: Document, context: ValidationContext) -> [DocumentValidationError] {
+        var errors: [DocumentValidationError] = []
+
+        for field in context.docType.fields where field.type == .table {
+            guard let childTypeName = field.childDocType,
+                  let childType = context.childDocTypeProvider(childTypeName) else {
+                continue
+            }
+            let rows = document.children[field.key] ?? []
+
+            // Per-row field validation.
+            for (index, row) in rows.enumerated() {
+                let childDoc = makeChildDocument(row: row, childType: childType, parent: document)
+                let childContext = makeChildContext(childType: childType, parent: context)
+                for stage in rowStages {
+                    for error in stage.validate(document: childDoc, context: childContext) {
+                        errors.append(DocumentValidationError(
+                            stage: stageName,
+                            field: rowFieldPath(table: field.key, index: index, field: error.field),
+                            message: "Row \(index + 1): \(error.message)"
+                        ))
+                    }
+                }
+            }
+
+            // Table-scoped uniqueness: enforce the child DocType's unique
+            // indexes across the rows of this one table (P0.5 duplicate-row
+            // detection). Legitimate exact-duplicate lines are allowed unless
+            // the child DocType explicitly marks a field unique.
+            errors.append(contentsOf: duplicateRowErrors(rows: rows, childType: childType, tableKey: field.key))
+        }
+
+        return errors
+    }
+
+    private func makeChildDocument(row: ChildRow, childType: DocType, parent: Document) -> Document {
+        Document(
+            id: row.id,
+            docType: childType.id,
+            company: parent.company,
+            status: "",
+            createdAt: parent.createdAt,
+            updatedAt: parent.updatedAt,
+            syncVersion: 0,
+            syncState: .local,
+            fields: row.fields,
+            children: [:]
+        )
+    }
+
+    private func makeChildContext(childType: DocType, parent: ValidationContext) -> ValidationContext {
+        ValidationContext(
+            docType: childType,
+            userId: parent.userId,
+            userRoles: parent.userRoles,
+            operation: parent.operation,
+            expressionEvaluator: parent.expressionEvaluator,
+            permissionEngine: parent.permissionEngine,
+            documentExists: parent.documentExists,
+            // Child uniqueness is handled table-locally, not against the store.
+            uniqueConflictExists: { _, _, _, _ in false },
+            workflowProvider: { _ in nil },
+            previousStatus: { _, _ in nil },
+            childDocTypeProvider: parent.childDocTypeProvider
+        )
+    }
+
+    private func rowFieldPath(table: String, index: Int, field: String?) -> String {
+        guard let field else { return "\(table)[\(index)]" }
+        return "\(table)[\(index)].\(field)"
+    }
+
+    private func duplicateRowErrors(rows: [ChildRow], childType: DocType, tableKey: String) -> [DocumentValidationError] {
+        var errors: [DocumentValidationError] = []
+        for index in childType.indexes where index.unique {
+            // (value, firstRowIndex) pairs; linear scan keeps this dependent only
+            // on FieldValue: Equatable (it is not guaranteed Hashable).
+            var seen: [(value: FieldValue, row: Int)] = []
+            for (rowIndex, row) in rows.enumerated() {
+                guard let value = row.fields[index.fieldKey], !isNull(value) else { continue }
+                if let first = seen.first(where: { $0.value == value }) {
+                    errors.append(DocumentValidationError(
+                        stage: stageName,
+                        field: rowFieldPath(table: tableKey, index: rowIndex, field: index.fieldKey),
+                        message: "Row \(rowIndex + 1): duplicates '\(index.fieldKey)' from row \(first.row + 1)."
+                    ))
+                } else {
+                    seen.append((value, rowIndex))
+                }
+            }
+        }
         return errors
     }
 

--- a/mercantis core/Identity/ExecutionContext.swift
+++ b/mercantis core/Identity/ExecutionContext.swift
@@ -1,0 +1,100 @@
+//
+//  ExecutionContext.swift
+//  mercantis core
+//
+//  Phase 0 / P0.1 — first-class execution identity.
+//
+//  Before this type, `DocumentEngine` baked a single `userId` / `deviceId` into
+//  the instance at construction, so every audit row, document version, and
+//  mutation recorded the same identity regardless of who actually performed the
+//  operation. `ExecutionContext` carries the *live* operator (and their company,
+//  roles, device, and session) into each call, so audit and permission checks
+//  can attribute and authorise per operation.
+//
+//  Threading is intentionally additive: every `DocumentEngine` lifecycle method
+//  takes `context:` as an optional defaulting to `nil`. When `nil`, the engine
+//  synthesises a `.legacy(...)` context from its constructor identity, so all
+//  existing call sites keep their current behaviour until they opt in.
+//
+
+import Foundation
+
+/// Who is performing an operation, on behalf of which company, with which roles,
+/// from which device and session. Propagated into `DocumentEngine` per call so
+/// audit, versioning, mutation provenance, and permission checks reflect the
+/// real operator rather than a single instance-wide identity.
+public struct ExecutionContext: Sendable, Equatable {
+
+    /// The authenticated operator performing the action. Recorded as the
+    /// `userId` on audit rows, the `savedBy` on document versions, and the
+    /// `userId` on mutation records.
+    public let operatorId: String
+
+    /// The company the operation is scoped to. Empty string means "unscoped"
+    /// (single-company deployments). Used by company-scoped access checks.
+    public let companyId: String
+
+    /// The operator's roles, used by permission and workflow-guard checks.
+    public let roles: Set<String>
+
+    /// The physical device. Recorded as the `deviceId` on mutation records and
+    /// used for offline-safe numbering. Stable per install, not per session.
+    public let deviceId: String
+
+    /// The current session (e.g. an unlock session). Optional; empty when not
+    /// tracked. Useful for correlating an operator's actions within one sign-in.
+    public let sessionId: String
+
+    /// `true` for explicit system / import / migration work that is allowed to
+    /// bypass interactive permission gating. Never set this implicitly — it must
+    /// be a deliberate choice at the call site so the bypass is auditable.
+    public let isSystemOperation: Bool
+
+    public init(
+        operatorId: String,
+        companyId: String = "",
+        roles: Set<String> = [],
+        deviceId: String,
+        sessionId: String = "",
+        isSystemOperation: Bool = false
+    ) {
+        self.operatorId = operatorId
+        self.companyId = companyId
+        self.roles = roles
+        self.deviceId = deviceId
+        self.sessionId = sessionId
+        self.isSystemOperation = isSystemOperation
+    }
+}
+
+public extension ExecutionContext {
+
+    /// Backward-compatible context synthesised from a `DocumentEngine`'s
+    /// constructor identity when a caller does not supply a per-operation
+    /// context. Preserves pre-P0.1 behaviour: the instance `userId` becomes the
+    /// operator and no roles are asserted (so role checks remain permissive for
+    /// callers that have not yet adopted `ExecutionContext`).
+    static func legacy(userId: String, deviceId: String) -> ExecutionContext {
+        ExecutionContext(
+            operatorId: userId,
+            deviceId: deviceId,
+            isSystemOperation: false
+        )
+    }
+
+    /// Explicit system / import context: audit-attributed to `operatorId`
+    /// (default `"system"`) and flagged as a system operation so permission
+    /// gating can deliberately exempt it.
+    static func system(
+        operatorId: String = "system",
+        deviceId: String,
+        companyId: String = ""
+    ) -> ExecutionContext {
+        ExecutionContext(
+            operatorId: operatorId,
+            companyId: companyId,
+            deviceId: deviceId,
+            isSystemOperation: true
+        )
+    }
+}

--- a/mercantis coreTests/ChildTableValidationTests.swift
+++ b/mercantis coreTests/ChildTableValidationTests.swift
@@ -1,0 +1,203 @@
+//
+//  ChildTableValidationTests.swift
+//  mercantis coreTests
+//
+//  Phase 0 / P0.5 + P0.6 — child-table rows now receive the same field-level
+//  validation as parent fields (type, required, link, rule, table-scoped
+//  uniqueness), are frozen after submit, and are captured in version history.
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class ChildTableValidationTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness(userId: "tester")
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        harness = nil
+    }
+
+    // MARK: - Fixtures
+
+    private func registerDocTypes(
+        itemUnique: Bool = false,
+        itemsAllowOnSubmit: Bool = false,
+        submittable: Bool = false
+    ) throws {
+        let orderItem = TestSupport.makeDocType(
+            id: "OrderItem",
+            fields: [
+                TestSupport.linkField("item", targeting: "Product"),
+                TestSupport.numberField("qty", required: true),
+                TestSupport.numberField("rate")
+            ],
+            indexes: itemUnique ? [IndexDefinition(fieldKey: "item", unique: true)] : []
+        )
+        let product = TestSupport.makeDocType(
+            id: "Product",
+            fields: [TestSupport.textField("name")]
+        )
+        let items = FieldDefinition(
+            key: "items",
+            label: "Items",
+            type: .table,
+            required: false,
+            childDocType: "OrderItem",
+            allowOnSubmit: itemsAllowOnSubmit
+        )
+        let order = TestSupport.makeDocType(
+            id: "Order",
+            fields: [items],
+            isSubmittable: submittable,
+            syncPolicy: submittable ? TestSupport.submittableSyncPolicy() : nil
+        )
+        try harness.registry.register(orderItem)
+        try harness.registry.register(product)
+        try harness.registry.register(order)
+    }
+
+    private func makeProduct(_ id: String) throws {
+        try harness.engine.save(
+            TestSupport.makeDocument(id: id, docType: "Product", fields: ["name": .string(id)])
+        )
+    }
+
+    private func itemRow(_ id: String, item: String?, qty: FieldValue?, rowIndex: Int = 0) -> ChildRow {
+        var fields: [String: FieldValue] = [:]
+        if let item { fields["item"] = .string(item) }
+        if let qty { fields["qty"] = qty }
+        return ChildRow(id: id, rowIndex: rowIndex, fields: fields)
+    }
+
+    private func order(id: String, rows: [ChildRow]) -> Document {
+        TestSupport.makeDocument(id: id, docType: "Order", fields: [:], children: ["items": rows])
+    }
+
+    private func assertValidationFails(
+        _ document: Document,
+        expectField: String,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(try harness.engine.save(document), message, file: file, line: line) { error in
+            guard case DocumentEngineError.validationFailed(let errors) = error else {
+                return XCTFail("expected validationFailed, got \(error)", file: file, line: line)
+            }
+            XCTAssertTrue(
+                errors.contains { $0.field == expectField },
+                "expected an error on '\(expectField)'; got \(errors.map { $0.field ?? "<nil>" })",
+                file: file, line: line
+            )
+        }
+    }
+
+    // MARK: - Validation
+
+    func testValidChildRowSaves() throws {
+        try registerDocTypes()
+        try makeProduct("p1")
+        XCTAssertNoThrow(
+            try harness.engine.save(order(id: "o1", rows: [itemRow("r1", item: "p1", qty: .int(2))]))
+        )
+    }
+
+    func testChildMissingRequiredFieldFails() throws {
+        try registerDocTypes()
+        try makeProduct("p1")
+        assertValidationFails(
+            order(id: "o2", rows: [itemRow("r1", item: "p1", qty: nil)]),
+            expectField: "items[0].qty",
+            "a required child field must be enforced"
+        )
+    }
+
+    func testChildIncompatibleTypeFails() throws {
+        try registerDocTypes()
+        try makeProduct("p1")
+        assertValidationFails(
+            order(id: "o3", rows: [itemRow("r1", item: "p1", qty: .string("abc"))]),
+            expectField: "items[0].qty",
+            "a non-numeric qty in a child row must be rejected"
+        )
+    }
+
+    func testChildDanglingLinkFails() throws {
+        try registerDocTypes()
+        // Note: no Product created, so the link target does not exist.
+        assertValidationFails(
+            order(id: "o4", rows: [itemRow("r1", item: "ghost", qty: .int(1))]),
+            expectField: "items[0].item",
+            "a child link to a non-existent document must be rejected"
+        )
+    }
+
+    func testDuplicateChildRowFails() throws {
+        try registerDocTypes(itemUnique: true)
+        try makeProduct("p1")
+        let rows = [
+            itemRow("r1", item: "p1", qty: .int(1), rowIndex: 0),
+            itemRow("r2", item: "p1", qty: .int(2), rowIndex: 1)
+        ]
+        assertValidationFails(
+            order(id: "o5", rows: rows),
+            expectField: "items[1].item",
+            "a child DocType's unique index must be enforced within the table"
+        )
+    }
+
+    // MARK: - Immutability (P0.6)
+
+    func testChildRowsFrozenAfterSubmit() throws {
+        try registerDocTypes(submittable: true)
+        try makeProduct("p1")
+        try harness.engine.save(order(id: "o6", rows: [itemRow("r1", item: "p1", qty: .int(1))]))
+        var doc = try XCTUnwrap(harness.engine.fetch(docType: "Order", id: "o6"))
+        try harness.engine.submit(&doc)
+
+        var submitted = try XCTUnwrap(harness.engine.fetch(docType: "Order", id: "o6"))
+        var rows = submitted.children["items"] ?? []
+        rows[0].fields["qty"] = .int(99)
+        submitted.children["items"] = rows
+
+        XCTAssertThrowsError(try harness.engine.save(submitted)) { error in
+            guard case DocumentEngineError.fieldImmutableAfterSubmit(let fieldKey, _) = error else {
+                return XCTFail("expected fieldImmutableAfterSubmit, got \(error)")
+            }
+            XCTAssertEqual(fieldKey, "items")
+        }
+    }
+
+    // MARK: - Versioning (P0.6)
+
+    func testChildRowEditIsVersioned() throws {
+        try registerDocTypes()
+        try makeProduct("p1")
+        try harness.engine.save(order(id: "o7", rows: [itemRow("r1", item: "p1", qty: .int(1))]))
+
+        var doc = try XCTUnwrap(harness.engine.fetch(docType: "Order", id: "o7"))
+        var rows = doc.children["items"] ?? []
+        rows[0].fields["qty"] = .int(7)
+        doc.children["items"] = rows
+        try harness.engine.save(doc)
+
+        let matches = try harness.database.read { db in
+            try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(*) FROM document_versions
+                    WHERE documentId = ? AND fieldDiffs LIKE '%items[0].qty%'
+                    """,
+                arguments: ["o7"]
+            ) ?? 0
+        }
+        XCTAssertGreaterThanOrEqual(matches, 1, "a child-row field change must appear in version history")
+    }
+}

--- a/mercantis coreTests/ExecutionContextTests.swift
+++ b/mercantis coreTests/ExecutionContextTests.swift
@@ -1,0 +1,118 @@
+//
+//  ExecutionContextTests.swift
+//  mercantis coreTests
+//
+//  Phase 0 / P0.1 — a per-operation ExecutionContext attributes audit rows,
+//  document versions, and mutation provenance to the *live* operator, and the
+//  absence of a context preserves pre-P0.1 behaviour (the engine's instance
+//  identity is used).
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class ExecutionContextTests: XCTestCase {
+
+    private var harness: TestSupport.Harness!
+
+    override func setUpWithError() throws {
+        // The engine's constructor identity is deliberately distinct from any
+        // operator below so a test failing to thread context is obvious.
+        harness = try TestSupport.makeHarness(userId: "device-default")
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        harness = nil
+    }
+
+    private func context(_ operatorId: String, roles: Set<String> = []) -> ExecutionContext {
+        ExecutionContext(
+            operatorId: operatorId,
+            companyId: "ACME",
+            roles: roles,
+            deviceId: "device-1",
+            sessionId: "session-1"
+        )
+    }
+
+    func testSaveAttributesAuditToContextOperator() throws {
+        try harness.registry.register(TestSupport.makeDocType())
+        try harness.engine.save(
+            TestSupport.makeDocument(id: "n1", fields: ["title": .string("v1")]),
+            context: context("bob")
+        )
+
+        let entries = try harness.engine.auditEntries(forDocumentId: "n1")
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(
+            entries[0].userId, "bob",
+            "audit must record the live operator, not the engine's instance identity"
+        )
+    }
+
+    func testLifecycleAttributesEachActionToItsOperator() throws {
+        try harness.registry.register(TestSupport.makeDocType(isSubmittable: true))
+        var doc = TestSupport.makeDocument(id: "inv-1", fields: ["title": .string("Invoice 1")])
+        try harness.engine.save(doc, context: context("clerk"))
+        doc = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "inv-1"))
+        try harness.engine.submit(&doc, context: context("manager"))
+
+        let entries = try harness.engine.auditEntries(forDocumentId: "inv-1")
+        let create = try XCTUnwrap(entries.first(where: { $0.action == "create" }))
+        let submit = try XCTUnwrap(entries.first(where: { $0.action == "submit" }))
+        XCTAssertEqual(create.userId, "clerk", "the creating operator must be recorded")
+        XCTAssertEqual(
+            submit.userId, "manager",
+            "the submitting operator must be recorded on the submit lifecycle row"
+        )
+    }
+
+    func testNoContextFallsBackToInstanceIdentity() throws {
+        try harness.registry.register(TestSupport.makeDocType())
+        // No context supplied: behaviour must be unchanged from pre-P0.1.
+        try harness.engine.save(TestSupport.makeDocument(id: "n2", fields: ["title": .string("x")]))
+
+        let entries = try harness.engine.auditEntries(forDocumentId: "n2")
+        XCTAssertEqual(
+            entries[0].userId, "device-default",
+            "absent a context, the engine's instance identity is used"
+        )
+    }
+
+    func testMutationRecordsContextOperatorAndDevice() throws {
+        try harness.registry.register(TestSupport.makeDocType())
+        try harness.engine.save(
+            TestSupport.makeDocument(id: "n3", fields: ["title": .string("v")]),
+            context: context("dana")
+        )
+
+        let provenance = try harness.database.read { db -> (userId: String, deviceId: String) in
+            let row = try XCTUnwrap(
+                Row.fetchOne(
+                    db,
+                    sql: """
+                        SELECT userId, deviceId FROM sync_queue
+                        WHERE type = 'upsertDocument'
+                        ORDER BY localTimestamp DESC LIMIT 1
+                        """
+                )
+            )
+            return (row["userId"] ?? "", row["deviceId"] ?? "")
+        }
+        XCTAssertEqual(provenance.userId, "dana", "mutation provenance must carry the operator")
+        XCTAssertEqual(provenance.deviceId, "device-1", "mutation provenance must carry the device")
+    }
+
+    func testLegacyAndSystemFactoriesCarryExpectedFlags() {
+        let legacy = ExecutionContext.legacy(userId: "u", deviceId: "d")
+        XCTAssertEqual(legacy.operatorId, "u")
+        XCTAssertEqual(legacy.deviceId, "d")
+        XCTAssertFalse(legacy.isSystemOperation)
+
+        let system = ExecutionContext.system(deviceId: "d", companyId: "ACME")
+        XCTAssertEqual(system.operatorId, "system")
+        XCTAssertTrue(system.isSystemOperation, "system context must flag the bypass for audit")
+    }
+}

--- a/mercantis coreTests/PermissionFailClosedTests.swift
+++ b/mercantis coreTests/PermissionFailClosedTests.swift
@@ -1,0 +1,99 @@
+//
+//  PermissionFailClosedTests.swift
+//  mercantis coreTests
+//
+//  Phase 0 / P0.4 — when a deployment opts in, submittable (financial)
+//  DocTypes are fail-CLOSED: an unauthenticated write, or a DocType with no
+//  permission rules, is denied rather than silently allowed. The legacy
+//  permissive behaviour is preserved when the flag is off and for
+//  non-submittable masters.
+//
+
+import XCTest
+@testable import mercantis_core
+
+final class PermissionFailClosedTests: XCTestCase {
+
+    private func makeSubmittable(perms: [PermissionRule]) -> DocType {
+        TestSupport.makeDocType(
+            id: "Invoice",
+            fields: [TestSupport.textField("title", required: true)],
+            permissions: perms,
+            isSubmittable: true,
+            syncPolicy: TestSupport.submittableSyncPolicy()
+        )
+    }
+
+    private func invoice(_ id: String) -> Document {
+        TestSupport.makeDocument(id: id, docType: "Invoice", fields: ["title": .string("X")])
+    }
+
+    private func assertPermissionDenied(
+        _ error: Error,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case DocumentEngineError.validationFailed(let errors) = error else {
+            return XCTFail("expected validationFailed, got \(error)", file: file, line: line)
+        }
+        XCTAssertTrue(
+            errors.contains { $0.stage == "Permission" },
+            "expected a Permission-stage denial; got \(errors.map { $0.stage })",
+            file: file, line: line
+        )
+    }
+
+    func testFlagOffKeepsLegacyPermissiveBehaviour() throws {
+        let h = try TestSupport.makeHarness()
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        try h.registry.register(makeSubmittable(perms: []))
+        // Submittable, no rules, no operator — legacy behaviour still allows it.
+        XCTAssertNoThrow(try h.engine.save(invoice("i1")))
+    }
+
+    func testFailClosedDeniesSubmittableWithoutOperator() throws {
+        let h = try TestSupport.makeHarness(failClosedForSubmittable: true)
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        try h.registry.register(makeSubmittable(perms: [TestSupport.permissionRule(role: "Accountant")]))
+        XCTAssertThrowsError(try h.engine.save(invoice("i2"))) { assertPermissionDenied($0) }
+    }
+
+    func testFailClosedDeniesSubmittableWithNoRules() throws {
+        let h = try TestSupport.makeHarness(failClosedForSubmittable: true)
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        try h.registry.register(makeSubmittable(perms: []))
+        let ctx = ExecutionContext(operatorId: "u", roles: ["Accountant"], deviceId: "d")
+        XCTAssertThrowsError(try h.engine.save(invoice("i3"), context: ctx)) { assertPermissionDenied($0) }
+    }
+
+    func testFailClosedAllowsGrantingRole() throws {
+        let h = try TestSupport.makeHarness(failClosedForSubmittable: true)
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        try h.registry.register(makeSubmittable(perms: [TestSupport.permissionRule(role: "Accountant")]))
+        let ctx = ExecutionContext(operatorId: "u", roles: ["Accountant"], deviceId: "d")
+        XCTAssertNoThrow(try h.engine.save(invoice("i4"), context: ctx))
+    }
+
+    func testFailClosedDeniesNonGrantingRole() throws {
+        let h = try TestSupport.makeHarness(failClosedForSubmittable: true)
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        try h.registry.register(makeSubmittable(perms: [TestSupport.permissionRule(role: "Accountant")]))
+        let ctx = ExecutionContext(operatorId: "u", roles: ["Clerk"], deviceId: "d")
+        XCTAssertThrowsError(try h.engine.save(invoice("i5"), context: ctx)) { assertPermissionDenied($0) }
+    }
+
+    func testFailClosedAllowsExplicitSystemOperation() throws {
+        let h = try TestSupport.makeHarness(failClosedForSubmittable: true)
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        try h.registry.register(makeSubmittable(perms: []))
+        let ctx = ExecutionContext.system(deviceId: "d")
+        XCTAssertNoThrow(try h.engine.save(invoice("i6"), context: ctx))
+    }
+
+    func testFailClosedIgnoresNonSubmittableMasters() throws {
+        let h = try TestSupport.makeHarness(failClosedForSubmittable: true)
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        try h.registry.register(TestSupport.makeDocType(id: "Note", permissions: []))
+        XCTAssertNoThrow(try h.engine.save(TestSupport.makeDocument(id: "n1", fields: ["title": .string("X")])))
+    }
+}

--- a/mercantis coreTests/Support/TestSupport.swift
+++ b/mercantis coreTests/Support/TestSupport.swift
@@ -169,7 +169,8 @@ enum TestSupport {
     static func makeHarness(
         deviceId: String = "test-device",
         userId: String = "test-user",
-        pipeline: ValidationPipeline? = nil
+        pipeline: ValidationPipeline? = nil,
+        failClosedForSubmittable: Bool = false
     ) throws -> Harness {
         let url = tempDatabaseURL()
         let database = try makeDatabase(at: url)
@@ -181,7 +182,8 @@ enum TestSupport {
             deviceId: deviceId,
             userId: userId,
             eventEmitter: emitter,
-            validationPipeline: pipeline ?? ValidationPipeline()
+            validationPipeline: pipeline ?? ValidationPipeline(),
+            failClosedForSubmittable: failClosedForSubmittable
         )
         return Harness(database: database, registry: registry, emitter: emitter, engine: engine, url: url)
     }

--- a/mercantis coreTests/UnitOfWorkTests.swift
+++ b/mercantis coreTests/UnitOfWorkTests.swift
@@ -1,0 +1,83 @@
+//
+//  UnitOfWorkTests.swift
+//  mercantis coreTests
+//
+//  Phase 0 / P0.8 — lifecycle audit rows commit in the SAME transaction as the
+//  docStatus change, and the `inTransaction` unit-of-work seam commits (or rolls
+//  back) atomically with the submit. The rollback test is the Phase-1 contract:
+//  a posting failure must leave no partial state and no "submitted" document.
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class UnitOfWorkTests: XCTestCase {
+
+    private struct InjectedFailure: Error {}
+
+    private var harness: TestSupport.Harness!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness(userId: "tester")
+        try harness.registry.register(TestSupport.makeDocType(isSubmittable: true))
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        harness = nil
+    }
+
+    private func savedDraft(_ id: String) throws -> Document {
+        try harness.engine.save(
+            TestSupport.makeDocument(id: id, fields: ["title": .string("Doc \(id)")])
+        )
+        return try XCTUnwrap(harness.engine.fetch(docType: "Note", id: id))
+    }
+
+    private func actions(_ id: String) throws -> [String] {
+        try harness.engine.auditEntries(forDocumentId: id).map { $0.action }
+    }
+
+    func testSubmitAppendsLifecycleAuditAtomically() throws {
+        var doc = try savedDraft("a1")
+        try harness.engine.submit(&doc)
+
+        XCTAssertTrue(try actions("a1").contains("submit"), "submit must append a lifecycle audit row")
+        XCTAssertEqual(try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "a1")).docStatus, 1)
+    }
+
+    func testInTransactionHookCommitsWithSubmit() throws {
+        var doc = try savedDraft("a2")
+        try harness.engine.submit(&doc, inTransaction: { uow in
+            // Stand-in for Phase 1 posting: a row written through the unit of work.
+            try uow.audit(
+                action: "posted",
+                documentId: "a2",
+                docType: "Note",
+                payloadJSON: "{\"batch\":\"B1\"}"
+            )
+        })
+
+        let recorded = try actions("a2")
+        XCTAssertTrue(recorded.contains("submit"))
+        XCTAssertTrue(recorded.contains("posted"), "unit-of-work work must commit with the submit")
+    }
+
+    func testInTransactionFailureRollsBackEntireSubmit() throws {
+        var doc = try savedDraft("a3")
+
+        XCTAssertThrowsError(
+            try harness.engine.submit(&doc, inTransaction: { _ in throw InjectedFailure() }),
+            "a failing in-transaction hook must propagate"
+        )
+
+        // Nothing from the failed submit may survive: the document is still Draft
+        // and no submit audit row was written.
+        let persisted = try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "a3"))
+        XCTAssertEqual(persisted.docStatus, 0, "a failing hook must roll back the docStatus change")
+        let recorded = try actions("a3")
+        XCTAssertFalse(recorded.contains("submit"), "no submit audit row may survive a rolled-back submit")
+        XCTAssertTrue(recorded.contains("create"), "the prior committed create remains")
+    }
+}


### PR DESCRIPTION
The Core-side foundation tasks of Phase 0 from the implementation plan. Each is a separate commit; all are **additive and backward-compatible** (new optional parameters / opt-in flags), so existing call sites and tests are unchanged.

### Commits
1. **P0.1 — ExecutionContext** (`9879445`). New `ExecutionContext` (operator, company, roles, device, session, isSystemOperation). `save/submit/cancel/amend/delete` gain an optional `context:`; when absent, a `.legacy` context is synthesised from the instance identity. The operator now stamps audit rows, version `savedBy`, and mutation provenance; roles flow into validation.
2. **P0.5/P0.6 — recursive child validation, immutability, versioning** (`b03d183`). New `ChildTableValidationStage` validates every child row (type/required/link/rule + table-scoped uniqueness). Child rows are frozen after submit (unless the table field is `allowOnSubmit`) and captured in version history (`computeChildDiffs`).
3. **P0.8 — UnitOfWork + atomic lifecycle audit** (`59f58b9`). Lifecycle audit rows now commit in the *same* transaction as the docStatus change (fixes the split-transaction gap). New `UnitOfWork` + `save(..., inTransaction:)` seam is the boundary Phase 1 atomic posting will commit through; a failure-injection test proves a failing hook rolls back the entire submit.
4. **P0.4 (Core) — opt-in fail-closed permissions** (`d90b9ca`). `PermissionStage` can fail *closed* for submittable DocTypes (deny empty roles / no rules, except explicit system ops). Off by default; Hub opts in once roles + operator propagation land.

### ⚠️ Unverified build
No Swift toolchain is available in this environment (org egress policy blocks every Apple Swift download host). The diffs are additive and hand-reviewed but **not compiled or tested here**. Please run on macOS:

```
xcodebuild test -scheme "mercantis core" -destination 'platform=macOS'
```

### Behavioural change to verify in Hub
Enabling child validation means Hub child DocTypes (SalesItem, PurchaseItem, …) now have their required/link fields enforced on save — this may surface previously-silent invalid data or child links that store codes rather than document ids.

### Follow-ups (separate PRs)
- Hub: implement roles, propagate `AuthStore.currentOperator` into `ExecutionContext`, and turn on `failClosedForSubmittable` (P0.2 / P0.3) — depends on this merging and Hub's Core pin being bumped.
- Distinct submit/cancel/amend permissions (build on the fail-closed flag).
- Phase 1: atomic posting through the `inTransaction` seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5