### PR TITLE
Fix (review P1): explicit operator with no roles fails closed

### DIFF
--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -1294,7 +1294,8 @@ public final class DocumentEngine {
                 self?.registry.get(childTypeName)
             },
             isSystemOperation: exec.isSystemOperation,
-            failClosedForSubmittable: failClosedForSubmittable
+            failClosedForSubmittable: failClosedForSubmittable,
+            isLegacyFallback: exec.isLegacyFallback
         )
         let errors = validationPipeline.validate(document: &document, context: ctx)
         if !errors.isEmpty {

--- a/mercantis core/DocumentEngine/ValidationPipeline.swift
+++ b/mercantis core/DocumentEngine/ValidationPipeline.swift
@@ -76,6 +76,13 @@ public struct ValidationContext: Sendable {
     /// When true, `PermissionStage` does not gate it. (P0.4)
     public let isSystemOperation: Bool
 
+    /// Whether the driving context is the synthesised legacy fallback (no caller
+    /// identity). Only then does an empty role set stay permissive; an explicit
+    /// operator context with no roles fails closed. Defaults to `true` so
+    /// directly-constructed contexts keep the pre-P0.1 "empty roles = bypass"
+    /// convention. (P1 review fix)
+    public let isLegacyFallback: Bool
+
     /// When true, submittable (financial / transactional) DocTypes are
     /// fail-CLOSED in `PermissionStage`: an empty role set or a DocType with no
     /// declared permission rules is denied rather than allowed. Defaults to
@@ -96,7 +103,8 @@ public struct ValidationContext: Sendable {
         previousStatus: @escaping @Sendable (String, String) -> String? = { _, _ in nil },
         childDocTypeProvider: @escaping @Sendable (String) -> DocType? = { _ in nil },
         isSystemOperation: Bool = false,
-        failClosedForSubmittable: Bool = false
+        failClosedForSubmittable: Bool = false,
+        isLegacyFallback: Bool = true
     ) {
         self.docType = docType
         self.userId = userId
@@ -111,6 +119,7 @@ public struct ValidationContext: Sendable {
         self.childDocTypeProvider = childDocTypeProvider
         self.isSystemOperation = isSystemOperation
         self.failClosedForSubmittable = failClosedForSubmittable
+        self.isLegacyFallback = isLegacyFallback
     }
 }
 
@@ -761,18 +770,27 @@ public struct PermissionStage: ValidationStage {
 
         // Submittable (financial / transactional) DocTypes are fail-CLOSED when a
         // deployment opts in: they must not silently allow an unauthenticated or
-        // unconstrained write. Non-submittable masters keep the legacy permissive
-        // behaviour, and the whole tightening is off by default. (P0.4)
+        // unconstrained write. (P0.4)
         let requiresExplicitGrant = context.failClosedForSubmittable && context.docType.isSubmittable
 
-        guard !context.userRoles.isEmpty else {
-            if requiresExplicitGrant {
-                return [deniedError(
-                    context,
-                    reason: "requires an authenticated operator with a granting role"
-                )]
+        if context.userRoles.isEmpty {
+            // Empty role set. This stays permissive ONLY for the legacy fallback
+            // (no caller identity), and only when a fail-closed submittable rule
+            // doesn't apply. An *explicit* operator context with no roles fails
+            // closed — an authenticated operator without a granting role may not
+            // act on a DocType that declares permission rules. (P1 review fix)
+            if context.isLegacyFallback && !requiresExplicitGrant {
+                return []
             }
-            return []
+            // No rules to enforce on an otherwise-unconstrained DocType (unless a
+            // fail-closed submittable rule applies).
+            if context.docType.permissions.isEmpty && !requiresExplicitGrant {
+                return []
+            }
+            return [deniedError(
+                context,
+                reason: "requires an authenticated operator with a granting role"
+            )]
         }
 
         guard !context.docType.permissions.isEmpty else {

--- a/mercantis core/Identity/ExecutionContext.swift
+++ b/mercantis core/Identity/ExecutionContext.swift
@@ -50,6 +50,14 @@ public struct ExecutionContext: Sendable, Equatable {
     /// be a deliberate choice at the call site so the bypass is auditable.
     public let isSystemOperation: Bool
 
+    /// `true` only for the synthesised pre-P0.1 fallback context (no caller
+    /// supplied an identity). It distinguishes "no operator at all" — which stays
+    /// permissive for backward compatibility — from "an explicit operator context
+    /// that happens to carry no roles", which must NOT bypass permission checks
+    /// (an authenticated operator with no granting role is denied). Callers
+    /// cannot set this; only `.legacy(...)` produces it.
+    public let isLegacyFallback: Bool
+
     public init(
         operatorId: String,
         companyId: String = "",
@@ -64,6 +72,38 @@ public struct ExecutionContext: Sendable, Equatable {
         self.deviceId = deviceId
         self.sessionId = sessionId
         self.isSystemOperation = isSystemOperation
+        self.isLegacyFallback = false
+    }
+
+    /// Private initialiser that can mark the context as the legacy fallback.
+    private init(
+        operatorId: String,
+        companyId: String,
+        roles: Set<String>,
+        deviceId: String,
+        sessionId: String,
+        isSystemOperation: Bool,
+        isLegacyFallback: Bool
+    ) {
+        self.operatorId = operatorId
+        self.companyId = companyId
+        self.roles = roles
+        self.deviceId = deviceId
+        self.sessionId = sessionId
+        self.isSystemOperation = isSystemOperation
+        self.isLegacyFallback = isLegacyFallback
+    }
+
+    fileprivate static func makeLegacy(operatorId: String, deviceId: String) -> ExecutionContext {
+        ExecutionContext(
+            operatorId: operatorId,
+            companyId: "",
+            roles: [],
+            deviceId: deviceId,
+            sessionId: "",
+            isSystemOperation: false,
+            isLegacyFallback: true
+        )
     }
 }
 
@@ -75,11 +115,7 @@ public extension ExecutionContext {
     /// operator and no roles are asserted (so role checks remain permissive for
     /// callers that have not yet adopted `ExecutionContext`).
     static func legacy(userId: String, deviceId: String) -> ExecutionContext {
-        ExecutionContext(
-            operatorId: userId,
-            deviceId: deviceId,
-            isSystemOperation: false
-        )
+        ExecutionContext.makeLegacy(operatorId: userId, deviceId: deviceId)
     }
 
     /// Explicit system / import context: audit-attributed to `operatorId`

--- a/mercantis coreTests/ExecutionContextTests.swift
+++ b/mercantis coreTests/ExecutionContextTests.swift
@@ -27,7 +27,10 @@ final class ExecutionContextTests: XCTestCase {
         harness = nil
     }
 
-    private func context(_ operatorId: String, roles: Set<String> = []) -> ExecutionContext {
+    // Operator contexts carry a granting role: after the P1 review fix, an
+    // explicit operator context with no roles is denied on a DocType that
+    // declares permission rules (the test DocType grants "System Manager").
+    private func context(_ operatorId: String, roles: Set<String> = ["System Manager"]) -> ExecutionContext {
         ExecutionContext(
             operatorId: operatorId,
             companyId: "ACME",

--- a/mercantis coreTests/PermissionFailClosedTests.swift
+++ b/mercantis coreTests/PermissionFailClosedTests.swift
@@ -96,4 +96,25 @@ final class PermissionFailClosedTests: XCTestCase {
         try h.registry.register(TestSupport.makeDocType(id: "Note", permissions: []))
         XCTAssertNoThrow(try h.engine.save(TestSupport.makeDocument(id: "n1", fields: ["title": .string("X")])))
     }
+
+    // MARK: - P1 review fix: explicit operator with no roles fails closed
+
+    /// Independent of the fail-closed flag: an authenticated operator context
+    /// that carries no roles must NOT bypass a DocType that declares rules.
+    func testExplicitOperatorWithoutRolesIsDeniedOnRuleBearingDocType() throws {
+        let h = try TestSupport.makeHarness() // flag OFF on purpose
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        try h.registry.register(makeSubmittable(perms: [TestSupport.permissionRule(role: "Accountant")]))
+        let ctx = ExecutionContext(operatorId: "u", roles: [], deviceId: "d")
+        XCTAssertThrowsError(try h.engine.save(invoice("i7"), context: ctx)) { assertPermissionDenied($0) }
+    }
+
+    /// The legacy fallback (no caller context) stays permissive for backward
+    /// compatibility, even on a rule-bearing DocType, when the flag is off.
+    func testLegacyNoContextStaysPermissive() throws {
+        let h = try TestSupport.makeHarness() // flag OFF
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        try h.registry.register(makeSubmittable(perms: [TestSupport.permissionRule(role: "Accountant")]))
+        XCTAssertNoThrow(try h.engine.save(invoice("i8")))
+    }
 }


### PR DESCRIPTION
Addresses the Codex P1 review comment on #151 (which merged before it was resolved).

## Problem
An `ExecutionContext` built for a real operator but with an empty role set was treated like the system/legacy bypass — `PermissionStage`'s `guard !userRoles.isEmpty` skipped enforcement. An authenticated operator missing a granting role could write DocTypes with restrictive rules, and `isSystemOperation` was never consulted in that path.

## Fix
Empty roles stay permissive **only** for the synthesised *legacy fallback* (no caller identity, preserving pre-P0.1 behaviour). An **explicit** operator context with no roles is denied on any DocType that declares permission rules. `isSystemOperation` remains the explicit bypass.

- `ExecutionContext` gains an internal `isLegacyFallback` marker set only by `.legacy(...)`; the public initialiser always produces an explicit (non-legacy) context.
- `ValidationContext` carries `isLegacyFallback` (defaults `true` so directly-constructed contexts keep the old convention); `DocumentEngine` passes the real value.
- `PermissionStage`: empty roles → permissive only when legacy-fallback (and not a fail-closed submittable case); otherwise denied.

## Tests
- `testExplicitOperatorWithoutRolesIsDeniedOnRuleBearingDocType` — the P1 case, independent of the fail-closed flag.
- `testLegacyNoContextStaysPermissive` — backward-compatible legacy path preserved.
- `ExecutionContextTests` now pass a granting role (their operator contexts previously relied on the empty-role bypass).

The P2 review comment (submit checked as `.write` rather than `.submit`) is tracked separately as the "distinct submit/cancel/amend permissions" follow-up.

## ⚠️ Unverified build
No Swift toolchain here. Please run on macOS:
```
xcodebuild test -scheme "mercantis core" -destination 'platform=macOS'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5)_