### PR TITLE
Phase 1 (1/3): posting-batch substrate for atomic posting

### DIFF
--- a/mercantis core/DocumentEngine/UnitOfWork.swift
+++ b/mercantis core/DocumentEngine/UnitOfWork.swift
@@ -82,4 +82,23 @@ public struct UnitOfWork {
     public func execute(sql: String, arguments: StatementArguments = StatementArguments()) throws {
         try db.execute(sql: sql, arguments: arguments)
     }
+
+    // MARK: - Posting (Phase 1)
+
+    /// Record a posting batch in this transaction, so it commits atomically with
+    /// the source document's submit. Stamps `postedBy` with the operator when not
+    /// already set.
+    public func recordPostingBatch(_ batch: PostingBatch) throws {
+        var batch = batch
+        if batch.postedBy.isEmpty {
+            batch.postedBy = context.operatorId
+        }
+        try PostingBatchWriter.upsert(batch, in: db)
+    }
+
+    /// Whether a posting batch with `id` already exists — the idempotency guard
+    /// for re-fired / replayed posting in this transaction.
+    public func postingBatchExists(id: String) throws -> Bool {
+        try PostingBatchWriter.exists(id: id, in: db)
+    }
 }

--- a/mercantis core/Posting/PostingBatch.swift
+++ b/mercantis core/Posting/PostingBatch.swift
@@ -1,0 +1,180 @@
+//
+//  PostingBatch.swift
+//  mercantis core
+//
+//  Phase 1 — the atomic-posting record. A PostingBatch is written in the SAME
+//  transaction as a submittable document's submit (through `UnitOfWork`), so the
+//  source document and its derived ledger rows commit together or not at all.
+//
+//  Core stays domain-neutral: it owns the batch primitive (identity, status,
+//  idempotency, reversal linkage) and the transactional plumbing. Hub owns the
+//  accounting rules that decide *what* ledger rows a batch contains.
+//
+
+import Foundation
+import GRDB
+
+/// Lifecycle of a posting attempt.
+public enum PostingStatus: String, Codable, Sendable {
+    /// Reserved but not yet completed (rare in the atomic path; used by recovery).
+    case pending
+    /// Ledger rows written and committed.
+    case posted
+    /// Posting failed; the batch records the error for recovery / diagnostics.
+    case failed
+    /// A later reversal batch has reversed this one.
+    case reversed
+}
+
+/// One posting attempt for a source document.
+public struct PostingBatch: Identifiable, Codable, Sendable, Equatable {
+    public let id: String
+    public let sourceType: String
+    public let sourceId: String
+    public var status: PostingStatus
+    public var version: Int
+    public var errorCode: String?
+    public var errorMessage: String?
+    public var postedAt: Date?
+    public var postedBy: String
+    /// When this batch reverses another, the id of the batch it reverses.
+    public var reversalOfBatch: String?
+
+    public init(
+        id: String,
+        sourceType: String,
+        sourceId: String,
+        status: PostingStatus = .pending,
+        version: Int = 1,
+        errorCode: String? = nil,
+        errorMessage: String? = nil,
+        postedAt: Date? = nil,
+        postedBy: String = "",
+        reversalOfBatch: String? = nil
+    ) {
+        self.id = id
+        self.sourceType = sourceType
+        self.sourceId = sourceId
+        self.status = status
+        self.version = version
+        self.errorCode = errorCode
+        self.errorMessage = errorMessage
+        self.postedAt = postedAt
+        self.postedBy = postedBy
+        self.reversalOfBatch = reversalOfBatch
+    }
+
+    /// Deterministic batch id so retries are idempotent: `POST-<sourceId>-v<version>`.
+    public static func makeID(sourceId: String, version: Int = 1) -> String {
+        "POST-\(sourceId)-v\(version)"
+    }
+}
+
+/// Low-level writer usable inside an existing GRDB transaction (e.g. a
+/// `UnitOfWork`). Stateless so it can be called from the transaction-scoped seam
+/// without holding a database reference.
+public enum PostingBatchWriter {
+
+    /// Insert or replace a batch row in the supplied transaction.
+    public static func upsert(_ batch: PostingBatch, in db: Database) throws {
+        try db.execute(
+            sql: """
+                INSERT OR REPLACE INTO posting_batches
+                    (id, sourceType, sourceId, status, version,
+                     errorCode, errorMessage, postedAt, postedBy, reversalOfBatch)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+            arguments: [
+                batch.id,
+                batch.sourceType,
+                batch.sourceId,
+                batch.status.rawValue,
+                batch.version,
+                batch.errorCode,
+                batch.errorMessage,
+                batch.postedAt.map { ISO8601DateFormatter().string(from: $0) },
+                batch.postedBy,
+                batch.reversalOfBatch
+            ]
+        )
+    }
+
+    /// Whether a batch with `id` already exists (idempotency guard), in-transaction.
+    public static func exists(id: String, in db: Database) throws -> Bool {
+        try Int.fetchOne(
+            db,
+            sql: "SELECT 1 FROM posting_batches WHERE id = ? LIMIT 1",
+            arguments: [id]
+        ) != nil
+    }
+
+    static func batch(from row: Row) -> PostingBatch {
+        let postedAtString: String? = row["postedAt"]
+        return PostingBatch(
+            id: row["id"] ?? "",
+            sourceType: row["sourceType"] ?? "",
+            sourceId: row["sourceId"] ?? "",
+            status: PostingStatus(rawValue: row["status"] ?? "") ?? .pending,
+            version: row["version"] ?? 1,
+            errorCode: row["errorCode"],
+            errorMessage: row["errorMessage"],
+            postedAt: postedAtString.flatMap { ISO8601DateFormatter().date(from: $0) },
+            postedBy: row["postedBy"] ?? "",
+            reversalOfBatch: row["reversalOfBatch"]
+        )
+    }
+}
+
+/// Read API for posting batches: idempotency checks, recovery, and the
+/// diagnostics reports (failed / pending batches; per-source history).
+public final class PostingBatchStore {
+
+    private let database: MercantisDatabase
+
+    public init(database: MercantisDatabase) {
+        self.database = database
+    }
+
+    public func batch(id: String) throws -> PostingBatch? {
+        try database.read { db in
+            try Row.fetchOne(db, sql: "SELECT * FROM posting_batches WHERE id = ? LIMIT 1", arguments: [id])
+                .map(PostingBatchWriter.batch(from:))
+        }
+    }
+
+    public func exists(id: String) throws -> Bool {
+        try database.read { db in try PostingBatchWriter.exists(id: id, in: db) }
+    }
+
+    /// All batches for a source document, oldest first (by version).
+    public func batches(forSourceType sourceType: String, sourceId: String) throws -> [PostingBatch] {
+        try database.read { db in
+            try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT * FROM posting_batches
+                    WHERE sourceType = ? AND sourceId = ?
+                    ORDER BY version ASC
+                    """,
+                arguments: [sourceType, sourceId]
+            ).map(PostingBatchWriter.batch(from:))
+        }
+    }
+
+    /// Batches in a given status — backs the "failed postings" / "incomplete
+    /// postings" diagnostic reports (Appendix C).
+    public func batches(withStatus status: PostingStatus, limit: Int = 100) throws -> [PostingBatch] {
+        try database.read { db in
+            try Row.fetchAll(
+                db,
+                sql: "SELECT * FROM posting_batches WHERE status = ? ORDER BY sourceId LIMIT ?",
+                arguments: [status.rawValue, limit]
+            ).map(PostingBatchWriter.batch(from:))
+        }
+    }
+
+    /// The current (highest-version) batch for a source document, if any.
+    public func currentBatch(forSourceType sourceType: String, sourceId: String) throws -> PostingBatch? {
+        try batches(forSourceType: sourceType, sourceId: sourceId).last
+    }
+}

--- a/mercantis core/Storage/MigrationRunner.swift
+++ b/mercantis core/Storage/MigrationRunner.swift
@@ -88,6 +88,7 @@ public struct MigrationRunner {
         runner.register(version: 10, name: "add_attachments", sql: MigrationRunner.v10SQL)
         runner.register(version: 11, name: "add_notification_log", sql: MigrationRunner.v11SQL)
         runner.register(version: 12, name: "add_custom_fields", sql: MigrationRunner.v12SQL)
+        runner.register(version: 13, name: "add_posting_batches", sql: MigrationRunner.v13SQL)
     }
 
     // MARK: - v1 Schema
@@ -400,5 +401,37 @@ public struct MigrationRunner {
 
         CREATE INDEX IF NOT EXISTS idx_custom_fields_doctype
             ON custom_fields(doctype);
+        """
+
+    // MARK: - v13 Schema — posting_batches (Phase 1 / atomic posting)
+
+    private static let v13SQL = """
+        -- One row per posting attempt for a submittable source document. The
+        -- batch is written in the SAME transaction as the source document's
+        -- submit (via UnitOfWork), so a submitted financial / stock document can
+        -- never silently end up unposted, partially posted, or unbalanced: either
+        -- the batch row (status='posted') and its ledger rows commit together, or
+        -- the whole submit rolls back.
+        --
+        -- `id` is deterministic (`POST-<sourceId>-v<version>`) so a retry is
+        -- idempotent. `status`: pending | posted | failed | reversed.
+        -- `reversalOfBatch` links a reversal batch to the batch it reverses.
+        CREATE TABLE IF NOT EXISTS posting_batches (
+            id              TEXT    PRIMARY KEY NOT NULL,
+            sourceType      TEXT    NOT NULL,
+            sourceId        TEXT    NOT NULL,
+            status          TEXT    NOT NULL DEFAULT 'pending',
+            version         INTEGER NOT NULL DEFAULT 1,
+            errorCode       TEXT,
+            errorMessage    TEXT,
+            postedAt        TEXT,
+            postedBy        TEXT    NOT NULL DEFAULT '',
+            reversalOfBatch TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_posting_batches_source
+            ON posting_batches(sourceType, sourceId);
+        CREATE INDEX IF NOT EXISTS idx_posting_batches_status
+            ON posting_batches(status);
         """
 }

--- a/mercantis coreTests/PostingBatchTests.swift
+++ b/mercantis coreTests/PostingBatchTests.swift
@@ -1,0 +1,102 @@
+//
+//  PostingBatchTests.swift
+//  mercantis coreTests
+//
+//  Phase 1 — a PostingBatch recorded through the UnitOfWork commits atomically
+//  with the source document's submit, and rolls back entirely if posting fails.
+//  This is the contract that makes "submitted but unposted / partially posted"
+//  impossible.
+//
+
+import XCTest
+import GRDB
+@testable import mercantis_core
+
+final class PostingBatchTests: XCTestCase {
+
+    private struct InjectedFailure: Error {}
+
+    private var harness: TestSupport.Harness!
+    private var store: PostingBatchStore!
+
+    override func setUpWithError() throws {
+        harness = try TestSupport.makeHarness(userId: "tester")
+        store = PostingBatchStore(database: harness.database)
+        try harness.registry.register(TestSupport.makeDocType(isSubmittable: true))
+    }
+
+    override func tearDown() {
+        TestSupport.cleanUp(databaseURL: harness.url)
+        harness = nil
+        store = nil
+    }
+
+    private func savedDraft(_ id: String) throws -> Document {
+        try harness.engine.save(TestSupport.makeDocument(id: id, fields: ["title": .string("Doc \(id)")]))
+        return try XCTUnwrap(harness.engine.fetch(docType: "Note", id: id))
+    }
+
+    func testDeterministicBatchID() {
+        XCTAssertEqual(PostingBatch.makeID(sourceId: "INV-1"), "POST-INV-1-v1")
+        XCTAssertEqual(PostingBatch.makeID(sourceId: "INV-1", version: 2), "POST-INV-1-v2")
+    }
+
+    func testPostingBatchCommitsWithSubmit() throws {
+        var doc = try savedDraft("a1")
+        let batchId = PostingBatch.makeID(sourceId: "a1")
+
+        try harness.engine.submit(&doc, inTransaction: { uow in
+            XCTAssertFalse(try uow.postingBatchExists(id: batchId), "idempotency guard: no batch yet")
+            try uow.recordPostingBatch(PostingBatch(
+                id: batchId, sourceType: "Note", sourceId: "a1",
+                status: .posted, postedAt: Date()
+            ))
+        })
+
+        let batch = try XCTUnwrap(store.batch(id: batchId))
+        XCTAssertEqual(batch.status, .posted)
+        XCTAssertEqual(batch.postedBy, "tester", "postedBy is stamped from the operator context")
+        XCTAssertEqual(try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "a1")).docStatus, 1)
+    }
+
+    func testPostingBatchRollsBackWhenSubmitFails() throws {
+        var doc = try savedDraft("a2")
+        let batchId = PostingBatch.makeID(sourceId: "a2")
+
+        XCTAssertThrowsError(try harness.engine.submit(&doc, inTransaction: { uow in
+            try uow.recordPostingBatch(PostingBatch(
+                id: batchId, sourceType: "Note", sourceId: "a2", status: .posted
+            ))
+            throw InjectedFailure()
+        }))
+
+        XCTAssertNil(try store.batch(id: batchId), "no posting batch may survive a rolled-back submit")
+        XCTAssertEqual(
+            try XCTUnwrap(harness.engine.fetch(docType: "Note", id: "a2")).docStatus, 0,
+            "the document must remain Draft when posting fails"
+        )
+    }
+
+    func testStoreQueriesByStatusAndSource() throws {
+        var d1 = try savedDraft("b1")
+        try harness.engine.submit(&d1, inTransaction: { uow in
+            try uow.recordPostingBatch(PostingBatch(
+                id: PostingBatch.makeID(sourceId: "b1"), sourceType: "Note", sourceId: "b1", status: .posted
+            ))
+        })
+        var d2 = try savedDraft("b2")
+        try harness.engine.submit(&d2, inTransaction: { uow in
+            try uow.recordPostingBatch(PostingBatch(
+                id: PostingBatch.makeID(sourceId: "b2"), sourceType: "Note", sourceId: "b2",
+                status: .failed, errorCode: "UNBALANCED", errorMessage: "debits != credits"
+            ))
+        })
+
+        XCTAssertEqual(try store.batches(withStatus: .posted).count, 1)
+        let failed = try store.batches(withStatus: .failed)
+        XCTAssertEqual(failed.count, 1)
+        XCTAssertEqual(failed.first?.errorCode, "UNBALANCED")
+        XCTAssertTrue(try store.exists(id: PostingBatch.makeID(sourceId: "b1")))
+        XCTAssertEqual(try store.currentBatch(forSourceType: "Note", sourceId: "b2")?.status, .failed)
+    }
+}


### PR DESCRIPTION
First of three increments that move posting from a post-commit event subscriber (where failures are silently swallowed) into the submit transaction. This one adds the **Core primitive** posting commits through; **no behaviour change yet**.

## What's here
- **Migration v13** — `posting_batches` table: deterministic id `POST-<sourceId>-v<n>`, `status` (pending|posted|failed|reversed), error fields, `postedAt`/`postedBy`, `reversalOfBatch`; indexed by source and status.
- **`PostingBatch` / `PostingStatus`** value types.
- **`PostingBatchWriter`** — stateless, transaction-scoped `upsert` + `exists` (idempotency guard).
- **`PostingBatchStore`** — read API for idempotency, recovery, and the failed/incomplete-batch diagnostics (Appendix C of the plan).
- **`UnitOfWork`** gains `recordPostingBatch(...)` (stamps `postedBy` from the operator) and `postingBatchExists(...)`.

## Why it matters
A `PostingBatch` written through `UnitOfWork` commits in the *same* transaction as the source document's submit. The included failure-injection test proves a batch does **not** survive a failed posting hook (the document stays Draft, no batch row) — the contract that makes "submitted but unposted / partially posted" impossible.

## Next
- **(2/3)** Hub `PostingCoordinator` runs through `submit(..., inTransaction:)` with balanced-GL validation + batch recording, proven end-to-end on Journal Entry (event path stays for other DocTypes, gated to avoid double-posting).
- **(3/3)** Convert the remaining `derive*` and remove the post-commit event path.

## ⚠️ Unverified build
No Swift toolchain here. Please run on macOS:
```
xcodebuild test -scheme "mercantis core" -destination 'platform=macOS'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5)_