### PR TITLE
Fix MainActor build break + add in-transaction document write (Phase 1)

### DIFF
--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -288,6 +288,59 @@ public final class DocumentEngine {
         return document
     }
 
+    // MARK: - In-transaction document write (Phase 1 posting)
+
+    /// Write a derived system document (a ledger / subledger row) inside an
+    /// existing `UnitOfWork`, so it commits atomically with the source
+    /// document's submit. Unlike `save(...)`, this performs no validation,
+    /// naming, optimistic-concurrency, or versioning: the document must already
+    /// carry its (deterministic) id and be a trusted, append-only derived
+    /// record. It upserts the row + child rows, appends a sync mutation, and
+    /// writes an audit row attributed to the unit of work's operator.
+    ///
+    /// Idempotency is the caller's responsibility — guard re-posting at the
+    /// `PostingBatch` boundary (`UnitOfWork.postingBatchExists`).
+    @discardableResult
+    public func writeDocument(_ document: Document, action: String = "post", in uow: UnitOfWork) throws -> Document {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let payloadString = String(data: try encoder.encode(document.fields), encoding: .utf8) ?? "{}"
+        let createdAtString = ISO8601DateFormatter().string(from: document.createdAt)
+        let updatedAtString = ISO8601DateFormatter().string(from: document.updatedAt)
+
+        let mutation = MutationRecord(
+            id: UUID(),
+            type: .upsertDocument,
+            payload: try encoder.encode(document),
+            deviceId: uow.context.deviceId,
+            userId: uow.context.operatorId,
+            localTimestamp: Date(),
+            syncVersion: document.syncVersion,
+            status: .pending
+        )
+
+        try upsertDocumentRow(
+            uow.db, document: document,
+            createdAt: createdAtString,
+            updatedAt: updatedAtString,
+            syncState: document.syncState,
+            payloadString: payloadString
+        )
+        try syncChildRows(uow.db, document: document, encoder: encoder)
+        try appendMutation(uow.db, mutation: mutation)
+        try auditLogWriter.append(
+            documentId: document.id,
+            docType: document.docType,
+            userId: uow.context.operatorId,
+            action: action,
+            before: nil,
+            after: document.fields,
+            in: uow.db
+        )
+        return document
+    }
+
     // MARK: - Naming (P1.1 / ADR-014)
 
     /// If `document.id` is empty, resolve it via `NamingService` and return a

--- a/mercantis core/Posting/PostingBatch.swift
+++ b/mercantis core/Posting/PostingBatch.swift
@@ -76,7 +76,7 @@ public struct PostingBatch: Identifiable, Codable, Sendable, Equatable {
 public enum PostingBatchWriter {
 
     /// Insert or replace a batch row in the supplied transaction.
-    public static func upsert(_ batch: PostingBatch, in db: Database) throws {
+    public static nonisolated func upsert(_ batch: PostingBatch, in db: Database) throws {
         try db.execute(
             sql: """
                 INSERT OR REPLACE INTO posting_batches
@@ -100,7 +100,7 @@ public enum PostingBatchWriter {
     }
 
     /// Whether a batch with `id` already exists (idempotency guard), in-transaction.
-    public static func exists(id: String, in db: Database) throws -> Bool {
+    public static nonisolated func exists(id: String, in db: Database) throws -> Bool {
         try Int.fetchOne(
             db,
             sql: "SELECT 1 FROM posting_batches WHERE id = ? LIMIT 1",
@@ -108,7 +108,7 @@ public enum PostingBatchWriter {
         ) != nil
     }
 
-    static func batch(from row: Row) -> PostingBatch {
+    static nonisolated func batch(from row: Row) -> PostingBatch {
         let postedAtString: String? = row["postedAt"]
         return PostingBatch(
             id: row["id"] ?? "",


### PR DESCRIPTION
Two commits.

### 1. Build fix (priority) — `nonisolated PostingBatchWriter` helpers
The MercantisCore target builds with **default MainActor isolation**, so `PostingBatchWriter`'s static helpers were MainActor-isolated. `batch(from:)` is passed as a *function reference* to `Array.map` inside GRDB's nonisolated read closures, which the compiler rejects:

> Call to main actor-isolated static method 'batch(from:)' in a synchronous nonisolated context

(`upsert`/`exists` are called directly inside closure literals, which inherit isolation, so they were fine.) These are pure DB row helpers — marked `upsert`/`exists`/`batch` `nonisolated`. **Fixes the error you hit on `PostingBatch.swift` after #153 merged.**

### 2. `DocumentEngine.writeDocument(_:in:)` — the next Phase 1 primitive
Writes a derived system document (a ledger/subledger row) inside an existing `UnitOfWork`, so it commits atomically with the source submit. Unlike `save()`, it does no validation/naming/concurrency/versioning (the row is a trusted, deterministically-id'd, append-only derived record); it upserts the row + children, appends a sync mutation, and writes an audit row attributed to the unit of work's operator. The Hub `PostingCoordinator` (increment 2) uses this to write GL/stock/subledger rows in-transaction instead of via post-commit `engine.save`.

### Please build on macOS
```
xcodebuild test -scheme "mercantis core" -destination 'platform=macOS'
```
I proactively scanned my recent additions for the same `.map(StaticFunc)`-style isolation trap; `PostingBatchStore` was the only occurrence. If other concurrency errors surface, paste them and I'll fix them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5)_