### PR TITLE
Fix: nonisolated PostingBatch/PostingStatus (build break on main)

### DIFF
--- a/mercantis core/Posting/PostingBatch.swift
+++ b/mercantis core/Posting/PostingBatch.swift
@@ -15,7 +15,7 @@ import Foundation
 import GRDB
 
 /// Lifecycle of a posting attempt.
-public enum PostingStatus: String, Codable, Sendable {
+public nonisolated enum PostingStatus: String, Codable, Sendable {
     /// Reserved but not yet completed (rare in the atomic path; used by recovery).
     case pending
     /// Ledger rows written and committed.
@@ -27,7 +27,7 @@ public enum PostingStatus: String, Codable, Sendable {
 }
 
 /// One posting attempt for a source document.
-public struct PostingBatch: Identifiable, Codable, Sendable, Equatable {
+public nonisolated struct PostingBatch: Identifiable, Codable, Sendable, Equatable {
     public let id: String
     public let sourceType: String
     public let sourceId: String


### PR DESCRIPTION
Follow-on build fix. With the target's default MainActor isolation, the `PostingBatch` initializer (and `PostingStatus`' rawValue init) were MainActor-isolated, so the now-`nonisolated` `PostingBatchWriter.batch(from:)` couldn't construct them inside GRDB's nonisolated read closures:

> Call to main actor-isolated initializer ... in a synchronous nonisolated context

These are pure `Sendable` value types — marked `nonisolated`, matching the existing codebase pattern (`StockBalanceCalculator`'s `public nonisolated struct Balance`). **Fixes the error you hit on `PostingBatch.swift:113`.**

I've now applied the lesson across all the Phase-1 value types in this file. Please build:
```
xcodebuild test -scheme "mercantis core" -destination 'platform=macOS'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5)_