### PR TITLE
Enforce distinct submit / cancel / amend permissions

### DIFF
--- a/mercantis core/DocumentEngine/DocumentEngine.swift
+++ b/mercantis core/DocumentEngine/DocumentEngine.swift
@@ -559,6 +559,7 @@ public final class DocumentEngine {
                 from: document.docStatus, to: 1, id: document.id
             )
         }
+        try enforceLifecyclePermission(.submit, on: docType, context: ctx)
 
         document.docStatus = 1
         // NOTE: do not stamp `updatedAt` here. `save(...)` enforces optimistic
@@ -601,6 +602,7 @@ public final class DocumentEngine {
                 from: document.docStatus, to: 2, id: document.id
             )
         }
+        try enforceLifecyclePermission(.cancel, on: docType, context: ctx)
 
         let blockingDocuments = try findLinkedSubmittedDocuments(documentId: document.id)
         if !blockingDocuments.isEmpty {
@@ -644,6 +646,7 @@ public final class DocumentEngine {
                 from: document.docStatus, to: 0, id: document.id
             )
         }
+        try enforceLifecyclePermission(.amend, on: docType, context: ctx)
 
         let newId = UUID().uuidString
         let now = Date()
@@ -1309,6 +1312,71 @@ public final class DocumentEngine {
     }
 
     // MARK: - Private Helpers
+
+    /// Enforce the lifecycle-specific permission (`.submit` / `.cancel` /
+    /// `.amend`) before applying a docStatus transition. `save(...)` only checks
+    /// `.write`, so without this the per-rule `canSubmit` / `canCancel` /
+    /// `canAmend` rights are never consulted. Mirrors `PermissionStage`'s
+    /// decision logic: system actions are never gated; a fail-closed submittable
+    /// DocType demands an explicit granting role; otherwise the role set must
+    /// grant the operation. (P0.4 — distinct lifecycle rights)
+    private func enforceLifecyclePermission(
+        _ operation: DocumentOperation,
+        on docType: DocType,
+        context ctx: ExecutionContext
+    ) throws {
+        if ctx.isSystemOperation { return }
+
+        let requiresExplicitGrant = failClosedForSubmittable && docType.isSubmittable
+
+        if ctx.roles.isEmpty {
+            // Permissive only for the legacy fallback (no caller identity) and
+            // only when a fail-closed submittable rule doesn't apply; an
+            // explicit operator with no roles fails closed.
+            if ctx.isLegacyFallback && !requiresExplicitGrant { return }
+            if docType.permissions.isEmpty && !requiresExplicitGrant { return }
+            throw lifecyclePermissionError(
+                operation, docType: docType,
+                reason: "requires an authenticated operator with a granting role"
+            )
+        }
+
+        if docType.permissions.isEmpty {
+            if requiresExplicitGrant {
+                throw lifecyclePermissionError(
+                    operation, docType: docType,
+                    reason: "declares no permission rules, so no role may \(Self.describe(operation)) it"
+                )
+            }
+            return
+        }
+
+        if !permissionEngine.canPerform(operation: operation, on: docType, userRoles: ctx.roles) {
+            throw lifecyclePermissionError(operation, docType: docType, reason: nil)
+        }
+    }
+
+    private func lifecyclePermissionError(
+        _ operation: DocumentOperation, docType: DocType, reason: String?
+    ) -> DocumentEngineError {
+        let base = "User does not have permission to \(Self.describe(operation)) '\(docType.name)' documents."
+        let message = reason.map { "\(base) (\($0))" } ?? base
+        return .validationFailed(errors: [
+            DocumentValidationError(stage: "Permission", field: nil, message: message)
+        ])
+    }
+
+    private static func describe(_ operation: DocumentOperation) -> String {
+        switch operation {
+        case .read:   return "read"
+        case .write:  return "save"
+        case .create: return "create"
+        case .delete: return "delete"
+        case .submit: return "submit"
+        case .cancel: return "cancel"
+        case .amend:  return "amend"
+        }
+    }
 
     private func runValidationPipeline(
         on document: Document,

--- a/mercantis core/DocumentEngine/ValidationPipeline.swift
+++ b/mercantis core/DocumentEngine/ValidationPipeline.swift
@@ -831,6 +831,7 @@ public struct PermissionStage: ValidationStage {
         case .delete: return "delete"
         case .submit: return "submit"
         case .amend:  return "amend"
+        case .cancel: return "cancel"
         }
     }
 }

--- a/mercantis core/Metadata/PermissionRule.swift
+++ b/mercantis core/Metadata/PermissionRule.swift
@@ -15,9 +15,14 @@ public struct PermissionRule: Codable, Sendable {
     public let canCreate: Bool
     public let canDelete: Bool
     public let canSubmit: Bool
+    /// Whether the role may cancel a submitted document (docStatus 1 → 2).
+    /// Distinct from `canSubmit` so a deployment can let one role post and a
+    /// different role reverse. Defaults to `false`; the memberwise default and
+    /// the `canSubmit` fallback on decode keep older rules / call sites working.
+    public let canCancel: Bool
     public let canAmend: Bool
 
-    public init(role: String, canRead: Bool, canWrite: Bool, canCreate: Bool, canDelete: Bool, canSubmit: Bool, canAmend: Bool) {
+    public init(role: String, canRead: Bool, canWrite: Bool, canCreate: Bool, canDelete: Bool, canSubmit: Bool, canAmend: Bool, canCancel: Bool = false) {
         self.role = role
         self.canRead = canRead
         self.canWrite = canWrite
@@ -25,5 +30,24 @@ public struct PermissionRule: Codable, Sendable {
         self.canDelete = canDelete
         self.canSubmit = canSubmit
         self.canAmend = canAmend
+        self.canCancel = canCancel
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case role, canRead, canWrite, canCreate, canDelete, canSubmit, canAmend, canCancel
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        role      = try c.decode(String.self, forKey: .role)
+        canRead   = try c.decode(Bool.self, forKey: .canRead)
+        canWrite  = try c.decode(Bool.self, forKey: .canWrite)
+        canCreate = try c.decode(Bool.self, forKey: .canCreate)
+        canDelete = try c.decode(Bool.self, forKey: .canDelete)
+        canSubmit = try c.decode(Bool.self, forKey: .canSubmit)
+        canAmend  = try c.decode(Bool.self, forKey: .canAmend)
+        // Older manifests predate `canCancel`; fall back to `canSubmit` so a
+        // role that could post can still reverse, matching prior behaviour.
+        canCancel = try c.decodeIfPresent(Bool.self, forKey: .canCancel) ?? canSubmit
     }
 }

--- a/mercantis core/Permissions/PermissionEngine.swift
+++ b/mercantis core/Permissions/PermissionEngine.swift
@@ -29,6 +29,7 @@ public final class PermissionEngine {
             case .delete: if rule.canDelete { return true }
             case .submit: if rule.canSubmit { return true }
             case .amend:  if rule.canAmend  { return true }
+            case .cancel: if rule.canCancel { return true }
             }
         }
         return false
@@ -121,7 +122,7 @@ public final class PermissionEngine {
 // MARK: - Operation Types
 
 public enum DocumentOperation: Sendable {
-    case read, write, create, delete, submit, amend
+    case read, write, create, delete, submit, amend, cancel
 }
 
 public enum FieldOperation: Sendable {

--- a/mercantis core/UIShell/DocTypeBuilderView.swift
+++ b/mercantis core/UIShell/DocTypeBuilderView.swift
@@ -447,6 +447,7 @@ struct EditablePermission: Identifiable, Hashable {
     var canDelete: Bool
     var canSubmit: Bool
     var canAmend: Bool
+    var canCancel: Bool
 
     nonisolated init(
         role: String = "",
@@ -455,7 +456,8 @@ struct EditablePermission: Identifiable, Hashable {
         canCreate: Bool = false,
         canDelete: Bool = false,
         canSubmit: Bool = false,
-        canAmend: Bool = false
+        canAmend: Bool = false,
+        canCancel: Bool = false
     ) {
         self.role = role
         self.canRead = canRead
@@ -464,6 +466,7 @@ struct EditablePermission: Identifiable, Hashable {
         self.canDelete = canDelete
         self.canSubmit = canSubmit
         self.canAmend = canAmend
+        self.canCancel = canCancel
     }
 
     nonisolated init(_ permission: PermissionRule) {
@@ -474,7 +477,8 @@ struct EditablePermission: Identifiable, Hashable {
             canCreate: permission.canCreate,
             canDelete: permission.canDelete,
             canSubmit: permission.canSubmit,
-            canAmend: permission.canAmend
+            canAmend: permission.canAmend,
+            canCancel: permission.canCancel
         )
     }
 
@@ -486,7 +490,8 @@ struct EditablePermission: Identifiable, Hashable {
             canCreate: canCreate,
             canDelete: canDelete,
             canSubmit: canSubmit,
-            canAmend: canAmend
+            canAmend: canAmend,
+            canCancel: canCancel
         )
     }
 }
@@ -906,6 +911,7 @@ public struct DocTypeBuilderView: View {
                     if permission.canCreate  { permBadge("C") }
                     if permission.canDelete  { permBadge("D") }
                     if permission.canSubmit  { permBadge("S") }
+                    if permission.canCancel  { permBadge("X") }
                     if permission.canAmend   { permBadge("A") }
                 }
 
@@ -932,6 +938,7 @@ public struct DocTypeBuilderView: View {
             checkboxRow("Create", isOn: permission.canCreate)
             checkboxRow("Delete", isOn: permission.canDelete)
             checkboxRow("Submit", isOn: permission.canSubmit)
+            checkboxRow("Cancel", isOn: permission.canCancel)
             checkboxRow("Amend",  isOn: permission.canAmend)
 
             HStack {

--- a/mercantis core/UIShell/DocTypeListView.swift
+++ b/mercantis core/UIShell/DocTypeListView.swift
@@ -192,7 +192,8 @@ public struct DocTypeListView: View {
                                 "canCreate": .bool(permission.canCreate),
                                 "canDelete": .bool(permission.canDelete),
                                 "canSubmit": .bool(permission.canSubmit),
-                                "canAmend": .bool(permission.canAmend)
+                                "canAmend": .bool(permission.canAmend),
+                                "canCancel": .bool(permission.canCancel)
                             ]
                         )
                     }

--- a/mercantis coreTests/PermissionFailClosedTests.swift
+++ b/mercantis coreTests/PermissionFailClosedTests.swift
@@ -117,4 +117,49 @@ final class PermissionFailClosedTests: XCTestCase {
         try h.registry.register(makeSubmittable(perms: [TestSupport.permissionRule(role: "Accountant")]))
         XCTAssertNoThrow(try h.engine.save(invoice("i8")))
     }
+
+    // MARK: - Distinct lifecycle rights (submit / cancel / amend)
+
+    /// A submittable transition consults its own right, not just `.write`: a
+    /// role that may create the draft but is not granted submit is denied.
+    func testSubmitDeniedForNonGrantingRole() throws {
+        let h = try TestSupport.makeHarness(failClosedForSubmittable: true)
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        try h.registry.register(makeSubmittable(perms: [TestSupport.permissionRule(role: "Accountant")]))
+        let granting = ExecutionContext(operatorId: "u", roles: ["Accountant"], deviceId: "d")
+        var doc = try h.engine.save(invoice("L1"), context: granting)
+        let nonGranting = ExecutionContext(operatorId: "v", roles: ["Clerk"], deviceId: "d")
+        XCTAssertThrowsError(try h.engine.submit(&doc, context: nonGranting)) { assertPermissionDenied($0) }
+    }
+
+    /// `canCancel` is distinct from `canSubmit`: a role that may post is not
+    /// implicitly allowed to reverse unless it is also granted cancel.
+    func testCancelRequiresCancelRightEvenWhenSubmitGranted() throws {
+        let h = try TestSupport.makeHarness(failClosedForSubmittable: true)
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        let postNotReverse = PermissionRule(
+            role: "Poster", canRead: true, canWrite: true, canCreate: true,
+            canDelete: false, canSubmit: true, canAmend: false, canCancel: false
+        )
+        try h.registry.register(makeSubmittable(perms: [postNotReverse]))
+        let ctx = ExecutionContext(operatorId: "u", roles: ["Poster"], deviceId: "d")
+        var doc = try h.engine.save(invoice("L2"), context: ctx)
+        try h.engine.submit(&doc, context: ctx) // submit is granted
+        if let fetched = try h.engine.fetch(docType: "Invoice", id: "L2") { doc = fetched }
+        XCTAssertThrowsError(try h.engine.cancel(&doc, context: ctx)) { assertPermissionDenied($0) }
+    }
+
+    /// A fully granted role completes the whole submit → cancel → amend cycle.
+    func testGrantingRoleCompletesLifecycle() throws {
+        let h = try TestSupport.makeHarness(failClosedForSubmittable: true)
+        defer { TestSupport.cleanUp(databaseURL: h.url) }
+        try h.registry.register(makeSubmittable(perms: [TestSupport.permissionRule(role: "Accountant")]))
+        let ctx = ExecutionContext(operatorId: "u", roles: ["Accountant"], deviceId: "d")
+        var doc = try h.engine.save(invoice("L3"), context: ctx)
+        XCTAssertNoThrow(try h.engine.submit(&doc, context: ctx))
+        if let fetched = try h.engine.fetch(docType: "Invoice", id: "L3") { doc = fetched }
+        XCTAssertNoThrow(try h.engine.cancel(&doc, context: ctx))
+        if let fetched = try h.engine.fetch(docType: "Invoice", id: "L3") { doc = fetched }
+        XCTAssertNoThrow(try h.engine.amend(doc, context: ctx))
+    }
 }

--- a/mercantis coreTests/Support/TestSupport.swift
+++ b/mercantis coreTests/Support/TestSupport.swift
@@ -92,7 +92,8 @@ enum TestSupport {
             canCreate: true,
             canDelete: true,
             canSubmit: true,
-            canAmend: true
+            canAmend: true,
+            canCancel: true
         )
     }
 


### PR DESCRIPTION
Submittable lifecycle transitions previously routed through save(), so the permission stage only ever checked .write — the per-rule canSubmit and canAmend flags were never consulted, and there was no concept of a cancel right at all. An operator who could write a draft could submit, cancel, and (via the cancelled copy) amend it regardless of intent.

- Add DocumentOperation.cancel and PermissionRule.canCancel (distinct from canSubmit so one role can post and another reverse). canCancel defaults to false in the memberwise init and falls back to canSubmit on decode, so existing call sites and older manifests are unchanged.
- DocumentEngine.submit / cancel / amend now gate on .submit / .cancel / .amend via enforceLifecyclePermission, mirroring PermissionStage's decision logic (system actions never gated; fail-closed submittables demand an explicit granting role; legacy no-context stays permissive only when the flag is off).
- Thread canCancel through the DocType builder UI (editor checkbox, badge, list export) so editing a DocType no longer drops it.
- Tests: submit denied for a non-granting role; cancel requires its own right even when submit is granted; a fully granted role completes the whole submit → cancel → amend cycle.


Claude-Session: https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5