### PR TITLE
Empty numeric field stores null, not "" (fixes decimal type error)

### DIFF
--- a/mercantis core/UIShell/ChildTableField.swift
+++ b/mercantis core/UIShell/ChildTableField.swift
@@ -412,9 +412,12 @@ public struct ChildTableField: View {
             },
             set: { newValue in
                 guard idx < rows.count else { return }
-                if f.type == .number, let i = Int(newValue) {
+                let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+                if trimmed.isEmpty {
+                    rows[idx].fields[f.key] = .null
+                } else if f.type == .number, let i = Int(trimmed) {
                     rows[idx].fields[f.key] = .int(i)
-                } else if let d = Double(newValue) {
+                } else if let d = Double(trimmed) {
                     rows[idx].fields[f.key] = .double(d)
                 } else {
                     rows[idx].fields[f.key] = .string(newValue)
@@ -690,9 +693,12 @@ private struct ChildRowEditor: View {
                 }
             },
             set: { newValue in
-                if f.type == .number, let i = Int(newValue) {
+                let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+                if trimmed.isEmpty {
+                    row.fields[f.key] = .null
+                } else if f.type == .number, let i = Int(trimmed) {
                     row.fields[f.key] = .int(i)
-                } else if let d = Double(newValue) {
+                } else if let d = Double(trimmed) {
                     row.fields[f.key] = .double(d)
                 } else {
                     row.fields[f.key] = .string(newValue)

--- a/mercantis core/UIShell/GenericFormView.swift
+++ b/mercantis core/UIShell/GenericFormView.swift
@@ -837,9 +837,14 @@ public struct GenericFormView: View {
                 }
             },
             set: { newValue in
-                if field.type == .number, let intVal = Int(newValue) {
+                let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+                if trimmed.isEmpty {
+                    // An empty numeric field is "no value", not the string "" —
+                    // storing "" fails `.decimal` / `.currency` type validation.
+                    document.fields[field.key] = .null
+                } else if field.type == .number, let intVal = Int(trimmed) {
                     document.fields[field.key] = .int(intVal)
-                } else if let doubleVal = Double(newValue) {
+                } else if let doubleVal = Double(trimmed) {
                     document.fields[field.key] = .double(doubleVal)
                 } else {
                     document.fields[field.key] = .string(newValue)


### PR DESCRIPTION
An empty number / decimal / currency input was stored as `.string("")`, which fails `.decimal` / `.currency` type validation on save ("Field 'Total Qty' has an incompatible value type for 'decimal'"). Empty numeric input now clears to `.null` (skipped by type validation; RequiredFieldStage still guards required fields). Applied in both the top-level form (GenericFormView) and the inline child grid + row editor (ChildTableField).


Claude-Session: https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5