### PR TITLE
Print: default-format selection + multi-format Print menu

### DIFF
--- a/mercantis core/Printing/PrintFormat.swift
+++ b/mercantis core/Printing/PrintFormat.swift
@@ -40,6 +40,9 @@ public struct PrintFormat: Codable, Sendable, Equatable, Identifiable {
     public let name: String
     public let docType: String
     public let letterHeadId: String?
+    /// When several formats exist for a DocType, the one to use unless the
+    /// operator picks another. At most one per DocType should set this.
+    public let isDefault: Bool
     public let sections: [PrintSection]
 
     public init(
@@ -47,13 +50,29 @@ public struct PrintFormat: Codable, Sendable, Equatable, Identifiable {
         name: String,
         docType: String,
         letterHeadId: String? = nil,
+        isDefault: Bool = false,
         sections: [PrintSection]
     ) {
         self.id = id
         self.name = name
         self.docType = docType
         self.letterHeadId = letterHeadId
+        self.isDefault = isDefault
         self.sections = sections
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, docType, letterHeadId, isDefault, sections
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        docType = try c.decode(String.self, forKey: .docType)
+        letterHeadId = try c.decodeIfPresent(String.self, forKey: .letterHeadId)
+        isDefault = try c.decodeIfPresent(Bool.self, forKey: .isDefault) ?? false
+        sections = try c.decode([PrintSection].self, forKey: .sections)
     }
 }
 

--- a/mercantis core/Printing/PrintService.swift
+++ b/mercantis core/Printing/PrintService.swift
@@ -67,6 +67,22 @@ public final class PrintService: @unchecked Sendable {
         return formats.values.filter { $0.docType == docType }
     }
 
+    /// The default format for a DocType (the one flagged `isDefault`, else the
+    /// first registered), or nil when none are registered for it.
+    public func defaultFormat(forDocType docType: String) -> PrintFormat? {
+        let candidates = formats(forDocType: docType)
+        return candidates.first(where: \.isDefault) ?? candidates.first
+    }
+
+    /// All formats for a DocType, default first then by name — the order the
+    /// print menu lists them.
+    public func orderedFormats(forDocType docType: String) -> [PrintFormat] {
+        formats(forDocType: docType).sorted { lhs, rhs in
+            if lhs.isDefault != rhs.isDefault { return lhs.isDefault }
+            return lhs.name < rhs.name
+        }
+    }
+
     // MARK: - Render
 
     /// Render `document` with the format identified by `formatId` to bytes

--- a/mercantis core/UIShell/PrintRecordButton.swift
+++ b/mercantis core/UIShell/PrintRecordButton.swift
@@ -29,13 +29,17 @@ public struct PrintRecordButton: View {
     /// The record to print. An empty `id` disables the control.
     private let document: Document
     private let printService: PrintService
-    /// Resolves the `PrintFormat` to render `document` with. The button
-    /// registers the returned format with the service before rendering.
-    private let formatResolver: (Document) -> PrintFormat
+    /// Resolves the candidate `PrintFormat`s for `document`, default first. The
+    /// button registers each with the service before rendering. When more than
+    /// one is returned the menu lets the operator pick; otherwise it prints the
+    /// single (default) format directly.
+    private let formatsResolver: (Document) -> [PrintFormat]
 
     @State private var errorMessage: String?
     @State private var showError = false
 
+    /// Single-format init (back-compat): renders `document` with exactly the
+    /// resolved format.
     public init(
         document: Document,
         printService: PrintService,
@@ -43,25 +47,47 @@ public struct PrintRecordButton: View {
     ) {
         self.document = document
         self.printService = printService
-        self.formatResolver = formatResolver
+        self.formatsResolver = { [formatResolver($0)] }
+    }
+
+    /// Multi-format init: the operator chooses among several formats (default
+    /// listed first). An empty result disables printing.
+    public init(
+        document: Document,
+        printService: PrintService,
+        formatsResolver: @escaping (Document) -> [PrintFormat]
+    ) {
+        self.document = document
+        self.printService = printService
+        self.formatsResolver = formatsResolver
     }
 
     public var body: some View {
-        Menu {
-            Button {
-                run(.print)
-            } label: {
-                Label("Print…", systemImage: "printer")
-            }
-            Button {
-                run(.share)
-            } label: {
-                Label("Share PDF", systemImage: "square.and.arrow.up")
+        let formats = formatsResolver(document)
+        return Menu {
+            if formats.count <= 1 {
+                Button { run(.print, formats.first) } label: {
+                    Label("Print…", systemImage: "printer")
+                }
+                Button { run(.share, formats.first) } label: {
+                    Label("Share PDF", systemImage: "square.and.arrow.up")
+                }
+            } else {
+                ForEach(formats) { format in
+                    Section(format.isDefault ? "\(format.name) · Default" : format.name) {
+                        Button { run(.print, format) } label: {
+                            Label("Print…", systemImage: "printer")
+                        }
+                        Button { run(.share, format) } label: {
+                            Label("Share PDF", systemImage: "square.and.arrow.up")
+                        }
+                    }
+                }
             }
         } label: {
             Label("Print", systemImage: "printer")
         }
-        .disabled(document.id.isEmpty)
+        .disabled(document.id.isEmpty || formats.isEmpty)
         .accessibilityLabel("Print or share this record")
         .alert("Print failed", isPresented: $showError) {
             Button("OK", role: .cancel) { }
@@ -72,11 +98,14 @@ public struct PrintRecordButton: View {
 
     private enum Action { case print, share }
 
-    private func run(_ action: Action) {
+    private func run(_ action: Action, _ format: PrintFormat?) {
         #if os(macOS)
+        guard let format else {
+            present("No print format is available for this record.")
+            return
+        }
         do {
-            let format = formatResolver(document)
-            // Ensure the resolved format is known to the service before render.
+            // Ensure the chosen format is known to the service before render.
             printService.register(format: format)
             let result = try printService.render(
                 formatId: format.id,


### PR DESCRIPTION
- PrintFormat gains an `isDefault` flag (lenient decode) so a DocType with several formats can mark one as the default.
- PrintService: `defaultFormat(forDocType:)` and `orderedFormats(forDocType:)` (default first, then by name) to back the picker.
- PrintRecordButton: new multi-format initializer that lists all of a record's formats in the menu (each with Print… / Share PDF), default first; the existing single-format initializer is kept for back-compat.


Claude-Session: https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5