### PR TITLE
Saved reports: grouping, aggregates, charts + typed execution

### DIFF
--- a/mercantis core/Reporting/SavedReportDefinition.swift
+++ b/mercantis core/Reporting/SavedReportDefinition.swift
@@ -124,6 +124,68 @@ public struct SavedReportFilter: Codable, Sendable, Equatable {
     }
 }
 
+// MARK: - Aggregation
+
+/// How a column's values are combined for group subtotals / a grand total, and
+/// how a chart reduces the values in each category.
+public enum SavedReportAggregate: String, Codable, Sendable, CaseIterable {
+    case none
+    case sum
+    case average
+    case count
+    case min
+    case max
+
+    public var label: String {
+        switch self {
+        case .none:    return "None"
+        case .sum:     return "Sum"
+        case .average: return "Average"
+        case .count:   return "Count"
+        case .min:     return "Min"
+        case .max:     return "Max"
+        }
+    }
+}
+
+// MARK: - Chart
+
+/// The visual a report can render in addition to its table.
+public enum SavedReportChartKind: String, Codable, Sendable, CaseIterable {
+    case bar
+    case line
+    case pie
+
+    public var label: String {
+        switch self {
+        case .bar:  return "Bar"
+        case .line: return "Line"
+        case .pie:  return "Pie"
+        }
+    }
+}
+
+/// Declarative chart config: reduce `valueFieldKey` by `valueAggregate` within
+/// each `categoryFieldKey` bucket and plot it as `kind`.
+public struct SavedReportChart: Codable, Sendable, Equatable {
+    public var kind: SavedReportChartKind
+    public var categoryFieldKey: String
+    public var valueFieldKey: String
+    public var valueAggregate: SavedReportAggregate
+
+    public init(
+        kind: SavedReportChartKind = .bar,
+        categoryFieldKey: String,
+        valueFieldKey: String,
+        valueAggregate: SavedReportAggregate = .sum
+    ) {
+        self.kind = kind
+        self.categoryFieldKey = categoryFieldKey
+        self.valueFieldKey = valueFieldKey
+        self.valueAggregate = valueAggregate
+    }
+}
+
 // MARK: - Column
 
 /// A column in a saved report. `order` drives left-to-right placement;
@@ -139,23 +201,28 @@ public struct SavedReportColumn: Codable, Identifiable, Sendable, Equatable {
     /// Optional preferred render width (points). Advisory only — the engine
     /// ignores it; UI hosts may honour it.
     public var width: Double?
+    /// How this column is aggregated in group subtotals and the grand total.
+    /// `.none` (the default) contributes no total for this column.
+    public var aggregate: SavedReportAggregate
 
     public init(
         fieldKey: String,
         labelOverride: String? = nil,
         visible: Bool = true,
         order: Int,
-        width: Double? = nil
+        width: Double? = nil,
+        aggregate: SavedReportAggregate = .none
     ) {
         self.fieldKey = fieldKey
         self.labelOverride = labelOverride
         self.visible = visible
         self.order = order
         self.width = width
+        self.aggregate = aggregate
     }
 
     private enum CodingKeys: String, CodingKey {
-        case fieldKey, labelOverride, visible, order, width
+        case fieldKey, labelOverride, visible, order, width, aggregate
     }
 
     public init(from decoder: any Decoder) throws {
@@ -165,6 +232,7 @@ public struct SavedReportColumn: Codable, Identifiable, Sendable, Equatable {
         visible = try c.decodeIfPresent(Bool.self, forKey: .visible) ?? true
         order = try c.decode(Int.self, forKey: .order)
         width = try c.decodeIfPresent(Double.self, forKey: .width)
+        aggregate = try c.decodeIfPresent(SavedReportAggregate.self, forKey: .aggregate) ?? .none
     }
 
     /// The header label this column contributes to a `ReportResult` —
@@ -191,6 +259,11 @@ public struct SavedReportDefinition: Codable, Identifiable, Sendable, Equatable 
     public var columns: [SavedReportColumn]
     public var filters: [SavedReportFilter]
     public var sorts: [SavedReportSort]
+    /// When set, rows are grouped by this field; each group shows its column
+    /// aggregates as a subtotal, plus a grand total across all groups.
+    public var groupByFieldKey: String?
+    /// Optional chart rendered alongside the table.
+    public var chart: SavedReportChart?
     public let createdAt: Date
     public var updatedAt: Date
 
@@ -204,6 +277,8 @@ public struct SavedReportDefinition: Codable, Identifiable, Sendable, Equatable 
         columns: [SavedReportColumn] = [],
         filters: [SavedReportFilter] = [],
         sorts: [SavedReportSort] = [],
+        groupByFieldKey: String? = nil,
+        chart: SavedReportChart? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -216,13 +291,15 @@ public struct SavedReportDefinition: Codable, Identifiable, Sendable, Equatable 
         self.columns = columns
         self.filters = filters
         self.sorts = sorts
+        self.groupByFieldKey = groupByFieldKey
+        self.chart = chart
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
 
     private enum CodingKeys: String, CodingKey {
         case id, name, baseReportId, sourceDocType, ownerUserId, visibility
-        case columns, filters, sorts, createdAt, updatedAt
+        case columns, filters, sorts, groupByFieldKey, chart, createdAt, updatedAt
     }
 
     public init(from decoder: any Decoder) throws {
@@ -236,6 +313,8 @@ public struct SavedReportDefinition: Codable, Identifiable, Sendable, Equatable 
         columns = try c.decodeIfPresent([SavedReportColumn].self, forKey: .columns) ?? []
         filters = try c.decodeIfPresent([SavedReportFilter].self, forKey: .filters) ?? []
         sorts = try c.decodeIfPresent([SavedReportSort].self, forKey: .sorts) ?? []
+        groupByFieldKey = try c.decodeIfPresent(String.self, forKey: .groupByFieldKey)
+        chart = try c.decodeIfPresent(SavedReportChart.self, forKey: .chart)
         createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
         updatedAt = try c.decodeIfPresent(Date.self, forKey: .updatedAt) ?? Date()
     }

--- a/mercantis core/Reporting/SavedReportEngine.swift
+++ b/mercantis core/Reporting/SavedReportEngine.swift
@@ -117,6 +117,35 @@ public final class SavedReportEngine {
         runtimeFilterValues: [String: FieldValue] = [:],
         userRoles: Set<String> = []
     ) throws -> ReportResult {
+        let typed = try executeTyped(
+            savedReport: savedReport,
+            requestingUserId: requestingUserId,
+            runtimeFilterValues: runtimeFilterValues,
+            userRoles: userRoles
+        )
+        let rows = typed.rows.map { row in
+            row.map { ReportValueFormatter.string(from: $0) }
+        }
+        return ReportResult(columns: typed.columnLabels, rows: rows)
+    }
+
+    /// Raw, typed result of a saved report: the visible columns plus each
+    /// matching document's raw `FieldValue` per column. This is the basis the
+    /// host uses for grouping, aggregation and charts (which need numbers /
+    /// dates, not pre-formatted strings). `execute` formats this into the
+    /// string `ReportResult`.
+    public struct TypedReportResult: Sendable {
+        public let columnKeys: [String]
+        public let columnLabels: [String]
+        public let rows: [[FieldValue?]]
+    }
+
+    public func executeTyped(
+        savedReport: SavedReportDefinition,
+        requestingUserId: String? = nil,
+        runtimeFilterValues: [String: FieldValue] = [:],
+        userRoles: Set<String> = []
+    ) throws -> TypedReportResult {
         // Ownership / sharing gate.
         if let requestingUserId, !savedReport.canBeAccessed(byUserId: requestingUserId) {
             throw SavedReportError.notAuthorized(
@@ -174,14 +203,23 @@ public final class SavedReportEngine {
             listUserId: requestingUserId
         )
 
-        let columns = visibleColumns.map(\.resolvedLabel)
-        let rows: [[String?]] = documents.map { doc in
-            visibleColumns.map { column in
-                ReportValueFormatter.string(from: value(for: column.fieldKey, in: doc))
-            }
+        let rows: [[FieldValue?]] = documents.map { doc in
+            visibleColumns.map { column in value(for: column.fieldKey, in: doc) }
         }
 
-        return ReportResult(columns: columns, rows: rows)
+        return TypedReportResult(
+            columnKeys: visibleColumns.map(\.fieldKey),
+            columnLabels: visibleColumns.map(\.resolvedLabel),
+            rows: rows
+        )
+    }
+
+    /// Read a single document column value (exposed so hosts can resolve the
+    /// group-by / chart category & value fields, which need not be visible
+    /// columns). Honours the same user-field-then-system-column resolution as
+    /// the row builder.
+    public func columnValue(for key: String, in document: Document) -> FieldValue? {
+        value(for: key, in: document)
     }
 
     // MARK: - Validation


### PR DESCRIPTION
Extends the generic saved-report model and engine so a host can build grouped, totalled and charted reports without leaving the data-only foundation:

- SavedReportColumn gains an `aggregate` (none/sum/average/count/min/max) for subtotals and a grand total.
- SavedReportDefinition gains `groupByFieldKey` and a `chart` config (kind + category/value field + value aggregate). New enums/struct: SavedReportAggregate, SavedReportChartKind, SavedReportChart. All Codable lenient (decode-if-present), so existing saved reports load unchanged.
- SavedReportEngine.executeTyped returns the raw per-column FieldValues (TypedReportResult) so hosts can group / aggregate / chart on real numbers and dates; `execute` now formats that into the existing string ReportResult. Adds `columnValue(for:in:)` for resolving group/chart fields.


Claude-Session: https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5