### PR TITLE
PrintFormat: settingDefault(_:) copy helper

### DIFF
--- a/mercantis core/Printing/PrintFormat.swift
+++ b/mercantis core/Printing/PrintFormat.swift
@@ -99,6 +99,16 @@ public struct PrintFormat: Codable, Sendable, Equatable, Identifiable {
         fieldLinkDisplays[key] ?? linkDisplay
     }
 
+    /// A copy with `isDefault` flipped — used when a user-defined format becomes
+    /// the default for its DocType and the built-in default must step down.
+    public func settingDefault(_ flag: Bool) -> PrintFormat {
+        PrintFormat(
+            id: id, name: name, docType: docType, letterHeadId: letterHeadId,
+            isDefault: flag, linkDisplay: linkDisplay, fieldLinkDisplays: fieldLinkDisplays,
+            htmlTemplate: htmlTemplate, css: css, sections: sections
+        )
+    }
+
     private enum CodingKeys: String, CodingKey {
         case id, name, docType, letterHeadId, isDefault
         case linkDisplay, fieldLinkDisplays, htmlTemplate, css, sections


### PR DESCRIPTION
Returns a copy with isDefault flipped, so a user-defined format can claim the default for its DocType while the built-in default steps down.


Claude-Session: https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5