### PR TITLE
Theme: single brand-indigo accent for all active states

### DIFF
--- a/mercantis core/UIShell/Components/MercantisSidebarComponents.swift
+++ b/mercantis core/UIShell/Components/MercantisSidebarComponents.swift
@@ -52,7 +52,7 @@ public struct MercantisSidebarIconChip: View {
         case .emphasizedSelection:
             return Color.white.opacity(0.22)
         case .mutedSelection:
-            return MercantisTheme.accentFillSoft
+            return MercantisTheme.brandPrimarySoft
         case .normal:
             if let tone {
                 return MercantisTheme.moduleFill(tone)
@@ -66,7 +66,7 @@ public struct MercantisSidebarIconChip: View {
         case .emphasizedSelection:
             return MercantisTheme.selectionForegroundEmphasized
         case .mutedSelection:
-            return MercantisTheme.accent
+            return MercantisTheme.brandPrimary
         case .normal:
             if let tone {
                 return MercantisTheme.moduleTint(tone)
@@ -156,15 +156,15 @@ public struct MercantisSidebarRow: View {
             // the strong selection background is owned by the native list, so
             // layering an accent wash there would muddy it.
             RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .fill(emphasis == .mutedSelection ? MercantisTheme.accentFillSoft : Color.clear)
+                .fill(emphasis == .mutedSelection ? MercantisTheme.brandPrimarySoft : Color.clear)
         )
         .overlay(alignment: .leading) {
             // Colour is never the only selection signal: keep a leading rule on
-            // every selected row, tinted white on the strong selection and
-            // accent on the muted one so it stays visible against either fill.
+            // every selected row, tinted white on the strong selection and the
+            // brand indigo on the muted one so it stays visible against either fill.
             if isSelected {
                 RoundedRectangle(cornerRadius: 1.5, style: .continuous)
-                    .fill(highContrast ? MercantisTheme.selectionForegroundEmphasized : MercantisTheme.accent)
+                    .fill(highContrast ? MercantisTheme.selectionForegroundEmphasized : MercantisTheme.brandPrimary)
                     .frame(width: 2.5)
                     .padding(.vertical, 5)
                     .padding(.leading, indentation)
@@ -180,14 +180,14 @@ public struct MercantisSidebarRow: View {
         if highContrast {
             return Color.white.opacity(0.22)
         }
-        return isSelected ? MercantisTheme.accentFillSoft : Color.secondary.opacity(0.14)
+        return isSelected ? MercantisTheme.brandPrimarySoft : Color.secondary.opacity(0.14)
     }
 
     private func badgeForeground(highContrast: Bool) -> Color {
         if highContrast {
             return MercantisTheme.selectionForegroundEmphasized
         }
-        return isSelected ? MercantisTheme.accent : .secondary
+        return isSelected ? MercantisTheme.brandPrimary : .secondary
     }
 }
 

--- a/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
+++ b/mercantis core/UIShell/DesignTokens/MercantisTheme.swift
@@ -125,12 +125,14 @@ public enum MercantisTheme {
 
     // MARK: - System accent (native selection / control tint)
 
-    /// The system accent is intentionally retained for selection and native
-    /// control tint so the app still respects the user's macOS accent choice.
-    /// Product identity uses `brandPrimary` instead.
-    public static let accent = Color.accentColor
-    public static let accentFillSoft = Color.accentColor.opacity(0.12)
-    public static let accentBorder = Color.accentColor.opacity(0.34)
+    /// "Accent" now resolves to the Mercantis brand (indigo) so every active
+    /// state — selection, chips, focus rings, segmented tabs — shows one
+    /// consistent product colour rather than splitting between brand and the
+    /// system azure. (The native focused selection is retinted to match
+    /// app-wide via `.tint(brandPrimary)`.)
+    public static let accent = brandPrimary
+    public static let accentFillSoft = brandPrimary.opacity(0.12)
+    public static let accentBorder = brandPrimary.opacity(0.34)
 
     public static let softFillOpacity = 0.14
     public static let warningFillOpacity = 0.16
@@ -150,8 +152,11 @@ public enum MercantisTheme {
         light: (0.18, 0.36, 0.78),
         dark:  (0.40, 0.58, 0.96)
     )
-    public static let selectionBackground = accentFillSoft
-    public static let selectionForeground = accent
+    // Selection chrome uses the Mercantis brand (indigo), not the system accent,
+    // so active states match product identity everywhere. (The native focused
+    // selection is retinted app-wide via `.tint(brandPrimary)`.)
+    public static let selectionBackground = brandPrimarySoft
+    public static let selectionForeground = brandPrimary
     /// High-contrast foreground for a row drawn on the *strong* (emphasized,
     /// key-window) selection fill — the saturated accent that macOS paints
     /// behind a focused sidebar/list selection. White clears the accent in
@@ -225,9 +230,10 @@ public enum MercantisTheme {
     /// already inverts per appearance (near-black in light, near-white in dark),
     /// so a single low opacity reads correctly in both.
     public static let tableRowHover = Color.primary.opacity(0.05)
-    /// Selected-row background — reuses the native selection tint so the table
-    /// still respects the user's macOS accent.
-    public static let tableRowSelection = accentFillSoft
+    /// Selected-row background — the Mercantis brand (indigo) soft fill, so the
+    /// app shows one consistent accent across navigation, tables, and tabs
+    /// rather than splitting between brand and the system azure.
+    public static let tableRowSelection = brandPrimarySoft
     /// Header strip behind a table's column titles.
     public static let tableHeaderBackground = surfaceMuted
 

--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -262,7 +262,7 @@ public struct RecordCollectionHostView: View {
             .init("\(documents.count) records")
         ]
         if !docType.module.isEmpty {
-            badges.append(.init(ModuleDisplay.label(docType.module), tone: .info, help: ModuleDisplay.hint))
+            badges.append(.init(ModuleDisplay.label(docType.module), tone: .muted, help: ModuleDisplay.hint))
         }
         return badges
     }


### PR DESCRIPTION
Unify the app on one accent (the Mercantis brand indigo) instead of splitting between brand chrome and the system azure used for selection.

- Repoint the accent family (accent / accentFillSoft / accentBorder) and the selection tokens (selectionBackground / selectionForeground / tableRowSelection) from Color.accentColor to brandPrimary, so every active state — list/sidebar selection, chips, focus borders, segmented tabs — reads as one indigo.
- Sidebar selection chrome (row fill, leading rule, icon chip, count badge) switches from the system accent to the brand soft fill / brand tint.
- Quiet the workspace-header module chip from the blue ".info" tone to ".muted".

Pairs with `.tint(brandPrimary)` at the app root, which retints the native focused selection to match.


Claude-Session: https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5