### PR TITLE
Fix Data Browser build: use a Color in the column-icon ternary

### DIFF
--- a/mercantis core/UIShell/DataBrowserView.swift
+++ b/mercantis core/UIShell/DataBrowserView.swift
@@ -91,7 +91,7 @@ public struct DataBrowserView: View {
                                 HStack(spacing: 6) {
                                     Image(systemName: column.isPrimaryKey ? "key.fill" : "circle.fill")
                                         .font(.system(size: column.isPrimaryKey ? 9 : 4))
-                                        .foregroundStyle(column.isPrimaryKey ? MercantisTheme.brandPrimary : .tertiary)
+                                        .foregroundStyle(column.isPrimaryKey ? MercantisTheme.brandPrimary : MercantisTheme.textMuted)
                                         .frame(width: 12)
                                     Text(column.name).font(.system(size: 11))
                                     Spacer(minLength: 4)


### PR DESCRIPTION
`.tertiary` is a ShapeStyle, not a Color, so the `isPrimaryKey ? brandPrimary : .tertiary` ternary failed to type-check (both branches must share a type). Use MercantisTheme.textMuted for the non-key dot.


Claude-Session: https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5