### PR TITLE
Add a Tree view mode for hierarchical (isTree) DocTypes

### DIFF
--- a/mercantis core/UIShell/RecordCollectionHostView.swift
+++ b/mercantis core/UIShell/RecordCollectionHostView.swift
@@ -274,8 +274,45 @@ public struct RecordCollectionHostView: View {
             listPane
         case .browse:
             browsePane
+        case .tree:
+            treePane
         case .detail:
             detailPane
+        }
+    }
+
+    /// The view modes offered for this DocType: the caller's configured set,
+    /// plus Tree for hierarchical (tree) DocTypes — so the chart of accounts and
+    /// other group masters can be browsed as an expandable outline. Inserted
+    /// before Detail to read "List · Browse · Tree · Detail".
+    private var effectiveViewModes: [RecordViewMode] {
+        var modes = configuration.supportedViewModes
+        if docType.isTree, !modes.contains(.tree) {
+            if let detailIndex = modes.firstIndex(of: .detail) {
+                modes.insert(.tree, at: detailIndex)
+            } else {
+                modes.append(.tree)
+            }
+        }
+        return modes
+    }
+
+    /// Tree (outline) of the records on the left, the selected record's detail
+    /// on the right — the same split as Browse, but hierarchical.
+    private var treePane: some View {
+        HStack(spacing: 0) {
+            RecordTreeView(
+                docType: effectiveDocType,
+                documents: documents,
+                selectedDocumentID: selectedDocument?.id,
+                onSelect: selectDocument(_:)
+            )
+            .frame(minWidth: 360, maxWidth: .infinity)
+
+            Divider()
+
+            detailPane
+                .frame(minWidth: 380, maxWidth: .infinity)
         }
     }
 
@@ -283,7 +320,7 @@ public struct RecordCollectionHostView: View {
         RecordWorkspaceToolbarContent(
             statusText: workspaceRecordStatusText,
             selectedViewMode: $selectedViewMode,
-            supportedViewModes: configuration.supportedViewModes,
+            supportedViewModes: effectiveViewModes,
             primaryActionTitle: primaryCreateActionTitle,
             // Primary create lives in the hero header; surfacing it here too
             // would render two identical "+ New <DocType>" buttons on every
@@ -554,7 +591,7 @@ public struct RecordCollectionHostView: View {
     }
 
     private func syncSelection(from documentID: String?) {
-        if !configuration.supportedViewModes.contains(selectedViewMode) {
+        if !effectiveViewModes.contains(selectedViewMode) {
             selectedViewMode = configuration.defaultViewMode
         }
 
@@ -574,7 +611,7 @@ public struct RecordCollectionHostView: View {
             return
         }
 
-        if selectedViewMode == .browse || selectedViewMode == .detail,
+        if selectedViewMode == .browse || selectedViewMode == .detail || selectedViewMode == .tree,
            let first = documents.first {
             selectDocument(first)
             return
@@ -588,7 +625,7 @@ public struct RecordCollectionHostView: View {
     private func restorePersistedViewMode() {
         guard let rawValue = UserDefaults.standard.string(forKey: viewModeStorageKey),
               let mode = RecordViewMode(rawValue: rawValue),
-              configuration.supportedViewModes.contains(mode) else {
+              effectiveViewModes.contains(mode) else {
             selectedViewMode = configuration.defaultViewMode
             return
         }

--- a/mercantis core/UIShell/RecordTreeView.swift
+++ b/mercantis core/UIShell/RecordTreeView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+#if canImport(MercantisCore)
+import MercantisCore
+#endif
+
+/// A hierarchical (outline) presentation of a tree DocType's records — e.g. the
+/// Chart of Accounts. Parent rows expand to reveal their children, derived from
+/// the DocType's self-referential link field: the `.link` field whose
+/// `linkedDocType` is the DocType itself (for `Account`, that's
+/// `parent_account`). Selecting a row drives the same detail pane the other
+/// view modes use.
+public struct RecordTreeView: View {
+
+    let docType: DocType
+    let documents: [Document]
+    let selectedDocumentID: String?
+    let onSelect: (Document) -> Void
+
+    public init(
+        docType: DocType,
+        documents: [Document],
+        selectedDocumentID: String?,
+        onSelect: @escaping (Document) -> Void
+    ) {
+        self.docType = docType
+        self.documents = documents
+        self.selectedDocumentID = selectedDocumentID
+        self.onSelect = onSelect
+    }
+
+    private struct Node: Identifiable {
+        let document: Document
+        var children: [Node]?
+        var id: String { document.id }
+    }
+
+    public var body: some View {
+        let roots = buildTree()
+        if roots.isEmpty {
+            ContentUnavailableView("No records", systemImage: "list.bullet.indent")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List(selection: selectionBinding) {
+                OutlineGroup(roots, children: \.children) { node in
+                    row(node).tag(node.document.id)
+                }
+            }
+        }
+    }
+
+    private var selectionBinding: Binding<String?> {
+        Binding(
+            get: { selectedDocumentID },
+            set: { id in
+                if let id, let doc = documents.first(where: { $0.id == id }) { onSelect(doc) }
+            }
+        )
+    }
+
+    private func row(_ node: Node) -> some View {
+        let isParent = (node.children?.isEmpty == false)
+        return HStack(spacing: 8) {
+            Text(title(node.document))
+                .font(.system(size: 13, weight: isParent ? .semibold : .regular))
+            Spacer(minLength: 8)
+            if let code = code(node.document) {
+                Text(code)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: - Tree construction
+
+    private func buildTree() -> [Node] {
+        let parentKey = parentFieldKey
+        let ids = Set(documents.map(\.id))
+        var childrenByParent: [String: [Document]] = [:]
+        var roots: [Document] = []
+        for doc in documents {
+            if let parentKey,
+               let parent = stringValue(doc.fields[parentKey]),
+               parent != doc.id,             // ignore a self-parent
+               ids.contains(parent) {
+                childrenByParent[parent, default: []].append(doc)
+            } else {
+                roots.append(doc)
+            }
+        }
+        // `childrenByParent` is keyed by a present, in-set parent id, so the
+        // recursion only ever descends into real children — a parent cycle
+        // simply leaves both nodes out of `roots` rather than looping.
+        func node(_ doc: Document) -> Node {
+            let kids = (childrenByParent[doc.id] ?? []).sorted(by: order)
+            return Node(document: doc, children: kids.isEmpty ? nil : kids.map(node))
+        }
+        return roots.sorted(by: order).map(node)
+    }
+
+    private var parentFieldKey: String? {
+        docType.fields.first { $0.type == .link && $0.linkedDocType == docType.id }?.key
+    }
+
+    /// Sort by a numeric code field when the DocType has one (so a chart of
+    /// accounts orders 1010, 1020, 2010…), otherwise by display title.
+    private var sortFieldKey: String? {
+        docType.fields.first { $0.key.contains("number") || $0.key.contains("code") }?.key
+    }
+
+    private func order(_ a: Document, _ b: Document) -> Bool {
+        if let key = sortFieldKey {
+            let av = stringValue(a.fields[key]) ?? ""
+            let bv = stringValue(b.fields[key]) ?? ""
+            if av != bv { return av < bv }
+        }
+        return title(a).localizedCaseInsensitiveCompare(title(b)) == .orderedAscending
+    }
+
+    private func title(_ document: Document) -> String {
+        stringValue(document.fields[docType.titleField]) ?? document.id
+    }
+
+    private func code(_ document: Document) -> String? {
+        guard let key = sortFieldKey, key != docType.titleField else { return nil }
+        return stringValue(document.fields[key])
+    }
+
+    private func stringValue(_ value: FieldValue?) -> String? {
+        guard case .string(let s)? = value else { return nil }
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/mercantis core/UIShell/RecordViewMode.swift
+++ b/mercantis core/UIShell/RecordViewMode.swift
@@ -6,6 +6,7 @@ import MercantisCore
 public enum RecordViewMode: String, CaseIterable, Codable, Hashable, Identifiable {
     case list
     case browse
+    case tree
     case detail
 
     public var id: String { rawValue }
@@ -14,6 +15,7 @@ public enum RecordViewMode: String, CaseIterable, Codable, Hashable, Identifiabl
         switch self {
         case .list: return "List"
         case .browse: return "Browse"
+        case .tree: return "Tree"
         case .detail: return "Detail"
         }
     }


### PR DESCRIPTION
Adds an outline presentation to the record workspace, alongside List / Browse / Detail, for any DocType that declares isTree (e.g. the Chart of Accounts, Item Groups, Cost Centers).

- RecordViewMode gains a `.tree` case.
- RecordTreeView renders the hierarchy from the DocType's self-referential link field (the `.link` field whose linkedDocType is the DocType itself, e.g. Account.parent_account), as an expandable OutlineGroup with the selected row driving the same detail pane Browse uses. Parents are bold; rows sort by a numeric code field (account number) when present.
- RecordCollectionHostView auto-offers Tree (inserted before Detail) only for isTree DocTypes, so existing callers need no change; mode validity, persistence, and first-row selection all account for the new mode.

A parent cycle or self-parent can't loop the builder — only present, in-set parents form edges, and the recursion descends from roots only.


Claude-Session: https://claude.ai/code/session_01ERbKoLTbt5MSPPnzPAtPz5